### PR TITLE
fix: organization card overflow issue for small screen

### DIFF
--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-main/edit-organization-main.component.html
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-main/edit-organization-main.component.html
@@ -1,298 +1,373 @@
-<form [formGroup]="form" *ngIf="form">
-	<div class="fields">
-		<div class="row">
-			<div class="col">
-				<div class="form-group">
-					<label class="label" for="nameInput">{{
-						'FORM.LABELS.NAME' | translate
-					}}</label>
-					<input
-						fullWidth
-						id="nameInput"
-						type="text"
-						nbInput
-						formControlName="name"
-						placeholder="{{ 'FORM.PLACEHOLDERS.NAME' | translate }}"
+<div class="content">
+	<div class="organization-container">
+		<div class="organization-photo">
+			<ngx-image-uploader
+				(changeHoverState)="hoverState = $event"
+				(uploadedImageUrl)="updateImageUrl($event)"
+				(uploadImageError)="handleImageUploadError($event)"
+			></ngx-image-uploader>
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				xmlns:xlink="http://www.w3.org/1999/xlink"
+				width="68"
+				height="68"
+				viewBox="0 0 68 68"
+				[ngStyle]="{ opacity: hoverState ? '1' : '0.3' }"
+			>
+				<defs>
+					<path
+						id="a"
+						d="M28.667 31.333a2 2 0 1 0-.002-4.001 2 2 0 0 0 .002 4.001m13.333 12H26.748l9.34-7.793c.328-.279.923-.277 1.244-.001l6.001 5.12V42c0 .736-.597 1.333-1.333 1.333M26 24.667h16c.736 0 1.333.597 1.333 1.333v11.152l-4.27-3.643c-1.32-1.122-3.386-1.122-4.694-.008l-9.702 8.096V26c0-.736.597-1.333 1.333-1.333M42 22H26c-2.205 0-4 1.795-4 4v16c0 2.205 1.795 4 4 4h16c2.205 0 4-1.795 4-4V26c0-2.205-1.795-4-4-4"
 					/>
-				</div>
-			</div>
-			<div class="col">
-				<div class="form-group">
-					<label class="label">{{
-						'FORM.LABELS.CURRENCY' | translate
-					}}</label>
-					<nb-select
-						class="d-block"
-						size="medium"
-						formControlName="currency"
-						placeholder="{{
-							'FORM.PLACEHOLDERS.ALL_CURRENCIES' | translate
-						}}"
-						fullWidth="true"
-					>
-						<nb-option
-							*ngFor="let currency of currencies"
-							[value]="currency"
-						>
-							{{ currency }}
-						</nb-option>
-					</nb-select>
-				</div>
-			</div>
-		</div>
+				</defs>
+				<g fill="none" fill-rule="evenodd">
+					<circle
+						cx="34"
+						cy="34"
+						r="34"
+						fill="#0091FF"
+						opacity=".3"
+					/>
+					<circle
+						cx="34"
+						cy="34"
+						r="26"
+						fill="#0091FF"
+						opacity=".9"
+					/>
+					<use fill="#FFF" fill-rule="nonzero" xlink:href="#a" />
+				</g>
+			</svg>
+			<div
+				class="image-overlay"
+				[ngStyle]="{ opacity: hoverState ? '0.2' : '0' }"
+			></div>
 
-		<div class="row">
-			<div class="col-6">
-				<div class="form-group">
-					<label class="label" for="officialNameInput">{{
-						'FORM.LABELS.OFFICIAL_NAME' | translate
-					}}</label>
-					<input
-						fullWidth
-						id="officialNameInput"
-						type="text"
-						nbInput
-						formControlName="officialName"
-						placeholder="{{
-							'FORM.PLACEHOLDERS.OFFICIAL_NAME' | translate
-						}}"
-					/>
-				</div>
-			</div>
-			<div class="col-6">
-				<div class="form-group">
-					<label class="label" for="startWeekOnSelect">{{
-						'FORM.LABELS.START_WEEK_ON' | translate
-					}}</label>
-					<nb-select
-						class="d-block"
-						size="medium"
-						formControlName="startWeekOn"
-						id="startWeekOnSelect"
-						placeholder="{{
-							'FORM.PLACEHOLDERS.START_WEEK_ON' | translate
-						}}"
-						fullWidth="true"
-					>
-						<nb-option
-							*ngFor="let weekday of weekdays"
-							[value]="weekday"
-						>
-							{{ 'SM_TABLE.' + weekday | translate }}
-						</nb-option>
-					</nb-select>
-				</div>
-			</div>
+			<img
+				*ngIf="imageUrl"
+				[src]="imageUrl"
+				alt="Organization Photo"
+				(mouseenter)="hoverState = true"
+				(mouseleave)="hoverState = false"
+			/>
 		</div>
