### PR TITLE
fix: #383 dashboard calculations

### DIFF
--- a/apps/api/src/app/employee-statistics/employee-statistics.service.ts
+++ b/apps/api/src/app/employee-statistics/employee-statistics.service.ts
@@ -5,139 +5,165 @@ import { ExpenseService } from '../expense';
 
 @Injectable()
 export class EmployeeStatisticsService {
-    private _monthNames = [
-        'January',
-        'February',
-        'March',
-        'April',
-        'May',
-        'June',
-        'July',
-        'August',
-        'September',
-        'October',
-        'November',
-        'December'
-    ];
+	private _monthNames = [
+		'January',
+		'February',
+		'March',
+		'April',
+		'May',
+		'June',
+		'July',
+		'August',
+		'September',
+		'October',
+		'November',
+		'December'
+	];
 
-    constructor(private incomeService: IncomeService,
-        private expenseService: ExpenseService) { }
+	constructor(
+		private incomeService: IncomeService,
+		private expenseService: ExpenseService
+	) {}
 
-    async getStatisticsByEmployeeId(employeeId: string, findInput?: EmployeeStatisticsFindInput): Promise<EmployeeStatistics> {
-        const mappedEmployeeIncome = (await this.incomeService.findAll({
-            where: {
-                employee: {
-                    id: employeeId
-                }
-            }
-        }, findInput ? findInput.valueDate.toString() : null)).items.map(e => {
-            const obj = {};
-            const formattedDate = this._formatDate(e.valueDate);
+	async getStatisticsByEmployeeId(
+		employeeId: string,
+		findInput?: EmployeeStatisticsFindInput
+	): Promise<EmployeeStatistics> {
+		const mappedEmployeeIncome = (await this.incomeService.findAll(
+			{
+				where: {
+					employee: {
+						id: employeeId
+					}
+				}
+			},
+			findInput ? findInput.valueDate.toString() : null
+		)).items.map((e) => {
+			const obj = {};
+			const formattedDate = this._formatDate(e.valueDate);
 
-            obj[formattedDate] = e.amount;
+			obj[formattedDate] = +e.amount;
 
-            return obj;
-        });
+			return obj;
+		});
 
-        const mappedEmployeeExpenses = (await this.expenseService.findAll({
-            where: {
-                employee: {
-                    id: employeeId
-                }
-            }
-        }, findInput ? findInput.valueDate.toString() : null)).items.map(e => {
-            const obj = {};
-            const formattedDate = this._formatDate(e.valueDate);
+		const mappedEmployeeExpenses = (await this.expenseService.findAll(
+			{
+				where: {
+					employee: {
+						id: employeeId
+					}
+				}
+			},
+			findInput ? findInput.valueDate.toString() : null
+		)).items.map((e) => {
+			const obj = {};
+			const formattedDate = this._formatDate(e.valueDate);
 
-            obj[formattedDate] = e.amount;
+			obj[formattedDate] = +e.amount;
 
-            return obj;
-        });
+			return obj;
+		});
 
-        const sortedEmployeeExpenses: Object[] = [];
+		const sortedEmployeeExpenses: Object[] = [];
 
-        mappedEmployeeExpenses.forEach(obj => {
-            // tslint:disable-next-line: forin
-            for (const key in obj) {
-                const foundObject = sortedEmployeeExpenses.find(o => o.hasOwnProperty(key));
-                if (foundObject) {
-                    foundObject[key] += obj[key];
-                } else {
-                    sortedEmployeeExpenses.push(obj);
-                }
-            }
-        });
+		mappedEmployeeExpenses.forEach((obj) => {
+			// tslint:disable-next-line: forin
+			for (const key in obj) {
+				const foundObject = sortedEmployeeExpenses.find((o) =>
+					o.hasOwnProperty(key)
+				);
+				if (foundObject) {
+					foundObject[key] += obj[key];
+				} else {
+					sortedEmployeeExpenses.push(obj);
+				}
+			}
+		});
 
-        const sortedEmployeeIncome: Object[] = [];
+		const sortedEmployeeIncome: Object[] = [];
 
-        mappedEmployeeIncome.forEach(obj => {
-            // tslint:disable-next-line: forin
-            for (const key in obj) {
-                const foundObject = sortedEmployeeIncome.find(o => o.hasOwnProperty(key));
-                if (foundObject) {
-                    foundObject[key] += obj[key];
-                } else {
-                    sortedEmployeeIncome.push(obj);
-                }
-            }
-        });
+		mappedEmployeeIncome.forEach((obj) => {
+			// tslint:disable-next-line: forin
+			for (const key in obj) {
+				const foundObject = sortedEmployeeIncome.find((o) =>
+					o.hasOwnProperty(key)
+				);
+				if (foundObject) {
+					foundObject[key] += obj[key];
+				} else {
+					sortedEmployeeIncome.push(obj);
+				}
+			}
+		});
 
-        let incomeStatistics = [];
-        let expenseStatistics = [];
+		let incomeStatistics = [];
+		let expenseStatistics = [];
 
-        this._getLast12months().forEach(month => {
-            const incomeStatForTheMonth = sortedEmployeeIncome.find(incomeStat => incomeStat.hasOwnProperty(month));
+		this._getLast12months().forEach((month) => {
+			const incomeStatForTheMonth = sortedEmployeeIncome.find(
+				(incomeStat) => incomeStat.hasOwnProperty(month)
+			);
 
-            incomeStatForTheMonth ? incomeStatistics.push(incomeStatForTheMonth[month]) : incomeStatistics.push(0);
+			incomeStatForTheMonth
+				? incomeStatistics.push(incomeStatForTheMonth[month])
+				: incomeStatistics.push(0);
 
-            const expenseStatForTheMonth = sortedEmployeeExpenses.find(expenseStat => expenseStat.hasOwnProperty(month));
+			const expenseStatForTheMonth = sortedEmployeeExpenses.find(
+				(expenseStat) => expenseStat.hasOwnProperty(month)
+			);
 
-            expenseStatForTheMonth ? expenseStatistics.push(expenseStatForTheMonth[month]) : expenseStatistics.push(0);
-        });
+			expenseStatForTheMonth
+				? expenseStatistics.push(expenseStatForTheMonth[month])
+				: expenseStatistics.push(0);
+		});
 
-        let profitStatistics = [];
-        let bonusStatistics = [];
+		let profitStatistics = [];
+		let bonusStatistics = [];
 
-        expenseStatistics.forEach((expenseStat, index) => {
-            const profit = incomeStatistics[index] - expenseStat;
-            profitStatistics.push(profit);
-            bonusStatistics.push((profit * 75) / 100);
-        });
+		expenseStatistics.forEach((expenseStat, index) => {
+			const profit = incomeStatistics[index] - expenseStat;
+			profitStatistics.push(profit);
+			bonusStatistics.push((profit * 75) / 100);
+		});
 
-        if (findInput && findInput.valueDate) {
-            expenseStatistics = expenseStatistics.filter(Number)
-            incomeStatistics = incomeStatistics.filter(Number)
-            profitStatistics = profitStatistics.filter(Number)
-            bonusStatistics = bonusStatistics.filter(Number)
-        }
-        
-        return {
-            expenseStatistics,
-            incomeStatistics,
-            profitStatistics,
-            bonusStatistics
-        }
-    }
+		if (findInput && findInput.valueDate) {
+			expenseStatistics = expenseStatistics.filter(Number);
+			incomeStatistics = incomeStatistics.filter(Number);
+			profitStatistics = profitStatistics.filter(Number);
+			bonusStatistics = bonusStatistics.filter(Number);
+		}
 
-    private _getLast12months() {
-        const start = (new Date(Date.now())).getMonth() + 1;
-        const end = start + 11;
-        const currentYear = (new Date(Date.now())).getFullYear() - 2000;
+		return {
+			expenseStatistics,
+			incomeStatistics,
+			profitStatistics,
+			bonusStatistics
+		};
+	}
 
-        const monthsNeeded = [];
+	private _getLast12months() {
+		const start = new Date(Date.now()).getMonth() + 1;
+		const end = start + 11;
+		const currentYear = new Date(Date.now()).getFullYear() - 2000;
 
-        for (let i = start; i <= end; i++) {
-            if (i > 11) {
-                monthsNeeded.push(this._monthNames[i - 12] + ` '${currentYear}`);
-            } else {
-                monthsNeeded.push(this._monthNames[i] + ` '${currentYear - 1}`);
-            }
-        }
+		const monthsNeeded = [];
 
-        return monthsNeeded.reverse();
-    }
+		for (let i = start; i <= end; i++) {
+			if (i > 11) {
+				monthsNeeded.push(
+					this._monthNames[i - 12] + ` '${currentYear}`
+				);
+			} else {
+				monthsNeeded.push(this._monthNames[i] + ` '${currentYear - 1}`);
+			}
+		}
 
-    private _formatDate(date: Date) {
-        return `${this._monthNames[date.getMonth()]} '${date.getFullYear() - 2000}`;
-    }
+		return monthsNeeded.reverse();
+	}
+
+	private _formatDate(date: Date) {
+		return `${this._monthNames[date.getMonth()]} '${date.getFullYear() -
+			2000}`;
+	}
 }

