### PR TITLE
Feature/#128 organization region date number format

### DIFF
--- a/apps/api/src/app/organization/organization.entity.ts
+++ b/apps/api/src/app/organization/organization.entity.ts
@@ -124,4 +124,16 @@ export class Organization extends Base implements IOrganization {
 	@IsOptional()
 	@Column({ nullable: true })
 	postcode?: string;
+
+	@ApiProperty({ type: String })
+	@Column()
+	@IsOptional()
+	@Column({ nullable: true })
+	regionCode?: string;
+
+	@ApiProperty({ type: String })
+	@Column()
+	@IsOptional()
+	@Column({ nullable: true })
+	numberFormat?: string;
 }

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.html
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.html
@@ -86,24 +86,44 @@
 					<div class="col-6">
 						<div class="form-group">
 							<label class="label">Regions</label>
-							<ng-select
-								[(items)]="regionCodes"
-								placeholder="Select Region"
-								[searchable]="true"
+							<nb-select
+								class="d-block"
+								size="medium"
+								placeholder="{{
+									'FORM.PLACEHOLDERS.REGIONS' | translate
+								}}"
 								formControlName="regionCode"
+								fullWidth
 							>
-							</ng-select>
+								<nb-option
+									*ngFor="let code of regionCodes"
+									[value]="code"
+								>
+									{{ 'SM_TABLE.REGION.' + code | translate }}
+								</nb-option>
+							</nb-select>
 						</div>
 					</div>
 					<div class="col-6">
 						<div class="form-group">
-							<label class="label">Number Format</label>
-							<ng-select
-								[(items)]="numberFormats"
-								placeholder="Select Number Format"
+							<label class="label">Number Formats</label>
+							<nb-select
+								class="d-block"
+								size="medium"
+								placeholder="{{
+									'FORM.PLACEHOLDERS.NUMBER_FORMAT'
+										| translate
+								}}"
 								formControlName="numberFormat"
+								fullWidth
 							>
-							</ng-select>
+								<nb-option
+									*ngFor="let numFormat of numberFormats"
+									[value]="numFormat"
+								>
+									{{ numberFormatPreview(numFormat) }}
+								</nb-option>
+							</nb-select>
 						</div>
 					</div>
 					<div class="col-6">

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.html
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.html
@@ -14,7 +14,8 @@
 							<ng-select
 								[(items)]="listOfZones"
 								placeholder="{{
-									'FORM.PLACEHOLDERS.CHOOSE_TIME_ZONE' | translate
+									'FORM.PLACEHOLDERS.CHOOSE_TIME_ZONE'
+										| translate
 								}}"
 								[searchable]="true"
 								formControlName="timeZone"
@@ -84,6 +85,29 @@
 					</div>
 					<div class="col-6">
 						<div class="form-group">
+							<label class="label">Regions</label>
+							<ng-select
+								[(items)]="regionCodes"
+								placeholder="Select Region"
+								[searchable]="true"
+								formControlName="regionCode"
+							>
+							</ng-select>
+						</div>
+					</div>
+					<div class="col-6">
+						<div class="form-group">
+							<label class="label">Number Format</label>
+							<ng-select
+								[(items)]="numberFormats"
+								placeholder="Select Number Format"
+								formControlName="numberFormat"
+							>
+							</ng-select>
+						</div>
+					</div>
+					<div class="col-6">
+						<div class="form-group">
 							<label class="label">
 								{{ 'FORM.LABELS.DATE_FORMAT' | translate }}
 							</label>
@@ -91,7 +115,10 @@
 								class="d-block"
 								size="medium"
 								formControlName="dateFormat"
-								placeholder="{{ 'FORM.PLACEHOLDERS.CHOOSE_FORMAT' | translate }}"
+								placeholder="{{
+									'FORM.PLACEHOLDERS.CHOOSE_FORMAT'
+										| translate
+								}}"
 								fullWidth
 							>
 								<nb-option
@@ -125,7 +152,9 @@
 								id="brandColorInput"
 								nbInput
 								formControlName="brandColor"
-								placeholder="{{ 'FORM.PLACEHOLDERS.ADD_COLOR' | translate }}"
+								placeholder="{{
+									'FORM.PLACEHOLDERS.ADD_COLOR' | translate
+								}}"
 								[colorPicker]="form.get('brandColor').value"
 								[style.background]="
 									form.get('brandColor').value
