### PR TITLE
feat: #161 #162 invite employee & user

### DIFF
--- a/apps/api/src/app/income/commands/handlers/income.create.handler.ts
+++ b/apps/api/src/app/income/commands/handlers/income.create.handler.ts
@@ -6,33 +6,38 @@ import { EmployeeService } from '../../../employee/employee.service';
 import { OrganizationService } from '../../../organization';
 
 @CommandHandler(IncomeCreateCommand)
-export class IncomeCreateHandler implements ICommandHandler<IncomeCreateCommand> {
-    constructor(
-        private readonly incomeService: IncomeService,
-        private readonly employeeService: EmployeeService,
-        private readonly organizationService: OrganizationService,
-    ) { }
+export class IncomeCreateHandler
+	implements ICommandHandler<IncomeCreateCommand> {
+	constructor(
+		private readonly incomeService: IncomeService,
+		private readonly employeeService: EmployeeService,
+		private readonly organizationService: OrganizationService
+	) {}
 
-    public async execute(command: IncomeCreateCommand): Promise<Income> {
-        const { input } = command;
+	public async execute(command: IncomeCreateCommand): Promise<Income> {
+		const { input } = command;
 
-        const income = new Income();
-        const employee = input.employeeId ? await this.employeeService.findOne(input.employeeId) : null;
-        const organization = await this.organizationService.findOne(input.orgId);
+		const income = new Income();
+		const employee = input.employeeId
+			? await this.employeeService.findOne(input.employeeId)
+			: null;
+		const organization = await this.organizationService.findOne(
+			input.orgId
+		);
 
-        income.clientName = input.clientName;
-        income.clientId = input.clientId;
-        income.employee = employee;
-        income.organization = organization;
-        income.amount = input.amount;
-        income.valueDate = input.valueDate;
-        income.notes = input.notes;
-        income.currency = input.currency;
+		income.clientName = input.clientName;
+		income.clientId = input.clientId;
+		income.employee = employee;
+		income.organization = organization;
+		income.amount = input.amount;
+		income.valueDate = input.valueDate;
+		income.notes = input.notes;
+		income.currency = input.currency;
 
-        if (!income.currency) {
-            income.currency = organization.currency
-        }
+		if (!income.currency) {
+			income.currency = organization.currency;
+		}
 
-        return await this.incomeService.create(income);
-    }
+		return await this.incomeService.create(income);
+	}
 }

--- a/apps/api/src/app/invite/commands/handlers/index.ts
+++ b/apps/api/src/app/invite/commands/handlers/index.ts
@@ -1,0 +1,7 @@
+import { InviteAcceptEmployeeHandler } from './invite.accept-employee.handler';
+import { InviteAcceptUserHandler } from './invite.accept-user.handler';
+
+export const CommandHandlers = [
+	InviteAcceptEmployeeHandler,
+	InviteAcceptUserHandler
+];

--- a/apps/api/src/app/invite/commands/handlers/invite.accept-employee.handler.ts
+++ b/apps/api/src/app/invite/commands/handlers/invite.accept-employee.handler.ts
@@ -1,0 +1,44 @@
+import { Invite, InviteStatusEnum } from '@gauzy/models';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { UpdateResult } from 'typeorm';
+import { AuthService } from '../../../auth';
+import { EmployeeService } from '../../../employee/employee.service';
+import { InviteService } from '../../invite.service';
+import { InviteAcceptEmployeeCommand } from '../invite.accept-employee.command';
+import { getUserDummyImage } from '../../../core';
+
+/**
+ * Use this command for registering employees.
+ * This command first registers a user, then creates an employee entry for the organization.
+ * If the above two steps are successful, it finally sets the invitation status to accepted
+ */
+@CommandHandler(InviteAcceptEmployeeCommand)
+export class InviteAcceptEmployeeHandler
+	implements ICommandHandler<InviteAcceptEmployeeCommand> {
+	constructor(
+		private readonly inviteService: InviteService,
+		private readonly employeeService: EmployeeService,
+		private readonly authService: AuthService
+	) {}
+
+	public async execute(
+		command: InviteAcceptEmployeeCommand
+	): Promise<UpdateResult | Invite> {
+		const { input } = command;
+
+		if (!input.user.imageUrl) {
+			input.user.imageUrl = getUserDummyImage(input.user);
+		}
+
+		const user = await this.authService.register(input);
+
+		await this.employeeService.create({
+			user,
+			organization: input.organization
+		});
+
+		return await this.inviteService.update(input.inviteId, {
+			status: InviteStatusEnum.ACCEPTED
+		});
+	}
+}

--- a/apps/api/src/app/invite/commands/handlers/invite.accept-user.handler.ts
+++ b/apps/api/src/app/invite/commands/handlers/invite.accept-user.handler.ts
@@ -1,0 +1,45 @@
+import { Invite, InviteStatusEnum } from '@gauzy/models';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { UpdateResult } from 'typeorm';
+import { AuthService } from '../../../auth';
+import { UserOrganizationService } from '../../../user-organization';
+import { InviteService } from '../../invite.service';
+import { InviteAcceptUserCommand } from '../invite.accept-user.command';
+import { getUserDummyImage } from '../../../core';
+
+/**
+ * Use this command for registering all non-employee users.
+ * This command first registers a user, then creates a user_organization relation.
+ * If the above two steps are successful, it finally sets the invitation status to accepted
+ */
+@CommandHandler(InviteAcceptUserCommand)
+export class InviteAcceptUserHandler
+	implements ICommandHandler<InviteAcceptUserCommand> {
+	constructor(
+		private readonly inviteService: InviteService,
+		private readonly userOrganizationService: UserOrganizationService,
+		private readonly authService: AuthService
+	) {}
+
+	public async execute(
+		command: InviteAcceptUserCommand
+	): Promise<UpdateResult | Invite> {
+		const { input } = command;
+
+		if (!input.user.imageUrl) {
+			input.user.imageUrl = getUserDummyImage(input.user);
+		}
+
+		const user = await this.authService.register(input);
+
+		await this.userOrganizationService.create({
+			userId: user.id,
+			orgId: input.organization.id,
+			isActive: true
+		});
+
+		return await this.inviteService.update(input.inviteId, {
+			status: InviteStatusEnum.ACCEPTED
+		});
+	}
+}

--- a/apps/api/src/app/invite/commands/invite.accept-employee.command.ts
+++ b/apps/api/src/app/invite/commands/invite.accept-employee.command.ts
@@ -1,0 +1,8 @@
+import { InviteAcceptInput as IInviteAcceptInput } from '@gauzy/models';
+import { ICommand } from '@nestjs/cqrs';
+
+export class InviteAcceptEmployeeCommand implements ICommand {
+	static readonly type = '[Invite] Accept Employee';
+
+	constructor(public readonly input: IInviteAcceptInput) {}
+}

--- a/apps/api/src/app/invite/commands/invite.accept-user.command.ts
+++ b/apps/api/src/app/invite/commands/invite.accept-user.command.ts
@@ -1,0 +1,8 @@
+import { InviteAcceptInput as IInviteAcceptInput } from '@gauzy/models';
+import { ICommand } from '@nestjs/cqrs';
+
+export class InviteAcceptUserCommand implements ICommand {
+	static readonly type = '[Invite] Accept User';
+
+	constructor(public readonly input: IInviteAcceptInput) {}
+}

--- a/apps/api/src/app/invite/invite.module.ts
+++ b/apps/api/src/app/invite/invite.module.ts
@@ -6,14 +6,37 @@ import { InviteService } from './invite.service';
 import { InviteController } from './invite.controller';
 import { SharedModule } from '../shared';
 import { OrganizationProjects } from '../organization-projects';
+import { Employee, EmployeeService } from '../employee';
+import { CqrsModule } from '@nestjs/cqrs';
+import { CommandHandlers } from './commands/handlers';
+import { UserService, User } from '../user';
+import { AuthService } from '../auth';
+import {
+	UserOrganizationService,
+	UserOrganization
+} from '../user-organization';
 
 @Module({
 	imports: [
-		TypeOrmModule.forFeature([Invite, OrganizationProjects]),
-		SharedModule
+		TypeOrmModule.forFeature([
+			Invite,
+			Employee,
+			User,
+			UserOrganization,
+			OrganizationProjects
+		]),
+		SharedModule,
+		CqrsModule
 	],
 	controllers: [InviteController],
-	providers: [InviteService],
+	providers: [
+		InviteService,
+		...CommandHandlers,
+		EmployeeService,
+		UserService,
+		AuthService,
+		UserOrganizationService
+	],
 	exports: [InviteService]
 })
 export class InviteModule {}

--- a/apps/gauzy/src/app/@core/services/invite.service.ts
+++ b/apps/gauzy/src/app/@core/services/invite.service.ts
@@ -5,7 +5,8 @@ import {
 	CreateEmailInvitesOutput,
 	Invite,
 	InviteFindInput,
-	PublicInviteFindInput
+	PublicInviteFindInput,
+	InviteAcceptInput
 } from '@gauzy/models';
 import { first } from 'rxjs/operators';
 
@@ -53,6 +54,20 @@ export class InviteService {
 	update(id: string, updateInput: any): Promise<any> {
 		return this.http
 			.put(`/api/invite/${id}`, updateInput)
+			.pipe(first())
+			.toPromise();
+	}
+
+	acceptEmployeeInvite(acceptInviteInput: InviteAcceptInput): Promise<any> {
+		return this.http
+			.post(`/api/invite/employee`, acceptInviteInput)
+			.pipe(first())
+			.toPromise();
+	}
+
+	acceptUserInvite(acceptInviteInput: InviteAcceptInput): Promise<any> {
+		return this.http
+			.post(`/api/invite/user`, acceptInviteInput)
 			.pipe(first())
 			.toPromise();
 	}

--- a/apps/gauzy/src/app/@shared/invite/invites/invites.component.ts
+++ b/apps/gauzy/src/app/@shared/invite/invites/invites.component.ts
@@ -1,12 +1,10 @@
 import { Component, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
 import { InvitationTypeEnum, RolesEnum } from '@gauzy/models';
 import { NbDialogService, NbToastrService } from '@nebular/theme';
 import { TranslateService } from '@ngx-translate/core';
 import { LocalDataSource } from 'ng2-smart-table';
 import { Subject } from 'rxjs';
 import { first, takeUntil } from 'rxjs/operators';
-import { ErrorHandlingService } from '../../../@core/services/error-handling.service';
 import { InviteService } from '../../../@core/services/invite.service';
 import { Store } from '../../../@core/services/store.service';
 import { InviteMutationComponent } from '../invite-mutation/invite-mutation.component';
@@ -52,9 +50,7 @@ export class InvitesComponent implements OnInit, OnDestroy {
 		private dialogService: NbDialogService,
 		private store: Store,
 		private toastrService: NbToastrService,
-		private route: ActivatedRoute,
 		private translate: TranslateService,
-		private errorHandler: ErrorHandlingService,
 		private inviteService: InviteService
 	) {}
 
@@ -116,37 +112,6 @@ export class InvitesComponent implements OnInit, OnDestroy {
 		);
 	}
 
-	// async delete() {
-	// 	this.dialogService
-	// 		.open(DeleteConfirmationComponent, {
-	// 			context: {
-	// 				recordType:
-	// 					this.selectedInvite.fullName +
-	// 					' ' +
-	// 					this.getTranslation('FORM.DELETE_CONFIRMATION.EMPLOYEE')
-	// 			}
-	// 		})
-	// 		.onClose.pipe(takeUntil(this._ngDestroy$))
-	// 		.subscribe(async (result) => {
-	// 			if (result) {
-	// 				try {
-	// 					// await this.employeesService.setEmployeeAsInactive(
-	// 					// 	this.selectedInvite.id
-	// 					// );
-
-	// 					this.toastrService.primary(
-	// 						this.invitedName + ' set as inactive.',
-	// 						'Success'
-	// 					);
-
-	// 					this.loadPage();
-	// 				} catch (error) {
-	// 					this.errorHandler.handleError(error);
-	// 				}
-	// 			}
-	// 		});
-	// }
-
 	private async loadPage() {
 		this.selectedInvite = null;
 
@@ -165,7 +130,10 @@ export class InvitesComponent implements OnInit, OnDestroy {
 					: invite.role.name !== RolesEnum.EMPLOYEE;
 			});
 		} catch (error) {
-			this.toastrService.warning('Could not load invites');
+			this.toastrService.danger(
+				this.getTranslation('TOASTR.MESSAGE.INVITES_LOAD'),
+				this.getTranslation('TOASTR.TITLE.ERROR')
+			);
 		}
 
 		const { name } = this.store.selectedOrganization;
@@ -183,9 +151,9 @@ export class InvitesComponent implements OnInit, OnDestroy {
 				roleName: invite.role
 					? this.getTranslation(`USERS_PAGE.ROLE.${invite.role.name}`)
 					: '',
-				status: this.getTranslation(
-					`INVITE_PAGE.STATUS.${invite.status}`
-				),
+				status: moment(invite.expireDate).isAfter(moment())
+					? this.getTranslation(`INVITE_PAGE.STATUS.${invite.status}`)
+					: this.getTranslation(`INVITE_PAGE.STATUS.EXPIRED`),
 				projectNames: (invite.projects || []).map(
 					(project) => project.name
 				),

--- a/apps/gauzy/src/app/auth/accept-invite/accept-invite-form/accept-invite-form.component.html
+++ b/apps/gauzy/src/app/auth/accept-invite/accept-invite-form/accept-invite-form.component.html
@@ -10,6 +10,14 @@
 					nbInput
 					formControlName="fullName"
 					fieldSize="large"
+					[ngClass]="{
+						'status-danger':
+							fullName.invalid &&
+							(fullName.dirty || fullName.touched),
+						'status-success':
+							fullName.valid &&
+							(fullName.dirty || fullName.touched)
+					}"
 				/>
 			</div>
 		</div>
@@ -27,6 +35,14 @@
 					formControlName="password"
 					placeholder="Password"
 					fieldSize="large"
+					[ngClass]="{
+						'status-danger':
+							password.invalid &&
+							(password.dirty || password.touched),
+						'status-success':
+							password.valid &&
+							(password.dirty || password.touched)
+					}"
 				/>
 			</div>
 		</div>