--- a/apps/gauzy/src/app/@shared/dashboard/profit-history/profit-history.component.ts
+++ b/apps/gauzy/src/app/@shared/dashboard/profit-history/profit-history.component.ts
@@ -41,10 +41,10 @@ export class ProfitHistoryComponent implements OnInit, OnDestroy {
 		});
 		const combinedTableData = [...incomeList, ...expenseList];
 
-		this.incomeTotal = combinedTableData.reduce((a, b) => a + b.income, 0);
+		this.incomeTotal = combinedTableData.reduce((a, b) => a + +b.income, 0);
 
 		this.expensesTotal = combinedTableData.reduce(
-			(a, b) => a + b.expense,
+			(a, b) => a + +b.expense,
 			0
 		);
 

--- a/apps/gauzy/src/app/pages/dashboard/dashboard.component.ts
+++ b/apps/gauzy/src/app/pages/dashboard/dashboard.component.ts
@@ -149,7 +149,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
 		);
 
 		this.incomeData = items;
-		this.totalIncome = items.reduce((a, b) => a + b.amount, 0);
+		this.totalIncome = items.reduce((a, b) => a + +b.amount, 0);
 
 		if (items.length && this.totalIncome !== 0) {
 			const firstItem = items[0];
@@ -191,13 +191,13 @@ export class DashboardComponent implements OnInit, OnDestroy {
 			}
 		)).items;
 
-		const totalExpense = items.reduce((a, b) => a + b.amount, 0);
+		const totalExpense = items.reduce((a, b) => a + +b.amount, 0);
 		const totalEmployeeRecurringexpense = employeeRecurringexpense.reduce(
-			(a, b) => a + b.value,
+			(a, b) => a + +b.value,
 			0
 		);
 		const totalOrgRecurringexpense = orgRecurringexpense.reduce(
-			(a, b) => a + b.value,
+			(a, b) => a + +b.value,
 			0
 		);
 


### PR DESCRIPTION
Fixes #383
---
- Earlier, as income and expense were integers `a + b` worked correctly even without typecasting.
- Since they were converted to float the issue boiled up as typecasting is required.
- Wherever I could see that we are adding income or expense, I've added the `+` unary operator.
- We'll need to make sure we do this in the future as well.