### PR TITLE
fix: hide expense table id no data

### DIFF
--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization.component.html
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization.component.html
@@ -161,7 +161,13 @@
 			</div>
 		</div>
 
-		<div class="sub-header block-content">
+		<div
+			*ngIf="
+				selectedOrgRecurringExpense &&
+				selectedOrgRecurringExpense.length > 0
+			"
+			class="sub-header block-content"
+		>
 			<div class="row block-info">
 				<div class="col">{{ 'POP_UPS.CATEGORY_NAME' | translate }}</div>
 				<div class="col">{{ 'POP_UPS.DATE' | translate }}</div>


### PR DESCRIPTION
Fixed #308 
Hides the table headers if selectedOrgRecurringExpense is null or length is 0.

<img width="1437" alt="Screen Shot 2019-12-02 at 5 07 23 PM" src="https://user-images.githubusercontent.com/6750734/69956717-bc480b00-1526-11ea-933f-b79b153169d0.png">
