### PR TITLE
feat: expense type selector implemented

### DIFF
--- a/apps/api/src/app/expense/commands/handlers/expense.create.handler.ts
+++ b/apps/api/src/app/expense/commands/handlers/expense.create.handler.ts
@@ -30,6 +30,7 @@ export class ExpenseCreateHandler
 		expense.categoryName = input.categoryName;
 		expense.vendorId = input.vendorId;
 		expense.vendorName = input.vendorName;
+		expense.typeOfExpense = input.typeOfExpense;
 		expense.clientName = input.clientName;
 		expense.clientId = input.clientId;
 		expense.projectName = input.projectName;

--- a/apps/api/src/app/expense/expense.entity.ts
+++ b/apps/api/src/app/expense/expense.entity.ts
@@ -61,6 +61,13 @@ export class Expense extends Base implements IExpense {
 	@Column({ nullable: true })
 	vendorId?: string;
 
+	@ApiPropertyOptional({ type: String })
+	@IsString()
+	@IsOptional()
+	@Index()
+	@Column({ nullable: true })
+	typeOfExpense: string;
+
 	@ApiProperty({ type: String })
 	@IsString()
 	@IsNotEmpty()

--- a/apps/gauzy/src/app/@core/services/error-handling.service.ts
+++ b/apps/gauzy/src/app/@core/services/error-handling.service.ts
@@ -16,7 +16,7 @@ export class ErrorHandlingService {
 	}
 
 	private getErrorDetails(err) {
-		const message: string = err.error.message;
+		const message: string = err.error.message || err.message;
 		const detail: string = err.error.detail;
 
 		if (message) {
@@ -27,20 +27,13 @@ export class ErrorHandlingService {
 					this.handleDuplicateKeyError(detail);
 					this.errorTitle = 'Record already exists';
 					break;
-				default:
-					this.errorTitle = message;
-			}
-		} else {
-			const keywords = err.message.split(' ', 3).join(' ');
-
-			switch (keywords) {
 				case 'Http failure response':
 					this.errorTitle = 'Lost connection with the server';
 					this.errorContent = 'Please try again later';
 					break;
 				default:
 					this.errorTitle = 'Error';
-					this.errorContent = err.message;
+					this.errorContent = message;
 			}
 		}
 	}

--- a/apps/gauzy/src/app/@shared/expenses/expenses-mutation/expenses-mutation.component.html
+++ b/apps/gauzy/src/app/@shared/expenses/expenses-mutation/expenses-mutation.component.html
@@ -21,6 +21,13 @@
 	</nb-card-header>
 	<nb-card-body class="body">
 		<form [formGroup]="form" *ngIf="form">
+			<nb-radio-group formControlName="typeOfExpense">
+				<nb-radio
+					*ngFor="let expenseType of expenseTypes"
+					[value]="expenseType"
+					>{{ expenseType }}
+				</nb-radio>
+			</nb-radio-group>
 			<div class="row">
 				<div class="col-sm-6">
 					<input
@@ -125,7 +132,6 @@
 						<div class="form-group">
 							<ng-select
 								[items]="clients"
-								nbInput
 								bindLabel="clientName"
 								[searchable]="true"
 								autocomplete="on"

--- a/apps/gauzy/src/app/@shared/expenses/expenses-mutation/expenses-mutation.component.scss
+++ b/apps/gauzy/src/app/@shared/expenses/expenses-mutation/expenses-mutation.component.scss
@@ -21,3 +21,9 @@
 		width: 220px;
 	}
 }
+
+nb-radio-group {
+	display: flex;
+	flex-direction: row;
+	margin-bottom: 1em;
+}

--- a/apps/gauzy/src/app/@shared/expenses/expenses-mutation/expenses-mutation.module.ts
+++ b/apps/gauzy/src/app/@shared/expenses/expenses-mutation/expenses-mutation.module.ts
@@ -1,7 +1,15 @@
 import { ThemeModule } from '../../../@theme/theme.module';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { NgModule } from '@angular/core';
-import { NbCardModule, NbButtonModule, NbIconModule, NbInputModule, NbDatepickerModule, NbSelectModule } from '@nebular/theme';
+import {
+	NbCardModule,
+	NbButtonModule,
+	NbIconModule,
+	NbInputModule,
+	NbDatepickerModule,
+	NbSelectModule,
+	NbRadioModule
+} from '@nebular/theme';
 import { ExpensesMutationComponent } from './expenses-mutation.component';
 import { NgSelectModule } from '@ng-select/ng-select';
 import { OrganizationsService } from '../../../@core/services/organizations.service';
