### PR TITLE
Fix: hide username if empty

### DIFF
--- a/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee.component.html
+++ b/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee.component.html
@@ -31,7 +31,10 @@
 
 			<div class="employee-info">
 				<div class="employee-details">
-					<div class="transparent">
+					<div
+						*ngIf="selectedEmployee.user.username"
+						class="transparent"
+					>
 						{{ 'FORM.USERNAME' | translate }}:
 						<strong>{{ selectedEmployee.user.username }}</strong>
 					</div>


### PR DESCRIPTION
Fixed #313 to only show "Username: __" if the username is not null

<img width="1438" alt="Screen Shot 2019-12-02 at 4 49 31 PM" src="https://user-images.githubusercontent.com/6750734/69955761-6e320800-1524-11ea-92a7-412ba1f82c6b.png">
