### PR TITLE
fix: organization page manage btn

### DIFF
--- a/apps/gauzy/src/app/pages/employees/employees.component.html
+++ b/apps/gauzy/src/app/pages/employees/employees.component.html
@@ -52,6 +52,7 @@
 			[settings]="settingsSmartTable"
 			[source]="sourceSmartTable"
 			(userRowSelect)="selectEmployeeTmp($event)"
+			#employeesTable
 		>
 		</ng2-smart-table>
 	</nb-card-body>

--- a/apps/gauzy/src/app/pages/employees/employees.component.ts
+++ b/apps/gauzy/src/app/pages/employees/employees.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
 import { Store } from '../../@core/services/store.service';
 import { first, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
@@ -57,6 +57,8 @@ export class EmployeesComponent implements OnInit, OnDestroy {
 	bonusForSelectedMonth = 0;
 
 	loading = true;
+
+	@ViewChild('employeesTable', { static: false }) employeesTable;
 
 	constructor(
 		private employeesService: EmployeesService,
@@ -322,6 +324,10 @@ export class EmployeesComponent implements OnInit, OnDestroy {
 		}
 
 		this.sourceSmartTable.load(employeesVm);
+
+		if (this.employeesTable) {
+			this.employeesTable.grid.dataSet.willSelect = 'false';
+		}
 
 		this.organizationName = name;
 

--- a/apps/gauzy/src/app/pages/expenses/expenses.component.html
+++ b/apps/gauzy/src/app/pages/expenses/expenses.component.html
@@ -42,11 +42,12 @@
 		</div>
 
 		<ng2-smart-table
-			*ngIf="showTable"
+			*ngIf="canShowTable()"
 			class="income-table"
 			[settings]="smartTableSettings"
 			[source]="smartTableSource"
 			(userRowSelect)="selectExpense($event)"
+			#expensesTable
 		>
 		</ng2-smart-table>
 	</nb-card-body>

--- a/apps/gauzy/src/app/pages/expenses/expenses.component.ts
+++ b/apps/gauzy/src/app/pages/expenses/expenses.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
 import { AuthService } from '../../@core/services/auth.service';
 import { RolesEnum, Expense } from '@gauzy/models';
 import { first, takeUntil } from 'rxjs/operators';
@@ -52,6 +52,8 @@ export class ExpensesComponent implements OnInit, OnDestroy {
 
 	private _ngDestroy$ = new Subject<void>();
 	private _selectedOrganizationId: string;
+
+	@ViewChild('expensesTable', { static: false }) expensesTable;
 
 	loadSettingsSmartTable() {
 		this.smartTableSettings = {
@@ -156,6 +158,13 @@ export class ExpensesComponent implements OnInit, OnDestroy {
 			});
 
 		this.loading = false;
+	}
+
+	canShowTable() {
+		if (this.expensesTable) {
+			this.expensesTable.grid.dataSet.willSelect = 'false';
+		}
+		return this.showTable;
 	}
 
 	openAddExpenseDialog() {

--- a/apps/gauzy/src/app/pages/income/income.component.html
+++ b/apps/gauzy/src/app/pages/income/income.component.html
@@ -43,11 +43,12 @@
 		</div>
 
 		<ng2-smart-table
-			*ngIf="showTable"
+			*ngIf="canShowTable()"
 			class="income-table"
 			(userRowSelect)="selectIncome($event)"
 			[settings]="smartTableSettings"
 			[source]="smartTableSource"
+			#incomeTable
 		>
 		</ng2-smart-table>
 	</nb-card-body>

--- a/apps/gauzy/src/app/pages/income/income.component.ts
+++ b/apps/gauzy/src/app/pages/income/income.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
 import { AuthService } from '../../@core/services/auth.service';
 import { RolesEnum, Income, Employee } from '@gauzy/models';
 import { Subject, Observable, forkJoin } from 'rxjs';
@@ -45,6 +45,8 @@ export class IncomeComponent implements OnInit, OnDestroy {
 	showTable: boolean;
 	employeeName: string;
 	loading = true;
+
+	@ViewChild('incomeTable', { static: false }) incomeTable;
 
 	private _ngDestroy$ = new Subject<void>();
 	private _selectedOrganizationId: string;
@@ -112,6 +114,13 @@ export class IncomeComponent implements OnInit, OnDestroy {
 			});
 
 		this.loading = false;
+	}
+
+	canShowTable() {
+		if (this.incomeTable) {
+			this.incomeTable.grid.dataSet.willSelect = 'false';
+		}
+		return this.showTable;
 	}
 
 	loadSettingsSmartTable() {

--- a/apps/gauzy/src/app/pages/organizations/organizations.component.html
+++ b/apps/gauzy/src/app/pages/organizations/organizations.component.html
@@ -40,6 +40,7 @@
 			[source]="smartTableSource"
 			(userRowSelect)="selectOrganization($event)"
 			style="cursor: pointer;"
+			#settingsTable
 		>
 		</ng2-smart-table>
 	</nb-card-body>

--- a/apps/gauzy/src/app/pages/organizations/organizations.component.ts
+++ b/apps/gauzy/src/app/pages/organizations/organizations.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { OrganizationsService } from '../../@core/services/organizations.service';
 import { OrganizationsFullnameComponent } from './table-components/organizations-fullname/organizations-fullname.component';
 import { Organization } from '@gauzy/models';
@@ -34,6 +34,8 @@ export class OrganizationsComponent implements OnInit, OnDestroy {
 		private employeesService: EmployeesService,
 		private translateService: TranslateService
 	) {}
+
+	@ViewChild('settingsTable', { static: false }) settingsTable;
 
 	settingsSmartTable: object;
 	selectedOrganization: Organization;
@@ -183,6 +185,9 @@ export class OrganizationsComponent implements OnInit, OnDestroy {
 			}
 
 			this.smartTableSource.load(items);
+			if (this.settingsTable) {
+				this.settingsTable.grid.dataSet.willSelect = 'false';
+			}
 		} catch (error) {
 			this.toastrService.danger(
 				error.error.message || error.message,

--- a/apps/gauzy/src/app/pages/proposals/proposals.component.html
+++ b/apps/gauzy/src/app/pages/proposals/proposals.component.html
@@ -83,12 +83,13 @@
 			</button>
 		</div>
 		<ng2-smart-table
-			*ngIf="showTable"
+			*ngIf="canShowTable()"
 			class="income-table"
 			[settings]="smartTableSettings"
 			[source]="smartTableSource"
 			(userRowSelect)="selectProposal($event)"
 			style="cursor: pointer"
+			#proposalsTable
 		>
 		</ng2-smart-table>
 	</nb-card-body>

--- a/apps/gauzy/src/app/pages/proposals/proposals.component.ts
+++ b/apps/gauzy/src/app/pages/proposals/proposals.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
 import { takeUntil } from 'rxjs/operators';
 import { LocalDataSource } from 'ng2-smart-table';
 import { NbToastrService, NbDialogService } from '@nebular/theme';
@@ -68,6 +68,8 @@ export class ProposalsComponent implements OnInit, OnDestroy {
 
 	private _selectedOrganizationId: string;
 
+	@ViewChild('proposalsTable', { static: false }) proposalsTable;
+
 	ngOnInit() {
 		this.loadSettingsSmartTable();
 		this._applyTranslationOnSmartTable();
@@ -109,6 +111,13 @@ export class ProposalsComponent implements OnInit, OnDestroy {
 
 				this.loading = false;
 			});
+	}
+
+	canShowTable() {
+		if (this.proposalsTable) {
+			this.proposalsTable.grid.dataSet.willSelect = 'false';
+		}
+		return this.showTable;
 	}
 
 	add() {


### PR DESCRIPTION
There is an existing issue with ng2-smart-table which is causing #335 
1. https://github.com/akveo/ng2-smart-table/issues/462
2. https://github.com/akveo/ng2-smart-table/issues/502

I have currently fixed it only for review, just for the organization settings table as explained in this comment: https://github.com/akveo/ng2-smart-table/issues/462#issuecomment-339380137 

Please let me know if this is okay, we will then need to implement it in all **ng2-smart-table** in the application 