### PR TITLE
feat: cosmetic changes on dashboard and fix on negative expenses

### DIFF
--- a/apps/gauzy/src/app/pages/dashboard/dashboard.component.html
+++ b/apps/gauzy/src/app/pages/dashboard/dashboard.component.html
@@ -27,7 +27,7 @@
 
 			<div *ngIf="avarageBonus" class="employee-details">
 				{{ 'DASHBOARD_PAGE.DEVELOPER.AVERAGE_BONUS' | translate }}:
-				{{ avarageBonus }}
+				{{ avarageBonus | currency: defaultCurrency }}
 			</div>
 		</div>
 
@@ -140,6 +140,7 @@
 					<div class="bonus-value">
 						<div>
 							{{ 'DASHBOARD_PAGE.DEVELOPER.BONUS' | translate }}
+							{{ bonusPercentage }} %
 						</div>
 						<div
 							*ngIf="defaultCurrency"
@@ -154,7 +155,7 @@
 							{{ bonus }}
 						</div>
 					</div>
-					<div class="bonus-disclaimer">
+					<div class="bonus-disclaimer" *ngIf="bonus < 0">
 						{{ 'DASHBOARD_PAGE.DEVELOPER.NOTE' | translate }}
 					</div>
 				</div>

--- a/apps/gauzy/src/app/pages/dashboard/dashboard.component.ts
+++ b/apps/gauzy/src/app/pages/dashboard/dashboard.component.ts
@@ -49,6 +49,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
 	totalExpense = 0;
 	difference = 0;
 	bonus = 0;
+	bonusPercentage = 0;
 
 	avarageBonus: number;
 
@@ -159,8 +160,9 @@ export class DashboardComponent implements OnInit, OnDestroy {
 
 	private async _loadEmployeeTotalExpense() {
 		await this._loadExpense();
-		this.difference = this.totalIncome - this.totalExpense;
+		this.difference = this.totalIncome - Math.abs(this.totalExpense);
 		this.bonus = (this.difference * 75) / 100;
+		this.bonusPercentage = (this.bonus / this.difference) * 100;
 	}
 
 	private async _loadExpense() {

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -189,11 +189,11 @@
 		"SELECT_A_MONTH_AND_EMPLOYEE": "Please select a month and employee from the menu above",
 		"DEVELOPER": {
 			"DEVELOPER": "Developer",
-			"AVERAGE_BONUS": "Average Bonus",
+			"AVERAGE_BONUS": "Average Monthly Bonus",
 			"TOTAL_INCOME": "Total Income",
 			"TOTAL_EXPENSES": "Total Expenses",
 			"PROFIT": "Profit",
-			"PROFIT_CALC": "Profit = Total Income - Total Expenses",
+			"PROFIT_CALC": "Profit (Net Income) = Total Income - Total Expenses",
 			"NOTE": "Note: negative bonuses should be deducted in the upcoming months from the positive bonuses before final bonus payments",
 			"BONUS": "Bonus"
 		}


### PR DESCRIPTION
feat: cosmetic changes on Dashboard page, according to #407 

fix: Calculation of Profit. 
If user inputs negative numbers for expenses (minus by minus equals plus), now profit will be calculated correctly.

![Dashboard](https://user-images.githubusercontent.com/40795644/71621522-75f2d400-2bd8-11ea-8f07-9f6839647b48.png)