@@ -46,6 +62,14 @@
 					formControlName="repeatPassword"
 					placeholder="Repeat Password"
 					fieldSize="large"
+					[ngClass]="{
+						'status-danger':
+							repeatPassword.invalid &&
+							(repeatPassword.dirty || repeatPassword.touched),
+						'status-success':
+							repeatPassword.valid &&
+							(repeatPassword.dirty || repeatPassword.touched)
+					}"
 				/>
 				<span *ngIf="!!repeatPasswordErrorMsg">
 					<strong class="text-danger">

--- a/apps/gauzy/src/app/auth/accept-invite/accept-invite.component.ts
+++ b/apps/gauzy/src/app/auth/accept-invite/accept-invite.component.ts
@@ -1,17 +1,8 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import {
-	Invite,
-	InviteStatusEnum,
-	RolesEnum,
-	UserRegistrationInput
-} from '@gauzy/models';
-import { first } from 'rxjs/operators';
-import { EmployeesService } from '../../@core/services';
-import { AuthService } from '../../@core/services/auth.service';
-import { InviteService } from '../../@core/services/invite.service';
-import { UsersOrganizationsService } from '../../@core/services/users-organizations.service';
+import { Invite, RolesEnum, UserRegistrationInput } from '@gauzy/models';
 import { NbToastrService } from '@nebular/theme';