-
-		<div class="row">
-			<div class="col-6">
-				<div class="form-group">
-					<label class="label">{{
-						'FORM.LABELS.DATE_TYPE' | translate
-					}}</label>
-					<nb-select
-						class="d-block"
-						size="medium"
-						formControlName="defaultValueDateType"
-						placeholder="{{
-							'FORM.PLACEHOLDERS.DATE_TYPE' | translate
-						}}"
-						fullWidth
-					>
-						<nb-option
-							*ngFor="let type of defaultValueDateTypes"
-							[value]="type"
-						>
-							{{ 'SM_TABLE.' + type | translate }}
-						</nb-option>
-					</nb-select>
-				</div>
-			</div>
-			<div class="col-6">
-				<div class="form-group">
-					<label class="label">
-						{{ 'FORM.LABELS.LOGO_ALIGNMENT' | translate }}
-					</label>
-					<nb-select
-						class="d-block"
-						size="medium"
-						formControlName="defaultAlignmentType"
-						placeholder="Align Logo To"
-						fullWidth
-					>
-						<nb-option
-							*ngFor="let type of defaultAlignmentTypes"
-							[value]="type.toUpperCase()"
-						>
-							{{ type }}
-						</nb-option>
-					</nb-select>
-				</div>
-			</div>
-		</div>
-		<div class="row">
-			<div class="col-6">
-				<div class="form-group">
-					<label class="label">
-						{{ 'FORM.LABELS.BRAND_COLOR' | translate }}
-					</label>
-					<input
-						fullWidth
-						id="brandColorInput"
-						nbInput
-						formControlName="brandColor"
-						placeholder="Add Color"
-						[colorPicker]="form.get('brandColor').value"
-						[style.background]="form.get('brandColor').value"
-						[value]="form.get('brandColor').value"
-						(colorPickerChange)="
-							form.get('brandColor').setValue($event)
-						"
-					/>
-				</div>
-			</div>
-			<div class="col-6">
-				<div class="form-group">
-					<label class="label">
-						{{ 'FORM.LABELS.DATE_FORMAT' | translate }}
-					</label>
-					<nb-select
-						class="d-block"
-						size="medium"
-						formControlName="dateFormat"
-						placeholder="Choose Format"
-						fullWidth
-					>
-						<nb-option
-							*ngFor="let format of listOfDateFormats"
-							[value]="format"
-						>
-							{{ dateFormatPreview(format) }}
-						</nb-option>
-					</nb-select>
-				</div>
-			</div>
-		</div>
-		<div class="row">
-			<div class="col-6">
-				<div class="form-group">
-					<label class="label">{{
-						'FORM.LABELS.CHOOSE_TIME_ZONE' | translate
-					}}</label>
-					<ng-select
-						[(items)]="listOfZones"
-						placeholder="Choose Timezone"
-						[searchable]="true"
-						formControlName="timeZone"
-					>
-						<ng-template
-							ng-option-tmp
-							let-item="item"
-							let-index="index"
-						>
-							{{ getTimeWithOffset(item) }}
-						</ng-template>
-						<ng-template ng-label-tmp let-item="item">
-							{{ getTimeWithOffset(item) }}
-						</ng-template>
-					</ng-select>
-				</div>
-			</div>
-			<div class="col-6">
-				<div class="form-group">
-					<label class="label" for="taxIdInput">{{
-						'FORM.LABELS.TAX_ID' | translate
-					}}</label>
-					<input
-						fullWidth
-						id="taxIdInput"
-						type="text"
-						nbInput
-						formControlName="taxId"
-						placeholder="{{
-							'FORM.PLACEHOLDERS.TAX_ID' | translate
-						}}"
-					/>
-				</div>
-			</div>
-		</div>
-		<div class="row">
-			<div class="col-6">
-				<div class="form-group">
-					<label class="label" for="countrySelect">{{
-						'FORM.LABELS.COUNTRY' | translate
-					}}</label>
-					<nb-select
-						class="d-block"
-						size="medium"
-						formControlName="country"
-						id="countrySelect"
-						placeholder="{{
-							'FORM.PLACEHOLDERS.COUNTRY' | translate
-						}}"
-						fullWidth="true"
-					>
-						<nb-option
-							*ngFor="let c of countries"
-							[value]="c.isoCode"
-						>
-							{{ c.country }}
-						</nb-option>
-					</nb-select>
-				</div>
-			</div>
-			<div class="col-6">
-				<div class="form-group">
-					<label class="label" for="cityInput">{{
-						'FORM.LABELS.CITY' | translate
-					}}</label>
-					<input
-						fullWidth
-						id="cityInput"
-						type="text"
-						nbInput
-						formControlName="city"
-						placeholder="{{ 'FORM.PLACEHOLDERS.CITY' | translate }}"
-					/>
-				</div>
-			</div>
-		</div>
-		<div class="row">
-			<div class="col-6">
-				<div class="form-group">
-					<label class="label" for="addressInput">{{
-						'FORM.LABELS.ADDRESS' | translate
-					}}</label>
-					<input
-						fullWidth
-						id="addressInput"
-						type="text"
-						nbInput
-						formControlName="address"
-						placeholder="{{
-							'FORM.PLACEHOLDERS.ADDRESS' | translate
-						}}"
-					/>
-				</div>
-			</div>
-			<div class="col-6">
-				<div class="form-group">
-					<label class="label" for="address2Input">{{
-						'FORM.LABELS.ADDRESS_2' | translate
-					}}</label>
-					<input
-						fullWidth
-						id="address2Input"
-						type="text"
-						nbInput
-						formControlName="address2"
-						placeholder="{{
-							'FORM.PLACEHOLDERS.ADDRESS_2' | translate
-						}}"
-					/>
-				</div>
-			</div>
-		</div>
+		<h6 class="text-center mt-2">
+			{{ employeesCount }}
+			{{ 'ORGANIZATIONS_PAGE.EMPLOYEES' | translate }}
+		</h6>
 	</div>
