### PR TITLE
feat: improved recompile speed after change scss

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -66,7 +66,7 @@
               "sourceMap": {
                 "hidden": true,
                 "scripts": true,
-                "styles": true
+                "styles": false
               },
               "extractCss": true,
               "namedChunks": false,

--- a/apps/gauzy/src/app/pages/dashboard/dashboard.component.scss
+++ b/apps/gauzy/src/app/pages/dashboard/dashboard.component.scss
@@ -1,4 +1,4 @@
-@import '../../../app/@theme/styles/styles.scss';
+// @import '../../../app/@theme/styles/styles.scss';
 
-@include nb-install-component() {
-}
+// @include nb-install-component() {
+// }

--- a/apps/gauzy/src/app/pages/employees/employees.component.scss
+++ b/apps/gauzy/src/app/pages/employees/employees.component.scss
@@ -1,4 +1,4 @@
-@import '../../../app/@theme/styles/styles.scss';
+// @import '../../../app/@theme/styles/styles.scss';
 
-@include nb-install-component() {
-}
+// @include nb-install-component() {
+// }

--- a/apps/gauzy/src/app/pages/expenses/expenses.component.scss
+++ b/apps/gauzy/src/app/pages/expenses/expenses.component.scss
@@ -1,4 +1,4 @@
-@import '../../../app/@theme/styles/styles.scss';
+// @import '../../../app/@theme/styles/styles.scss';
 
-@include nb-install-component() {
-}
+// @include nb-install-component() {
+// }

--- a/apps/gauzy/src/app/pages/income/income.component.html
+++ b/apps/gauzy/src/app/pages/income/income.component.html
@@ -1,4 +1,4 @@
-<nb-card>
+<nb-card class="income-component">
   <nb-card-header>
     <h4>Income</h4>
   </nb-card-header>

--- a/apps/gauzy/src/app/pages/income/income.component.scss
+++ b/apps/gauzy/src/app/pages/income/income.component.scss
@@ -1,6 +1,10 @@
-@import '../../../app/@theme/styles/styles.scss';
+// @import '../../../app/@theme/styles/styles.scss';
 
-@include nb-install-component() {
+// @include nb-install-component() {
+
+// }
+
+.income-component {
     .add-button {
         height: 40px;
         padding: 0;

--- a/apps/gauzy/src/app/pages/organizations/organizations.component.scss
+++ b/apps/gauzy/src/app/pages/organizations/organizations.component.scss
@@ -1,4 +1,4 @@
-@import '../../../app/@theme/styles/styles.scss';
+// @import '../../../app/@theme/styles/styles.scss';
 
-@include nb-install-component() {
-}
+// @include nb-install-component() {
+// }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compileOnSave": false,
   "compilerOptions": {
     "rootDir": ".",
-    "sourceMap": true,
+    "sourceMap": false,
     "declaration": false,
     "moduleResolution": "node",
 	"outDir": "./dist/out-tsc",


### PR DESCRIPTION
I fixed it like set value `false` on sourceMap field on compilerOptions and remove not needed scss imports.
Now is recompiling for 1sec before was 16sec.
![Code_iY57LeRdas](https://user-images.githubusercontent.com/22296670/61031504-523c9700-a3c8-11e9-9522-33efd5032ef5.png)
