### PR TITLE
Fix for #309 add missing headers

### DIFF
--- a/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-profile.component.html
+++ b/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-profile.component.html
@@ -4,7 +4,7 @@
 			{{ 'EMPLOYEES_PAGE.EDIT_EMPLOYEE.HEADER' | translate }}
 			<span
 				*ngIf="
-					selectedEmployee.user.firstName &&
+					selectedEmployee.user.firstName ||
 					selectedEmployee.user.lastName
 				"
 			>
@@ -14,7 +14,7 @@
 			<span *ngIf="selectedEmployee.user.username">
 				<ng-container
 					*ngIf="
-						selectedEmployee.user.firstName &&
+						selectedEmployee.user.firstName ||
 							selectedEmployee.user.lastName;
 						then withBraces;
 						else withQuotes

--- a/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-profile.component.html
+++ b/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-profile.component.html
@@ -1,4 +1,37 @@
 <nb-card>
+	<nb-card-header>
+		<h4>
+			{{ 'EMPLOYEES_PAGE.EDIT_EMPLOYEE.HEADER' | translate }}
+			<span
+				*ngIf="
+					selectedEmployee.user.firstName &&
+					selectedEmployee.user.lastName
+				"
+			>
+				{{ selectedEmployee.user.firstName }}
+				{{ selectedEmployee.user.lastName }}
+			</span>
+			<span *ngIf="selectedEmployee.user.username">
+				<ng-container
+					*ngIf="
+						selectedEmployee.user.firstName &&
+							selectedEmployee.user.lastName;
+						then withBraces;
+						else withQuotes
+					"
+				>
+				</ng-container>
+
+				<ng-template #withBraces>
+					({{ selectedEmployee.user.username }})
+				</ng-template>
+
+				<ng-template #withQuotes>
+					'{{ selectedEmployee.user.username }}'
+				</ng-template>
+			</span>
+		</h4>
+	</nb-card-header>
 	<nb-card-body>
 		<div class="navigate" (click)="goBack()">
 			<nb-icon icon="arrow-back-outline"></nb-icon>

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-settings.component.html
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-settings.component.html
@@ -1,5 +1,10 @@
 <nb-card>
-	<nb-card-header> </nb-card-header>
+	<nb-card-header>
+		<h4>
+			{{ 'ORGANIZATIONS_PAGE.EDIT.HEADER' | translate }}
+			{{ organization.name }}
+		</h4>
+	</nb-card-header>
 	<nb-card-body>
 		<div class="navigate" (click)="goBack()">
 			<nb-icon icon="arrow-back-outline"></nb-icon>

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -167,6 +167,7 @@
 		"RECURRING_EXPENSE": "Add employee recurring expense",
 		"BACK_TO_WORK": "Back to Work",
 		"EDIT_EMPLOYEE": {
+			"HEADER": "Manage Employee",
 			"DEVELOPER": "Developer",
 			"DEPARTMENT": "Department",
 			"POSITION": "Position"
@@ -185,6 +186,7 @@
 		"ACTIVE": "Active",
 		"ARCHIVED": "Archived",
 		"EDIT": {
+			"HEADER": "Manage",
 			"CLIENT": "Client",
 			"NEW_CLIENT": "Add new client",
 			"NAME": "Name",


### PR DESCRIPTION
Fixed #309 

1. Added header in Edit Organization settings
<img width="774" alt="Screen Shot 2019-12-03 at 1 55 50 PM" src="https://user-images.githubusercontent.com/6750734/70033007-a6911f00-15d4-11ea-9c37-e0b6021f64d4.png">


2. Added header in Edit Employee Profile page
Test cases:
2.1 (First Name OR Last Name) & username exist: **Manage Employee First Last (username)**
2.2 Only username: **Manage Employee 'username'**
2.3 Only First Name OR Last Name: **Manage Employee First Last**

<img width="1433" alt="Screen Shot 2019-12-03 at 1 42 07 PM" src="https://user-images.githubusercontent.com/6750734/70033034-aee95a00-15d4-11ea-8133-2160194f81ba.png">

<img width="1432" alt="Screen Shot 2019-12-03 at 1 41 12 PM" src="https://user-images.githubusercontent.com/6750734/70033067-b7da2b80-15d4-11ea-9f57-078dfc0b8ce4.png">