-</form>
+
+	<form class="main-form" [formGroup]="form" *ngIf="form">
+		<div class="fields">
+			<div class="row">
+				<div class="col">
+					<div class="form-group">
+						<label class="label" for="nameInput">{{
+							'FORM.LABELS.NAME' | translate
+						}}</label>
+						<input
+							fullWidth
+							id="nameInput"
+							type="text"
+							nbInput
+							formControlName="name"
+							placeholder="{{
+								'FORM.PLACEHOLDERS.NAME' | translate
+							}}"
+						/>
+					</div>
+				</div>
+				<div class="col">
+					<div class="form-group">
+						<label class="label">{{
+							'FORM.LABELS.CURRENCY' | translate
+						}}</label>
+						<nb-select
+							class="d-block"
+							size="medium"
+							formControlName="currency"
+							placeholder="{{
+								'FORM.PLACEHOLDERS.ALL_CURRENCIES' | translate
+							}}"
+							fullWidth="true"
+						>
+							<nb-option
+								*ngFor="let currency of currencies"
+								[value]="currency"
+							>
+								{{ currency }}
+							</nb-option>
+						</nb-select>
+					</div>
+				</div>
+			</div>
+
+			<div class="row">
+				<div class="col-6">
+					<div class="form-group">
+						<label class="label" for="officialNameInput">{{
+							'FORM.LABELS.OFFICIAL_NAME' | translate
+						}}</label>
+						<input
+							fullWidth
+							id="officialNameInput"
+							type="text"
+							nbInput
+							formControlName="officialName"
+							placeholder="{{
+								'FORM.PLACEHOLDERS.OFFICIAL_NAME' | translate
+							}}"
+						/>
+					</div>
+				</div>
+				<div class="col-6">
+					<div class="form-group">
+						<label class="label" for="startWeekOnSelect">{{
+							'FORM.LABELS.START_WEEK_ON' | translate
+						}}</label>
+						<nb-select
+							class="d-block"
+							size="medium"
+							formControlName="startWeekOn"
+							id="startWeekOnSelect"
+							placeholder="{{
+								'FORM.PLACEHOLDERS.START_WEEK_ON' | translate
+							}}"
+							fullWidth="true"
+						>
+							<nb-option
+								*ngFor="let weekday of weekdays"
+								[value]="weekday"
+							>
+								{{ 'SM_TABLE.' + weekday | translate }}
+							</nb-option>
+						</nb-select>
+					</div>
+				</div>
+			</div>
+
+			<div class="row">
+				<div class="col-6">
+					<div class="form-group">
+						<label class="label">{{
+							'FORM.LABELS.DATE_TYPE' | translate
+						}}</label>
+						<nb-select
+							class="d-block"
+							size="medium"
+							formControlName="defaultValueDateType"
+							placeholder="{{
+								'FORM.PLACEHOLDERS.DATE_TYPE' | translate
+							}}"
+							fullWidth
+						>
+							<nb-option
+								*ngFor="let type of defaultValueDateTypes"
+								[value]="type"
+							>
+								{{ 'SM_TABLE.' + type | translate }}
+							</nb-option>
+						</nb-select>
+					</div>
+				</div>
+				<div class="col-6">
+					<div class="form-group">
+						<label class="label">
+							{{ 'FORM.LABELS.LOGO_ALIGNMENT' | translate }}
+						</label>
+						<nb-select
+							class="d-block"
+							size="medium"
+							formControlName="defaultAlignmentType"
+							placeholder="Align Logo To"
+							fullWidth
+						>
+							<nb-option
+								*ngFor="let type of defaultAlignmentTypes"
+								[value]="type.toUpperCase()"
+							>
+								{{ type }}
+							</nb-option>
+						</nb-select>
+					</div>
+				</div>
+			</div>
+			<div class="row">
+				<div class="col-6">
+					<div class="form-group">
+						<label class="label">
+							{{ 'FORM.LABELS.BRAND_COLOR' | translate }}
+						</label>
+						<input
+							fullWidth
+							id="brandColorInput"
+							nbInput
+							formControlName="brandColor"
+							placeholder="Add Color"
+							[colorPicker]="form.get('brandColor').value"
+							[style.background]="form.get('brandColor').value"
+							[value]="form.get('brandColor').value"
+							(colorPickerChange)="
+								form.get('brandColor').setValue($event)
+							"
+						/>
+					</div>
+				</div>
+				<div class="col-6">
+					<div class="form-group">
+						<label class="label">
+							{{ 'FORM.LABELS.DATE_FORMAT' | translate }}
+						</label>
+						<nb-select
+							class="d-block"
+							size="medium"
+							formControlName="dateFormat"
+							placeholder="Choose Format"
+							fullWidth
+						>
+							<nb-option
+								*ngFor="let format of listOfDateFormats"
+								[value]="format"
+							>
+								{{ dateFormatPreview(format) }}
+							</nb-option>
+						</nb-select>
+					</div>
+				</div>
+			</div>
+			<div class="row">
+				<div class="col-6">
+					<div class="form-group">
+						<label class="label">{{
+							'FORM.LABELS.CHOOSE_TIME_ZONE' | translate
+						}}</label>
+						<ng-select
+							[(items)]="listOfZones"
+							placeholder="Choose Timezone"
+							[searchable]="true"
+							formControlName="timeZone"
+						>
+							<ng-template
+								ng-option-tmp
+								let-item="item"
+								let-index="index"
+							>
+								{{ getTimeWithOffset(item) }}
+							</ng-template>
+							<ng-template ng-label-tmp let-item="item">
+								{{ getTimeWithOffset(item) }}
+							</ng-template>
+						</ng-select>
+					</div>
+				</div>
+				<div class="col-6">
+					<div class="form-group">
+						<label class="label" for="taxIdInput">{{
+							'FORM.LABELS.TAX_ID' | translate
+						}}</label>
+						<input
+							fullWidth
+							id="taxIdInput"
+							type="text"
+							nbInput
+							formControlName="taxId"
+							placeholder="{{
+								'FORM.PLACEHOLDERS.TAX_ID' | translate
+							}}"
+						/>
+					</div>
+				</div>
+			</div>
+			<div class="row">
+				<div class="col-6">
+					<div class="form-group">
+						<label class="label" for="countrySelect">{{
+							'FORM.LABELS.COUNTRY' | translate
+						}}</label>
+						<nb-select
+							class="d-block"
+							size="medium"
+							formControlName="country"
+							id="countrySelect"
+							placeholder="{{
+								'FORM.PLACEHOLDERS.COUNTRY' | translate
+							}}"
+							fullWidth="true"
+						>
+							<nb-option
+								*ngFor="let c of countries"
+								[value]="c.isoCode"
+							>
+								{{ c.country }}
+							</nb-option>
+						</nb-select>
+					</div>
+				</div>
+				<div class="col-6">
+					<div class="form-group">
+						<label class="label" for="cityInput">{{
+							'FORM.LABELS.CITY' | translate
+						}}</label>
+						<input
+							fullWidth
+							id="cityInput"
+							type="text"
+							nbInput
+							formControlName="city"
+							placeholder="{{
+								'FORM.PLACEHOLDERS.CITY' | translate
+							}}"
+						/>
+					</div>
+				</div>
+			</div>
+			<div class="row">
+				<div class="col-6">
+					<div class="form-group">
+						<label class="label" for="addressInput">{{
+							'FORM.LABELS.ADDRESS' | translate
+						}}</label>
+						<input
+							fullWidth
+							id="addressInput"
+							type="text"
+							nbInput
+							formControlName="address"
+							placeholder="{{
+								'FORM.PLACEHOLDERS.ADDRESS' | translate
+							}}"
+						/>
+					</div>
+				</div>
+				<div class="col-6">
+					<div class="form-group">
+						<label class="label" for="address2Input">{{
+							'FORM.LABELS.ADDRESS_2' | translate
+						}}</label>
+						<input
+							fullWidth
+							id="address2Input"
+							type="text"
+							nbInput
+							formControlName="address2"
+							placeholder="{{
+								'FORM.PLACEHOLDERS.ADDRESS_2' | translate
+							}}"
+						/>
+					</div>
+				</div>
+			</div>
+		</div>
+
+		<div class="actions">
+			<button
+				[disabled]="this.form.invalid"
+				(click)="updateOrganizationSettings()"
+				nbButton
+				status="success"
+			>
+				Save
+			</button>
+		</div>
+	</form>
+</div>

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-main/edit-organization-main.component.scss
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-main/edit-organization-main.component.scss
@@ -1,0 +1,58 @@
+.main-form {
+	width: 100%;
+}
+
+.content {
+	display: flex;
+	padding: 50px 0px;
+}
+
+.organization-container {
+	height: 670px;
+	padding-right: 70px;
+	margin-right: 70px;
+	border-right: 1px solid rgba(0, 0, 0, 0.1);
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	transition: transform 150ms ease-in-out;
+
+	.organization-photo {
+		width: fit-content;
+		height: fit-content;
+		position: relative;
+
+		div {
+			pointer-events: none;
+			background: black;
+			position: absolute;
+			height: 100%;
+			width: 100%;
+			border-radius: 13px;
+		}
+
+		img {
+			width: 180px;
+			height: auto;
+			border-radius: 13px;
+		}
+
+		input {
+			width: 100%;
+			height: 100%;
+			opacity: 0;
+			position: absolute;
+			z-index: 3;
+			cursor: pointer;
+		}
+
+		svg {
+			z-index: 2;
+			transition: opacity 0.2s ease-in;
+			opacity: 0.3;
+			position: absolute;
+			top: calc(50% - 68px / 2);
+			left: calc(50% - 68px / 2);
+		}
+	}
+}

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-settings.component.html
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-settings.component.html
@@ -10,171 +10,97 @@
 			<nb-icon icon="arrow-back-outline"></nb-icon>
 			<span>{{ 'BUTTONS.BACK' | translate }}</span>
 		</div>