@@ -146,7 +175,10 @@
 								class="d-block"
 								size="medium"
 								formControlName="defaultAlignmentType"
-								placeholder="{{ 'FORM.PLACEHOLDERS.ALIGN_LOGO_TO' | translate }}"
+								placeholder="{{
+									'FORM.PLACEHOLDERS.ALIGN_LOGO_TO'
+										| translate
+								}}"
 								fullWidth
 							>
 								<nb-option

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.ts
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.ts
@@ -5,7 +5,8 @@ import {
 	DefaultValueDateTypeEnum,
 	Organization,
 	WeekDaysEnum,
-	RegionsEnum
+	RegionsEnum,
+	CurrenciesEnum
 } from '@gauzy/models';
 import { NbToastrService } from '@nebular/theme';
 import { OrganizationEditStore } from 'apps/gauzy/src/app/@core/services/organization-edit-store.service';
@@ -35,10 +36,11 @@ export class EditOrganizationOtherSettingsComponent implements OnInit {
 	);
 	listOfZones = timezone.tz.names().filter((zone) => zone.includes('/'));
 	// todo: maybe its better to place listOfDateFormats somewhere more global for the app?
-	listOfDateFormats = ['L', 'LL', 'LLL', 'LLLL'];
-	numberFormats: ['12000.00', '12 000.00', '12 000,00', "12'000.00"];
+	listOfDateFormats = ['L', 'L hh:mm', 'LL', 'LLL', 'LLLL'];
+	numberFormats = ['USD', 'BGN', 'ILS'];
 	numberFormat: string;
 	weekdays: string[] = Object.values(WeekDaysEnum);
+	currencies = Object.values(CurrenciesEnum);
 	regionCodes = Object.keys(RegionsEnum);
 	regionCode: string;
 	regions = Object.values(RegionsEnum);
@@ -62,8 +64,35 @@ export class EditOrganizationOtherSettingsComponent implements OnInit {
 	}
 
 	dateFormatPreview(format: string) {
+		this.form.valueChanges
+			.pipe(takeUntil(this._ngDestroy$))
+			.subscribe((val) => {
+				this.regionCode = val.regionCode;
+			});
+
 		moment.locale(this.regionCode);
 		return moment().format(format);
+	}
+
+	numberFormatPreview(format: string) {
+		const number = 12345.67;
+		let code: string;
+		switch (format) {
+			case 'BGN':
+				code = 'bg';
+				break;
+			case 'USD':
+				code = 'en';
+				break;
+			case 'ILS':
+				code = 'he';
+				break;
+		}
+		return number.toLocaleString(`${code}`, {
+			style: 'currency',
+			currency: `${format}`,
+			currencyDisplay: 'symbol'
+		});
 	}
 
 	ngOnInit(): void {
@@ -105,11 +134,13 @@ export class EditOrganizationOtherSettingsComponent implements OnInit {
 				this.organization.defaultValueDateType,
 				Validators.required
 			],
+			regionCode: [this.organization.regionCode],
 			defaultAlignmentType: [this.organization.defaultAlignmentType],
 			brandColor: [this.organization.brandColor],
 			dateFormat: [this.organization.dateFormat],
 			timeZone: [this.organization.timeZone],
-			startWeekOn: [this.organization.startWeekOn]
+			startWeekOn: [this.organization.startWeekOn],
+			numberFormat: [this.organization.numberFormat]
 		});
 	}
 }

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.ts
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.ts
@@ -4,7 +4,8 @@ import {
 	AlignmentOptions,
 	DefaultValueDateTypeEnum,
 	Organization,
-	WeekDaysEnum
+	WeekDaysEnum,
+	RegionsEnum
 } from '@gauzy/models';
 import { NbToastrService } from '@nebular/theme';
 import { OrganizationEditStore } from 'apps/gauzy/src/app/@core/services/organization-edit-store.service';
@@ -34,17 +35,14 @@ export class EditOrganizationOtherSettingsComponent implements OnInit {
 	);
 	listOfZones = timezone.tz.names().filter((zone) => zone.includes('/'));
 	// todo: maybe its better to place listOfDateFormats somewhere more global for the app?