+import { InviteService } from '../../@core/services/invite.service';
 
 @Component({
 	styleUrls: ['./accept-invite.component.scss'],

--- a/apps/gauzy/src/app/auth/accept-invite/accept-invite.module.ts
+++ b/apps/gauzy/src/app/auth/accept-invite/accept-invite.module.ts
@@ -15,10 +15,8 @@ import {
 import { NgSelectModule } from '@ng-select/ng-select';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
-import { EmployeesService } from '../../@core/services';
 import { InviteService } from '../../@core/services/invite.service';
 import { RoleService } from '../../@core/services/role.service';
-import { UsersOrganizationsService } from '../../@core/services/users-organizations.service';
 import { ThemeModule } from '../../@theme/theme.module';
 import { AcceptInviteFormComponent } from './accept-invite-form/accept-invite-form.component';
 import { AcceptInvitePage } from './accept-invite.component';
@@ -53,11 +51,6 @@ export function HttpLoaderFactory(http: HttpClient) {
 	],
 	declarations: [AcceptInvitePage, AcceptInviteFormComponent],
 	entryComponents: [AcceptInvitePage, AcceptInviteFormComponent],
-	providers: [
-		InviteService,
-		RoleService,
-		EmployeesService,
-		UsersOrganizationsService
-	]
+	providers: [InviteService, RoleService]
 })
 export class AcceptInviteModule {}

--- a/apps/gauzy/src/app/pages/employees/employees.component.html
+++ b/apps/gauzy/src/app/pages/employees/employees.component.html
@@ -4,17 +4,17 @@
 			<h4>
 				{{ 'EMPLOYEES_PAGE.HEADER' | translate }} {{ organizationName }}
 			</h4>
-			<!-- <button nbButton status="primary" (click)="manageInvites()">
+			<button nbButton status="primary" (click)="manageInvites()">
 				{{ 'BUTTONS.MANAGE_INVITES' | translate }}
-			</button> -->
+			</button>
 		</div>
 	</nb-card-header>
 	<nb-card-body>
 		<div class="mb-3">
-			<!-- <button nbButton status="primary" (click)="invite()" class="mr-2">
+			<button nbButton status="primary" (click)="invite()" class="mr-2">
 				<nb-icon class="mr-1" icon="email-outline"></nb-icon
 				>{{ 'BUTTONS.INVITE' | translate }}
-			</button> -->
+			</button>
 
 			<button nbButton status="success" (click)="add()" class="mr-2">
 				<nb-icon class="mr-1" icon="plus-outline"></nb-icon

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -370,7 +370,8 @@
 		},
 		"MESSAGE": {
 			"PROJECT_LOAD": "Could Not Load Projects",
-			"COPIED": "Link copied to clipboard"
+			"COPIED": "Link copied to clipboard",
+			"INVITES_LOAD": "Could Not Load Invites"
 		}
 	}
 }