-		<div class="content">
-			<div class="employee-container">
-				<div class="employee-photo">
-					<ngx-image-uploader
-						(changeHoverState)="hoverState = $event"
-						(uploadedImageUrl)="updateImageUrl($event)"
-						(uploadImageError)="handleImageUploadError($event)"
-					></ngx-image-uploader>
-					<svg
-						xmlns="http://www.w3.org/2000/svg"
-						xmlns:xlink="http://www.w3.org/1999/xlink"
-						width="68"
-						height="68"
-						viewBox="0 0 68 68"
-						[ngStyle]="{ opacity: hoverState ? '1' : '0.3' }"
-					>
-						<defs>
-							<path
-								id="a"
-								d="M28.667 31.333a2 2 0 1 0-.002-4.001 2 2 0 0 0 .002 4.001m13.333 12H26.748l9.34-7.793c.328-.279.923-.277 1.244-.001l6.001 5.12V42c0 .736-.597 1.333-1.333 1.333M26 24.667h16c.736 0 1.333.597 1.333 1.333v11.152l-4.27-3.643c-1.32-1.122-3.386-1.122-4.694-.008l-9.702 8.096V26c0-.736.597-1.333 1.333-1.333M42 22H26c-2.205 0-4 1.795-4 4v16c0 2.205 1.795 4 4 4h16c2.205 0 4-1.795 4-4V26c0-2.205-1.795-4-4-4"
-							/>
-						</defs>
-						<g fill="none" fill-rule="evenodd">
-							<circle
-								cx="34"
-								cy="34"
-								r="34"
-								fill="#0091FF"
-								opacity=".3"
-							/>
-							<circle
-								cx="34"
-								cy="34"
-								r="26"
-								fill="#0091FF"
-								opacity=".9"
-							/>
-							<use
-								fill="#FFF"
-								fill-rule="nonzero"
-								xlink:href="#a"
-							/>
-						</g>
-					</svg>
-					<div
-						class="image-overlay"
-						[ngStyle]="{ opacity: hoverState ? '0.2' : '0' }"
-					></div>
-
-					<img
-						*ngIf="imageUrl"
-						[src]="imageUrl"
-						alt="Organization Photo"
-						(mouseenter)="hoverState = true"
-						(mouseleave)="hoverState = false"
-					/>
-				</div>
-				<h6 class="text-center mt-2">
-					{{ employeesCount }}
-					{{ 'ORGANIZATIONS_PAGE.EMPLOYEES' | translate }}
-				</h6>
-			</div>
-
-			<div *ngIf="organization" class="org-settings">
-				<nb-tabset
-					(changeTab)="
-						tabChange($event);
-						clients.loadClients();
-						clients.showAddCard = false;
-						projects.loadProjects();
-						projects.showAddCard = false
-					"
-					fullWidth
+		<div *ngIf="organization" class="org-settings">
+			<nb-tabset
+				(changeTab)="
+					tabChange($event);
+					clients.loadClients();
+					clients.showAddCard = false;
+					projects.loadProjects();
+					projects.showAddCard = false
+				"
+				fullWidth
+			>
+				<nb-tab
+					[active]="activeTabName === 'main'"
+					tabTitle="{{ 'ORGANIZATIONS_PAGE.MAIN' | translate }}"
+					tabIcon="person-outline"
+					responsive
 				>
