### PR TITLE
feat: expenses include taxes partially implemented

### DIFF
--- a/apps/api/src/app/expense/commands/handlers/expense.create.handler.ts
+++ b/apps/api/src/app/expense/commands/handlers/expense.create.handler.ts
@@ -36,6 +36,9 @@ export class ExpenseCreateHandler
 		expense.organization = organization;
 		expense.currency = input.currency;
 		expense.purpose = input.purpose;
+		expense.taxType = input.taxType;
+		expense.taxLabel = input.taxLabel;
+		expense.rateValue = input.rateValue;
 
 		if (!expense.currency) {
 			expense.currency = organization.currency;

--- a/apps/api/src/app/expense/expense.entity.ts
+++ b/apps/api/src/app/expense/expense.entity.ts
@@ -98,4 +98,24 @@ export class Expense extends Base implements IExpense {
 	@IsOptional()
 	@Column({ nullable: true })
 	purpose?: string;
+
+	@ApiPropertyOptional({ type: String })
+	@Index()
+	@IsOptional()
+	@Column({ nullable: true })
+	taxType?: string;
+
+	@ApiPropertyOptional({ type: String })
+	@Index()
+	@IsOptional()
+	@Column({ nullable: true })
+	taxLabel?: string;
+
+	@ApiProperty({ type: Number })
+	@IsNumber()
+	@IsNotEmpty()
+	@Index()
+	@IsOptional()
+	@Column({ nullable: true })
+	rateValue: number;
 }

--- a/apps/gauzy/src/app/@shared/expenses/expenses-mutation/expenses-mutation.component.html
+++ b/apps/gauzy/src/app/@shared/expenses/expenses-mutation/expenses-mutation.component.html
@@ -1,11 +1,11 @@
 <nb-card class="main">
 	<nb-card-header class="d-flex">
-		<h5>
+		<h4>
 			{{
 				(expense ? 'POP_UPS.EDIT_EXPENSE' : 'POP_UPS.ADD_EXPENSE')
 					| translate
 			}}
-		</h5>
+		</h4>
 		<ga-employee-selector
 			#employeeSelector
 			[hidden]="expense"
@@ -110,7 +110,6 @@
 						</ng-select>
 					</div>
 				</div>
-
 				<div class="col-sm-6">
 					<div class="form-group">
 						<input
@@ -122,15 +121,26 @@
 					</div>
 				</div>
 			</div>
-			<div class="text-right">
+			<div class="text-left">
 				<button
 					nbButton
 					size="tiny"
 					status="info"
 					(click)="showNotesInput()"
 					*ngIf="!showNotes"
+					class="mr-3 mb-3"
 				>
 					{{ 'BUTTONS.ADD_NOTE' | translate }}
+				</button>
+				<button
+					nbButton
+					size="tiny"
+					status="info"
+					(click)="includeTaxes()"
+					*ngIf="!showTaxesInput"
+					class="mr-3 mb-3"
+				>
+					Include Taxes
 				</button>
 			</div>
 			<div class="row" *ngIf="showNotes">
@@ -152,6 +162,47 @@
 							}"
 						>
 						</textarea>