--- a/libs/models/src/lib/invite.model.ts
+++ b/libs/models/src/lib/invite.model.ts
@@ -4,7 +4,7 @@
 
 import { Role } from './role.model';
 import { BaseEntityModel as IBaseEntityModel } from './base-entity.model';
-import { User } from './user.model';
+import { User, UserRegistrationInput } from './user.model';
 import { OrganizationProjects } from './organization-projects.model';
 import { Organization } from './organization.model';
 
@@ -20,6 +20,11 @@ export interface Invite extends IBaseEntityModel {
 	invitedBy?: User;
 	projects?: OrganizationProjects[];
 	organization?: Organization;
+}
+
+export interface InviteAcceptInput extends UserRegistrationInput {
+	inviteId: string;
+	organization: Organization;
 }
 
 export interface CreateEmailInvitesInput {
@@ -63,8 +68,7 @@ export interface InviteUpdateInput {
 
 export enum InviteStatusEnum {
 	INVITED = 'INVITED',
-	ACCEPTED = 'ACCEPTED',
-	EXPIRED = 'EXPIRED'
+	ACCEPTED = 'ACCEPTED'
 }
 
 export enum InvitationTypeEnum {


### PR DESCRIPTION
1. Added feature to send a test email using ethereal
2. Handled expired invitations. Please note: In the backend, the status will always be INVITED or ACCEPTED. Expired is calculated at runtime from expire time.
3. As discussed, created two different command handlers to handle user creation and employee creation when they accept invites.
4. Added employee invites.
5. Improved feedback for password and name fields to show red/green borders when validation fails.

Fixes #161 
Fixes #162 
Fixes #163 
Fixes #164 

Created a new issue #437 to track invite employee enhancements (projects, clients, departments) 