-					<nb-tab
-						[active]="activeTabName === 'main'"
-						tabTitle="{{ 'ORGANIZATIONS_PAGE.MAIN' | translate }}"
-					>
-						<ga-edit-org-main
-							#main
-							[organization]="organization"
-							[countries]="countries"
-						></ga-edit-org-main>
+					<ga-edit-org-main
+						[organization]="organization"
+						[countries]="countries"
+					></ga-edit-org-main>
+				</nb-tab>
 
-						<div class="actions">
-							<button
-								[disabled]="main.form.invalid"
-								(click)="updateOrganizationSettings()"
-								nbButton
-								status="success"
-							>
-								Save
-							</button>
-						</div>
-					</nb-tab>
+				<nb-tab
+					[active]="activeTabName === 'departments'"
+					tabTitle="{{
+						'ORGANIZATIONS_PAGE.DEPARTMENTS' | translate
+					}}"
+					tabIcon="briefcase-outline"
+					responsive
+				>
+					<ga-edit-org-departments
+						[organizationId]="organization?.id"
+					>
+					</ga-edit-org-departments>
+				</nb-tab>
 
-					<nb-tab
-						[active]="activeTabName === 'departments'"
-						tabTitle="{{
-							'ORGANIZATIONS_PAGE.DEPARTMENTS' | translate
-						}}"
-					>
-						<ga-edit-org-departments
-							[organizationId]="organization?.id"
-						>
-						</ga-edit-org-departments>
-					</nb-tab>
+				<nb-tab
+					[active]="activeTabName === 'clients'"
+					tabTitle="{{ 'ORGANIZATIONS_PAGE.CLIENTS' | translate }}"
+					tabIcon="book-open-outline"
+					responsive
+				>
+					<ga-edit-org-clients
+						#clients
+						[organizationId]="organization?.id"
+					></ga-edit-org-clients>
+				</nb-tab>
 