-	listOfDateFormats = [
-		'M/D/YYYY',
-		'D/M/YYYY',
-		'DDDD/MMMM/YYYY',
-		'MMMM Do YYYY',
-		'dddd, MMMM Do YYYY',
-		'MMM D YYYY',
-		'YYYY-MM-DD',
-		'ddd, MMM D YYYY'
-	];
+	listOfDateFormats = ['L', 'LL', 'LLL', 'LLLL'];
+	numberFormats: ['12000.00', '12 000.00', '12 000,00', "12'000.00"];
+	numberFormat: string;
 	weekdays: string[] = Object.values(WeekDaysEnum);
+	regionCodes = Object.keys(RegionsEnum);
+	regionCode: string;
+	regions = Object.values(RegionsEnum);
+
 	constructor(
 		private fb: FormBuilder,
 		private organizationService: OrganizationsService,
@@ -64,6 +62,7 @@ export class EditOrganizationOtherSettingsComponent implements OnInit {
 	}
 
 	dateFormatPreview(format: string) {
+		moment.locale(this.regionCode);
 		return moment().format(format);
 	}
 

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -69,7 +69,13 @@
 		"INVITED_BY": "Invited By",
 		"EXPIRE_DATE": "Expires",
 		"CLIENTS": "Clients",
-		"DEPARTMENTS": "Departments"
+		"DEPARTMENTS": "Departments",
+		"REGION": {
+			"BG": "Български (България)",
+			"EN": "English (United States)",
+			"RU": "Русский (Россия)",
+			"HE": "עברית ישראל"
+		}
 	},
 	"FORM": {
 		"USERNAME": "Username",
@@ -148,7 +154,9 @@
 			"CHOOSE_TIME_ZONE": "Choose Time Zone",
 			"ADD_COLOR": "Add Color",
 			"ALIGN_LOGO_TO": "Align Logo To",
-			"DEPARTMENTS": "Departments"
+			"DEPARTMENTS": "Departments",
+			"NUMBER_FORMAT": "Select Number Format",
+			"REGIONS": "Select Region"
 		},
 		"RATES": {
 			"DEFAULT_RATE": "Default Rate",

--- a/libs/models/src/lib/organization.model.ts
+++ b/libs/models/src/lib/organization.model.ts
@@ -21,6 +21,8 @@ export interface Organization extends IBaseEntityModel {
 	address?: string;
 	address2?: string;
 	postcode?: string;
+	regionCode?: string;
+	numberFormat?: string;
 }
 
 export interface OrganizationFindInput extends IBaseEntityModel {
@@ -53,8 +55,8 @@ export enum OrganizationSelectInput {
 export enum RegionsEnum {
 	'EN' = 'English (United States)',
 	'BG' = 'Bulgarian (Bulgaria)',
-	'RU' = 'Rusian (Russia)',
-	'HE' = 'Hebrew (Israel)'
+	'HE' = 'Hebrew (Israel)',
+	'RU' = 'Rusian (Russia)'
 }
 
 export enum CurrenciesEnum {

--- a/libs/models/src/lib/organization.model.ts
+++ b/libs/models/src/lib/organization.model.ts
@@ -50,6 +50,13 @@ export enum OrganizationSelectInput {
 	isActive = 'isActive'
 }
 
+export enum RegionsEnum {
+	'EN' = 'English (United States)',
+	'BG' = 'Bulgarian (Bulgaria)',
+	'RU' = 'Rusian (Russia)',
+	'HE' = 'Hebrew (Israel)'
+}
+
 export enum CurrenciesEnum {
 	USD = 'USD',
 	BGN = 'BGN',


### PR DESCRIPTION
"Region", "Number format" and "Date format" dropdowns implemented on Organization settings page. When a user selects a region like English (United States), Bulgarian (Bulgaria) etc., country specific date formats are displayed. Number format shows country specific format and currency symbol, for example: "3000,00 лв.". On the respective pages the currency symbol should be displayed if for the selected organization the "currency" record match with "number format record". In the opposite case the default currency should be displayed like:  "3,000.00 BGN".

![DateFormat](https://user-images.githubusercontent.com/40795644/72902618-78a69c00-3d34-11ea-93ad-cb9ed35f8ec6.png)

![NumberFormat](https://user-images.githubusercontent.com/40795644/72902628-7e03e680-3d34-11ea-902f-f76357197b28.png)