+					</div>
+				</div>
+			</div>
+			<div class="row" *ngIf="showTaxesInput">
+				<div class="col">
+					<h6>Include Taxes</h6>
+					<div class="col-sm-6">
+						<div class="form-group">
+							<input
+								nbInput
+								type="text"
+								formControlName="taxLabel"
+								fullWidth
+								placeholder="Tax Label"
+							/>
+						</div>
+					</div>
+					<div class="col-sm-6">
+						<div class="form-group">
+							<ng-select
+								[items]="taxTypes"
+								bindLabel="taxType"
+								formControlName="taxType"
+								fullWidth
+								[clearable]="false"
+								placeholder="Tax Type (% or Value)"
+							>
+							</ng-select>
+						</div>
+					</div>
+					<div class="col-sm-6">
+						<div class="form-group">
+							<input
+								nbInput
+								type="number"
+								step="1"
+								fullWidth
+								placeholder="Tax Rate %"
+								formControlName="rateValue"
+							/>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/apps/gauzy/src/app/@shared/expenses/expenses-mutation/expenses-mutation.component.scss
+++ b/apps/gauzy/src/app/@shared/expenses/expenses-mutation/expenses-mutation.component.scss
@@ -10,7 +10,7 @@
 	}
 
 	.notes {
-		height: 198px;
+		height: 60px;
 	}
 
 	nb-card-header .employees {

--- a/apps/gauzy/src/app/@shared/expenses/expenses-mutation/expenses-mutation.component.ts
+++ b/apps/gauzy/src/app/@shared/expenses/expenses-mutation/expenses-mutation.component.ts
@@ -2,7 +2,11 @@ import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
 import { NbDialogRef } from '@nebular/theme';
 import { FormBuilder, Validators, FormGroup } from '@angular/forms';
 import { ExpenseViewModel } from '../../../pages/expenses/expenses.component';
-import { CurrenciesEnum, OrganizationSelectInput } from '@gauzy/models';
+import {
+	CurrenciesEnum,
+	OrganizationSelectInput,
+	TaxTypesEnum
+} from '@gauzy/models';
 import { OrganizationsService } from '../../../@core/services/organizations.service';
 import { Store } from '../../../@core/services/store.service';
 import { first } from 'rxjs/operators';
@@ -21,9 +25,12 @@ export class ExpensesMutationComponent implements OnInit {
 	expense: ExpenseViewModel;
 	fakeCategories: { categoryName: string; categoryId: string }[] = [];
 	currencies = Object.values(CurrenciesEnum);
+	taxTypes = Object.values(TaxTypesEnum);
 	vendor: { vendorName: string; vendorId: string };
 	vendors: { vendorName: string; vendorId: string }[] = [];
 	showNotes = false;
+	showTaxesInput = false;
+	disable = true;
 
 	constructor(
 		public dialogRef: NbDialogRef<ExpensesMutationComponent>,
@@ -121,6 +128,13 @@ export class ExpensesMutationComponent implements OnInit {
 		return (this.showNotes = !this.showNotes);
 	}
 
+	includeTaxes() {
+		if (this.form.value.taxType) {
+			this.disable = false;
+		}
+		return (this.showTaxesInput = !this.showTaxesInput);
+	}
+
 	private _initializeForm() {
 		if (this.expense) {
 			this.form = this.fb.group({
@@ -146,7 +160,10 @@ export class ExpensesMutationComponent implements OnInit {
 					new Date(this.expense.valueDate),
 					Validators.required
 				],
-				purpose: [this.expense.purpose]
+				purpose: [this.expense.purpose],
+				taxType: [this.expense.taxType],
+				taxLabel: [this.expense.taxLabel],
+				rateValue: [this.expense.rateValue]
 			});
 		} else {
 			this.form = this.fb.group({
@@ -159,7 +176,10 @@ export class ExpensesMutationComponent implements OnInit {
 					this.store.getDateFromOrganizationSettings(),
 					Validators.required
 				],
-				purpose: ['']
+				purpose: [''],
+				taxType: [TaxTypesEnum.PERCENTAGE],
+				taxLabel: [''],
+				rateValue: ['']
 			});
 
 			this._loadDefaultCurrency();

--- a/apps/gauzy/src/app/pages/expenses/expenses.component.ts
+++ b/apps/gauzy/src/app/pages/expenses/expenses.component.ts
@@ -25,6 +25,9 @@ export interface ExpenseViewModel {
 	amount: number;
 	notes: string;
 	purpose: string;
+	taxType: string;
+	taxLabel: string;
+	rateValue: number;
 }
 
 interface SelectedRowModel {
@@ -203,7 +206,10 @@ export class ExpensesComponent implements OnInit, OnDestroy {
 							valueDate: formData.valueDate,
 							notes: formData.notes,
 							currency: formData.currency,
-							purpose: formData.purpose
+							purpose: formData.purpose,
+							taxType: formData.taxType,
+							taxLabel: formData.taxLabel,
+							rateValue: formData.rateValue
 						});
 
 						this.toastrService.primary(
@@ -359,7 +365,10 @@ export class ExpensesComponent implements OnInit, OnDestroy {
 					notes: i.notes,
 					currency: i.currency,
 					employee: i.employee,
-					purpose: i.purpose
+					purpose: i.purpose,
+					taxType: i.taxType,
+					taxLabel: i.taxLabel,
+					rateValue: i.rateValue
 				};
 			});
 

--- a/libs/models/src/lib/expense.model.ts
+++ b/libs/models/src/lib/expense.model.ts
@@ -16,6 +16,9 @@ export interface Expense extends IBaseEntityModel {
 	valueDate?: Date;
 	currency: string;
 	purpose?: string;
+	taxType?: string;
+	taxLabel?: string;
+	rateValue?: number;
 }
 
 export interface ExpenseCreateInput {
@@ -30,6 +33,9 @@ export interface ExpenseCreateInput {
 	currency?: string;
 	orgId?: string;
 	purpose?: string;
+	taxType?: string;
+	taxLabel?: string;
+	rateValue?: number;
 }
 
 export interface ExpenseFindInput extends IBaseEntityModel {
@@ -46,6 +52,9 @@ export interface ExpenseFindInput extends IBaseEntityModel {
 	valueDate?: Date;
 	currency?: string;
 	purpose?: string;
+	taxType?: string;
+	taxLabel?: string;
+	rateValue?: number;
 }
 
 export interface ExpenseUpdateInput {
@@ -60,4 +69,12 @@ export interface ExpenseUpdateInput {
 	valueDate?: Date;
 	currency?: string;
 	purpose?: string;
+	taxType?: string;
+	taxLabel?: string;
+	rateValue?: number;
+}
+
+export enum TaxTypesEnum {
+	PERCENTAGE = 'Percentage',
+	VALUE = 'Value'
 }


### PR DESCRIPTION
Feature to "Include Taxes" on Expenses pages partialy implemented.  The required inputs added to Add Expense popup and data for "TaxType" ("%" or "Value"), Tax Label and Tax Rate (value or %) is stored in the Expense table in the DB.

TODO: Display data on Expenses page and represent calculations on taxes (%, value).