-					<nb-tab
-						[active]="activeTabName === 'clients'"
-						tabTitle="{{
-							'ORGANIZATIONS_PAGE.CLIENTS' | translate
-						}}"
-					>
-						<ga-edit-org-clients
-							#clients
-							[organizationId]="organization?.id"
-						></ga-edit-org-clients>
-					</nb-tab>
+				<nb-tab
+					[active]="activeTabName === 'positions'"
+					tabTitle="{{ 'ORGANIZATIONS_PAGE.POSITIONS' | translate }}"
+					tabIcon="award-outline"
+					responsive
+				>
+					<ga-edit-org-positions
+						[organizationId]="organization?.id"
+					></ga-edit-org-positions>
+				</nb-tab>
 
-					<nb-tab
-						[active]="activeTabName === 'positions'"
-						tabTitle="{{
-							'ORGANIZATIONS_PAGE.POSITIONS' | translate
-						}}"
-					>
-						<ga-edit-org-positions
-							[organizationId]="organization?.id"
-						></ga-edit-org-positions>
-					</nb-tab>
-
-					<nb-tab
-						[active]="activeTabName === 'vendors'"
-						tabTitle="{{
-							'ORGANIZATIONS_PAGE.VENDORS' | translate
-						}}"
-					>
-						<ga-edit-org-vendors
-							[organizationId]="organization?.id"
-						>
-						</ga-edit-org-vendors>
-					</nb-tab>
-					<nb-tab
-						[active]="activeTabName === 'projects'"
-						tabTitle="{{
-							'ORGANIZATIONS_PAGE.PROJECTS' | translate
-						}}"
-					>
-						<ga-edit-org-projects
-							#projects
-							[organizationId]="organization?.id"
-						></ga-edit-org-projects>
-					</nb-tab>
-					<nb-tab
-						[active]="activeTabName === 'teams'"
-						tabTitle="{{
-							'ORGANIZATIONS_PAGE.EDIT.TEAMS' | translate
-						}}"
-					>
-						<ga-edit-org-teams>
-							#teams [organizationId]="organization?.id"
-						</ga-edit-org-teams>
-					</nb-tab>
-				</nb-tabset>
-			</div>
+				<nb-tab
+					[active]="activeTabName === 'vendors'"
+					tabTitle="{{ 'ORGANIZATIONS_PAGE.VENDORS' | translate }}"
+					tabIcon="car-outline"
+					responsive
+				>
+					<ga-edit-org-vendors [organizationId]="organization?.id">
+					</ga-edit-org-vendors>
+				</nb-tab>
+				<nb-tab
+					[active]="activeTabName === 'projects'"
+					tabTitle="{{ 'ORGANIZATIONS_PAGE.PROJECTS' | translate }}"
+					tabIcon="book-outline"
+					responsive
+				>
+					<ga-edit-org-projects
+						#projects
+						[organizationId]="organization?.id"
+					></ga-edit-org-projects>
+				</nb-tab>
+				<nb-tab
+					[active]="activeTabName === 'teams'"
+					tabTitle="{{ 'ORGANIZATIONS_PAGE.EDIT.TEAMS' | translate }}"
+					tabIcon="people-outline"
+					responsive
+				>
+					<ga-edit-org-teams>
+						#teams [organizationId]="organization?.id"
+					</ga-edit-org-teams>
+				</nb-tab>
+			</nb-tabset>
 		</div>
 	</nb-card-body>
 	<nb-card-footer> </nb-card-footer>

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-settings.component.scss
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-settings.component.scss
@@ -10,3 +10,11 @@ nb-tab,
 nb-tabset {
 	height: 100%;
 }
