### PR TITLE
fix: expenses page random behaviour

### DIFF
--- a/apps/gauzy/src/app/pages/expenses/expenses.component.ts
+++ b/apps/gauzy/src/app/pages/expenses/expenses.component.ts
@@ -133,10 +133,6 @@ export class ExpensesComponent implements OnInit, OnDestroy {
 					if (this._selectedOrganizationId) {
 						this.selectedEmployeeId = null;
 						this._loadTableData(this._selectedOrganizationId);
-
-						this.expenseService.getAll().then((data) => {
-							this.smartTableSource.load(data.items);
-						});
 					}
 				}
 			});

--- a/apps/gauzy/src/app/pages/income/income.component.ts
+++ b/apps/gauzy/src/app/pages/income/income.component.ts
@@ -90,9 +90,6 @@ export class IncomeComponent implements OnInit, OnDestroy {
 							null,
 							this._selectedOrganizationId
 						);
-						this.incomeService.getAll().then((data) => {
-							this.smartTableSource.load(data.items);
-						});
 					}
 				}
 			});


### PR DESCRIPTION
Fixes #229 

Looks like that for every load, the expense & income tables were always sending two requests to the backend. One actual request and one with all fields as null.

<img width="554" alt="Screen Shot 2019-12-10 at 8 50 00 PM" src="https://user-images.githubusercontent.com/6750734/70542385-a8d41a00-1b8e-11ea-8e44-74e244e69fb5.png">

<img width="432" alt="Screen Shot 2019-12-10 at 8 14 15 PM" src="https://user-images.githubusercontent.com/6750734/70542414-b1c4eb80-1b8e-11ea-9acb-3b47688c6d25.png">

The behavior looked random because the data was displayed depending upon which response was received later. 

Please review the code changes, I have removed the second null call, I am not sure why the second request was added, looks like it was added for some fake data in this commit: https://github.com/ever-co/gauzy/commit/403df1404fa2689580996e74118bba7a8021c65d

