### PR TITLE
feat: on expenses pages assign to functionality implemented in fe

### DIFF
--- a/apps/gauzy/src/app/@shared/expenses/expenses-mutation/expenses-mutation.component.html
+++ b/apps/gauzy/src/app/@shared/expenses/expenses-mutation/expenses-mutation.component.html
@@ -117,7 +117,40 @@
 					</div>
 				</div>
 			</div>
-			<div class="text-left">
+
+			<div>
+				<h6>Assign to</h6>
+				<div class="row">
+					<div class="col-sm-6">
+						<div class="form-group">
+							<ng-select
+								[items]="clients"
+								nbInput
+								bindLabel="name"
+								[searchable]="true"
+								formControlName="clientName"
+								placeholder="Client"
+							>
+							</ng-select>
+						</div>
+					</div>
+					<div class="col-sm-6">
+						<div class="form-group">
+							<ng-select
+								[items]="projects"
+								nbInput
+								bindLabel="name"
+								[searchable]="true"
+								formControlName="projectName"
+								placeholder="Project"
+							>
+							</ng-select>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			<div class="mt-3 text-left">
 				<button
 					nbButton
 					size="tiny"


### PR DESCRIPTION
On expenses pages (add/ edit) "Asign to" functionality implemented on Front-end (component and template) with two dropdowns: "Client" and "Project" (both optional). This will allow assigning an Expense to specific project/client.