+
+nb-card-body {
+	overflow-y: hidden; //prevent extra scroll bar
+}
+
+:host ::ng-deep .tab-link {
+	padding: 1rem 5px !important;
+}

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-settings.component.ts
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-settings.component.ts
@@ -8,7 +8,6 @@ import { Subject } from 'rxjs';
 import { first, takeUntil } from 'rxjs/operators';
 import { CountryService } from '../../../../@core/services/country.service';
 import { OrganizationsService } from '../../../../@core/services/organizations.service';
-import { EditOrganizationMainComponent } from './edit-organization-main/edit-organization-main.component';
 
 export enum ListsInputType {
 	DEPARTMENTS = 'DEPARTMENTS',
@@ -26,13 +25,8 @@ export enum ListsInputType {
 	providers: [CountryService]
 })
 export class EditOrganizationSettingsComponent implements OnInit {
-	@ViewChild('main', { static: false })
-	main: EditOrganizationMainComponent;
-
-	imageUrl: string;
-
 	organization: Organization;
-	hoverState: boolean;
+
 	departments: string[] = [];
 	positions: string[] = [];
 	vendors: string[] = [];
@@ -47,7 +41,6 @@ export class EditOrganizationSettingsComponent implements OnInit {
 		private organizationService: OrganizationsService,
 		private countryService: CountryService,
 		private toastrService: NbToastrService,
-		private employeesService: EmployeesService,
 		private location: Location
 	) {}
 
@@ -90,26 +83,6 @@ export class EditOrganizationSettingsComponent implements OnInit {
 		);
 	}
 
