### PR TITLE
fix: #415 float calculation

### DIFF
--- a/apps/gauzy/src/app/pages/employees/employees.component.ts
+++ b/apps/gauzy/src/app/pages/employees/employees.component.ts
@@ -336,7 +336,7 @@ export class EmployeesComponent implements OnInit, OnDestroy {
 				bonus: this.bonusForSelectedMonth,
 				averageIncome: Math.floor(this.averageIncome),
 				averageExpenses: Math.floor(this.averageExpense),
-				averageBonus: this.averageBonus,
+				averageBonus: Math.floor(this.averageBonus),
 				bonusDate: Date.now()
 			});
 		}


### PR DESCRIPTION
Fixes #415 
I have added Math.floor because that was already being used in other fields.

Please let me know if it needs to be rounded to two decimal places or some other way.

@AlexTasev please let me know if there are these calculations on any other pages, since what I've noticed others seem to be fixed :) 