### PR TITLE
feat: sort by date descending by default on profit report popup

### DIFF
--- a/apps/gauzy/src/app/@shared/dashboard/profit-history/profit-history.component.ts
+++ b/apps/gauzy/src/app/@shared/dashboard/profit-history/profit-history.component.ts
@@ -54,6 +54,14 @@ export class ProfitHistoryComponent implements OnInit, OnDestroy {
 			editable: true,
 			noDataMessage: 'No Data',
 			columns: {
+				valueDate: {
+					title: 'Date',
+					type: 'custom',
+					width: '20%',
+					sortDirection: 'desc',
+					renderComponent: DateViewComponent,
+					filter: false
+				},
 				expense: {
 					title: 'Expenses',
 					type: 'string'
@@ -65,13 +73,6 @@ export class ProfitHistoryComponent implements OnInit, OnDestroy {
 				notes: {
 					title: 'Description',
 					type: 'string'
-				},
-				valueDate: {
-					title: 'Date',
-					type: 'custom',
-					width: '20%',
-					renderComponent: DateViewComponent,
-					filter: false
 				}
 			},
 			pager: {

--- a/apps/gauzy/src/app/@theme/components/header/header.component.ts
+++ b/apps/gauzy/src/app/@theme/components/header/header.component.ts
@@ -143,6 +143,11 @@ export class HeaderComponent implements OnInit, OnDestroy {
 			},
 			// TODO: divider
 			{
+				title: this.getTranslation('CONTEXT_MENU.TEAM'),
+				icon: 'people-outline',
+				link: 'pages/organizations'
+			},
+			{
 				title: this.getTranslation('CONTEXT_MENU.TASK'),
 				icon: 'calendar-outline',
 				link: '#'

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -218,6 +218,7 @@
 		"INVOICE": "Invoice",
 		"PROPOSAL": "Proposal",
 		"CONTRACT": "Contract",
+		"TEAM": "Team",
 		"TASK": "Task",
 		"CLIENT": "Client",
 		"PROJECT": "Project",


### PR DESCRIPTION
Sort by date, descending by default implemented. At the top of the table the latest records are shown.
Date column moved to the left.