-	async updateOrganizationSettings() {
-		this.organizationService.update(this.organization.id, {
-			imageUrl: this.imageUrl,
-			...this.main.mainUpdateObj
-		});
-
-		this.toastrService.primary(
-			this.organization.name + ' organization main info updeted.',
-			'Success'
-		);
-
-		this.goBack();
-	}
-
-	handleImageUploadError(event: any) {}
-
-	updateImageUrl(url: string) {
-		this.imageUrl = url;
-	}
-
 	private async _loadOrganization(id: string) {
 		try {
 			await this.loadCountries();
@@ -117,23 +90,12 @@ export class EditOrganizationSettingsComponent implements OnInit {
 				.getById(id)
 				.pipe(first())
 				.toPromise();
-			this.imageUrl = this.organization.imageUrl;
-			this.loadEmployeesCount();
 		} catch (error) {
 			this.toastrService.danger(
 				error.error.message || error.message,
 				'Error'
 			);
 		}
-	}
-
-	private async loadEmployeesCount() {
-		const { total } = await this.employeesService
-			.getAll([], { organization: { id: this.organization.id } })
-			.pipe(first())
-			.toPromise();
-
-		this.employeesCount = total;
 	}
 
 	private async loadCountries() {


### PR DESCRIPTION
**Fixed:**
1. Moved the tabs on top, and profile image under the main section
2. Moved the profile Image ts code into the main component instead of the parent
3. I had to create organization-container and organization-photo style classes similar to employee-container and employee-photo since these are in a different component now and not under nb-card-body as specified in the employee module.
4. I also had to use ::ng-deep for reducing the left/right padding of nb-tabs.

The table now looks like:
<img width="1677" alt="Screen Shot 2019-12-10 at 7 43 12 PM" src="https://user-images.githubusercontent.com/6750734/70536784-64904c00-1b85-11ea-997c-6a26191c6eaf.png">

**Remaining:**
Using only the responsive icons when screen resolution is <1600 (might need help with this)

Please review & merge. Issue #324 

This merge will unblock #310  so we can create more tabs and close the issue.