@@ -11,35 +19,34 @@ import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 import { HttpClient } from '@angular/common/http';
 
 export function HttpLoaderFactory(http: HttpClient) {
-    return new TranslateHttpLoader(http, './assets/i18n/', '.json');
+	return new TranslateHttpLoader(http, './assets/i18n/', '.json');
 }
 
 @NgModule({
-    imports: [
-        ThemeModule,
-        NbCardModule,
-        NbButtonModule,
-        NbIconModule,
-        NgSelectModule,
-        ReactiveFormsModule,
-        NbInputModule,
-        FormsModule,
-        NbDatepickerModule,
-        NbSelectModule,
-        EmployeeSelectorsModule,
-        TranslateModule.forChild({
-            loader: {
-                provide: TranslateLoader,
-                useFactory: HttpLoaderFactory,
-                deps: [HttpClient]
-            }
-        }),
-    ],
-    exports: [ExpensesMutationComponent],
-    declarations: [ExpensesMutationComponent],
-    entryComponents: [ExpensesMutationComponent],
-    providers: [
-        OrganizationsService
-    ]
+	imports: [
+		ThemeModule,
+		NbCardModule,
+		NbButtonModule,
+		NbIconModule,
+		NgSelectModule,
+		ReactiveFormsModule,
+		NbInputModule,
+		FormsModule,
+		NbDatepickerModule,
+		NbSelectModule,
+		NbRadioModule,
+		EmployeeSelectorsModule,
+		TranslateModule.forChild({
+			loader: {
+				provide: TranslateLoader,
+				useFactory: HttpLoaderFactory,
+				deps: [HttpClient]
+			}
+		})
+	],
+	exports: [ExpensesMutationComponent],
+	declarations: [ExpensesMutationComponent],
+	entryComponents: [ExpensesMutationComponent],
+	providers: [OrganizationsService]
 })
-export class ExpensesMutationModule { }
+export class ExpensesMutationModule {}

--- a/apps/gauzy/src/app/pages/expenses/expenses.component.ts
+++ b/apps/gauzy/src/app/pages/expenses/expenses.component.ts
@@ -19,6 +19,7 @@ export interface ExpenseViewModel {
 	valueDate: Date;
 	vendorId: string;
 	vendorName: string;
+	typeOfExpense: string;
 	categoryId: string;
 	categoryName: string;
 	clientId: string;
@@ -207,6 +208,7 @@ export class ExpensesComponent implements OnInit, OnDestroy {
 							categoryName: formData.category.categoryName,
 							vendorId: formData.vendor.vendorId,
 							vendorName: formData.vendor.vendorName,
+							typeOfExpense: formData.typeOfExpense,
 							clientId: formData.client.clientId,
 							clientName: formData.client.clientName,
 							projectId: formData.project.projectId,
@@ -253,6 +255,7 @@ export class ExpensesComponent implements OnInit, OnDestroy {
 							categoryName: formData.category.categoryName,
 							vendorId: formData.vendor.vendorId,
 							vendorName: formData.vendor.vendorName,
+							typeOfExpense: formData.typeOfExpense,
 							clientId: formData.client.clientId,
 							clientName: formData.client.clientName,
 							projectId: formData.project.projectId,
@@ -370,6 +373,7 @@ export class ExpensesComponent implements OnInit, OnDestroy {
 					valueDate: i.valueDate,
 					vendorId: i.vendorId,
 					vendorName: i.vendorName,
+					typeOfExpense: i.typeOfExpense,
 					categoryId: i.categoryId,
 					categoryName: i.categoryName,
 					clientId: i.clientId,

--- a/libs/models/src/lib/expense.model.ts
+++ b/libs/models/src/lib/expense.model.ts
@@ -10,6 +10,7 @@ export interface Expense extends IBaseEntityModel {
 	amount: number;
 	vendorName: string;
 	vendorId?: string;
+	typeOfExpense?: string;
 	categoryName: string;
 	categoryId?: string;
 	clientId?: string;
@@ -30,6 +31,7 @@ export interface ExpenseCreateInput {
 	amount: number;
 	vendorName: string;
 	vendorId: string;
+	typeOfExpense?: string;
 	categoryName: string;
 	categoryId: string;
 	clientId?: string;
@@ -51,6 +53,7 @@ export interface ExpenseFindInput extends IBaseEntityModel {
 	organization?: OrganizationFindInput;
 	vendorName?: string;
 	vendorId?: string;
+	typeOfExpense?: string;
 	categoryName?: string;
 	categoryId?: string;
 	amount?: number;
@@ -73,6 +76,7 @@ export interface ExpenseUpdateInput {
 	amount?: number;
 	vendorName?: string;
 	vendorId?: string;
+	typeOfExpense?: string;
 	categoryName?: string;
 	categoryId?: string;
 	clientId?: string;
@@ -86,6 +90,12 @@ export interface ExpenseUpdateInput {
 	taxType?: string;
 	taxLabel?: string;
 	rateValue?: number;
+}
+
+export enum ExpenseTypesEnum {
+	TAX_DEDUCTIBLE = 'Tax Deductible',
+	NOT_TAX_DEDUCTIBLE = 'Not Tax Deductible',
+	BILLABLE_TO_CLIENT = 'Billable to Client'
 }
 
 export enum TaxTypesEnum {


### PR DESCRIPTION
An additional selector (above other inputs) for the type of Expense (radio boxes, only one selection is valid): "Tax Deductible" (default), "Not Tax Deductible", "Billable to Client" implemented on Expense Add/ Edit pages. Idea is that if Tax-Deductible Expense is selected, the company can claim it in official accounting. If it's "Not Tax Deductable", it means that it't can't be claimed in official accounting. If it's "Billable to client" it means that companie's client will refund for it. Note: if Billable to Client is selected, the popup require selection of Client.

![Expense_Type](https://user-images.githubusercontent.com/40795644/71974134-61868b00-3219-11ea-8f81-435d079ad096.png)
