### PR TITLE
feat: #452 Employee assignments to project, department and clients

### DIFF
--- a/apps/api/src/app/organization-clients/commands/handlers/index.ts
+++ b/apps/api/src/app/organization-clients/commands/handlers/index.ts
@@ -1,0 +1,3 @@
+import { OrganizationClientsEditByEmployeeHandler } from './organization-clients.edit-by-employee.handler';
+
+export const CommandHandlers = [OrganizationClientsEditByEmployeeHandler];

--- a/apps/api/src/app/organization-clients/commands/handlers/organization-clients.edit-by-employee.handler.ts
+++ b/apps/api/src/app/organization-clients/commands/handlers/organization-clients.edit-by-employee.handler.ts
@@ -1,0 +1,21 @@
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { UpdateEntityByMembersHandler } from '../../../shared';
+import { OrganizationClientsService } from '../../organization-clients.service';
+import { OrganizationClientsEditByEmployeeCommand } from '../organization-clients.edit-by-employee.command';
+
+@CommandHandler(OrganizationClientsEditByEmployeeCommand)
+export class OrganizationClientsEditByEmployeeHandler
+	extends UpdateEntityByMembersHandler
+	implements ICommandHandler<OrganizationClientsEditByEmployeeCommand> {
+	constructor(
+		private readonly organizationClientsService: OrganizationClientsService
+	) {
+		super(organizationClientsService);
+	}
+
+	public async execute(
+		command: OrganizationClientsEditByEmployeeCommand
+	): Promise<any> {
+		return this.executeCommand(command.input);
+	}
+}

--- a/apps/api/src/app/organization-clients/commands/organization-clients.edit-by-employee.command.ts
+++ b/apps/api/src/app/organization-clients/commands/organization-clients.edit-by-employee.command.ts
@@ -1,0 +1,10 @@
+import { ICommand } from '@nestjs/cqrs';
+import { EditEntityByMemberInput as IOrganizationDepartmentEditByEmployeeInput } from '@gauzy/models';
+
+export class OrganizationClientsEditByEmployeeCommand implements ICommand {
+	static readonly type = '[OrganizationClients] Edit By Employee';
+
+	constructor(
+		public readonly input: IOrganizationDepartmentEditByEmployeeInput
+	) {}
+}

--- a/apps/api/src/app/organization-clients/organization-clients.module.ts
+++ b/apps/api/src/app/organization-clients/organization-clients.module.ts
@@ -3,13 +3,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { OrganizationClients } from './organization-clients.entity';
 import { OrganizationClientsController } from './organization-clients.controller';
 import { OrganizationClientsService } from './organization-clients.service';
+import { CqrsModule } from '@nestjs/cqrs';
+import { CommandHandlers } from './commands/handlers';
 
 @Module({
-    imports: [
-        TypeOrmModule.forFeature([OrganizationClients]),
-    ],
-    controllers: [OrganizationClientsController],
-    providers: [OrganizationClientsService],
-    exports: [OrganizationClientsService],
+	imports: [TypeOrmModule.forFeature([OrganizationClients]), CqrsModule],
+	controllers: [OrganizationClientsController],
+	providers: [OrganizationClientsService, ...CommandHandlers],
+	exports: [OrganizationClientsService]
 })
-export class OrganizationClientsModule { }
+export class OrganizationClientsModule {}

--- a/apps/api/src/app/organization-clients/organization-clients.service.ts
+++ b/apps/api/src/app/organization-clients/organization-clients.service.ts
@@ -5,10 +5,23 @@ import { CrudService } from '../core/crud/crud.service';
 import { OrganizationClients } from './organization-clients.entity';
 
 @Injectable()
-export class OrganizationClientsService extends CrudService<OrganizationClients> {
-    constructor(
-        @InjectRepository(OrganizationClients) private readonly organizationClientsRepository: Repository<OrganizationClients>
-    ) {
-        super(organizationClientsRepository);
-    }
+export class OrganizationClientsService extends CrudService<
+	OrganizationClients
+> {
+	constructor(
+		@InjectRepository(OrganizationClients)
+		private readonly organizationClientsRepository: Repository<
+			OrganizationClients
+		>
+	) {
+		super(organizationClientsRepository);
+	}
+
+	async findByEmployee(id: string): Promise<any> {
+		return await this.organizationClientsRepository
+			.createQueryBuilder('organization_clients')
+			.leftJoin('organization_clients.members', 'member')
+			.where('member.id = :id', { id })
+			.getMany();
+	}
 }

--- a/apps/api/src/app/organization-department/commands/handlers/index.ts
+++ b/apps/api/src/app/organization-department/commands/handlers/index.ts
@@ -1,0 +1,3 @@
+import { OrganizationDepartmentEditByEmployeeHandler } from './organization-department.edit-by-employee.handler';
+
+export const CommandHandlers = [OrganizationDepartmentEditByEmployeeHandler];

--- a/apps/api/src/app/organization-department/commands/handlers/organization-department.edit-by-employee.handler.ts
+++ b/apps/api/src/app/organization-department/commands/handlers/organization-department.edit-by-employee.handler.ts
@@ -1,0 +1,21 @@
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { OrganizationDepartmentEditByEmployeeCommand } from '../organization-department.edit-by-employee.command';
+import { OrganizationDepartmentService } from '../../organization-department.service';
+import { UpdateEntityByMembersHandler } from '../../../shared';
+
+@CommandHandler(OrganizationDepartmentEditByEmployeeCommand)
+export class OrganizationDepartmentEditByEmployeeHandler
+	extends UpdateEntityByMembersHandler
+	implements ICommandHandler<OrganizationDepartmentEditByEmployeeCommand> {
+	constructor(
+		private readonly organizationDepartmentService: OrganizationDepartmentService
+	) {
+		super(organizationDepartmentService);
+	}
+
+	public async execute(
+		command: OrganizationDepartmentEditByEmployeeCommand
+	): Promise<any> {
+		return this.executeCommand(command.input);
+	}
+}

--- a/apps/api/src/app/organization-department/commands/organization-department.edit-by-employee.command.ts
+++ b/apps/api/src/app/organization-department/commands/organization-department.edit-by-employee.command.ts
@@ -1,0 +1,10 @@
+import { ICommand } from '@nestjs/cqrs';
+import { EditEntityByMemberInput as IOrganizationDepartmentEditByEmployeeInput } from '@gauzy/models';
+
+export class OrganizationDepartmentEditByEmployeeCommand implements ICommand {
+	static readonly type = '[OrganizationDepartment] Edit By Employee';
+
+	constructor(
+		public readonly input: IOrganizationDepartmentEditByEmployeeInput
+	) {}
+}

--- a/apps/api/src/app/organization-department/organization-department.module.ts
+++ b/apps/api/src/app/organization-department/organization-department.module.ts
@@ -3,13 +3,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { OrganizationDepartment } from './organization-department.entity';
 import { OrganizationDepartmentController } from './organization-department.controller';
 import { OrganizationDepartmentService } from './organization-department.service';
+import { CqrsModule } from '@nestjs/cqrs';
+import { CommandHandlers } from './commands/handlers';
 
 @Module({
-    imports: [
-        TypeOrmModule.forFeature([OrganizationDepartment]),
-    ],
-    controllers: [OrganizationDepartmentController],
-    providers: [OrganizationDepartmentService],
-    exports: [OrganizationDepartmentService],
+	imports: [TypeOrmModule.forFeature([OrganizationDepartment]), CqrsModule],
+	controllers: [OrganizationDepartmentController],
+	providers: [OrganizationDepartmentService, ...CommandHandlers],
+	exports: [OrganizationDepartmentService]
 })
-export class OrganizationDepartmentModule { }
+export class OrganizationDepartmentModule {}

--- a/apps/api/src/app/organization-department/organization-department.service.ts
+++ b/apps/api/src/app/organization-department/organization-department.service.ts
@@ -5,10 +5,23 @@ import { CrudService } from '../core/crud/crud.service';
 import { OrganizationDepartment } from './organization-department.entity';
 
 @Injectable()
-export class OrganizationDepartmentService extends CrudService<OrganizationDepartment> {
-    constructor(
-        @InjectRepository(OrganizationDepartment) private readonly organizationDepartmentRepository: Repository<OrganizationDepartment>
-    ) {
-        super(organizationDepartmentRepository);
-    }
+export class OrganizationDepartmentService extends CrudService<
+	OrganizationDepartment
+> {
+	constructor(
+		@InjectRepository(OrganizationDepartment)
+		private readonly organizationDepartmentRepository: Repository<
+			OrganizationDepartment
+		>
+	) {
+		super(organizationDepartmentRepository);
+	}
+
+	async findByEmployee(id: string): Promise<any> {
+		return await this.organizationDepartmentRepository
+			.createQueryBuilder('organization_department')
+			.leftJoin('organization_department.members', 'member')
+			.where('member.id = :id', { id })
+			.getMany();
+	}
 }

--- a/apps/api/src/app/organization-projects/commands/handlers/index.ts
+++ b/apps/api/src/app/organization-projects/commands/handlers/index.ts
@@ -1,0 +1,3 @@
+import { OrganizationProjectEditByEmployeeHandler } from './organization-project.edit-by-employee.handler';
+
+export const CommandHandlers = [OrganizationProjectEditByEmployeeHandler];

--- a/apps/api/src/app/organization-projects/commands/handlers/organization-project.edit-by-employee.handler.ts
+++ b/apps/api/src/app/organization-projects/commands/handlers/organization-project.edit-by-employee.handler.ts
@@ -1,0 +1,21 @@
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { UpdateEntityByMembersHandler } from '../../../shared';
+import { OrganizationProjectsService } from '../../organization-projects.service';
+import { OrganizationProjectEditByEmployeeCommand } from '../organization-project.edit-by-employee.command';
+
+@CommandHandler(OrganizationProjectEditByEmployeeCommand)
+export class OrganizationProjectEditByEmployeeHandler
+	extends UpdateEntityByMembersHandler
+	implements ICommandHandler<OrganizationProjectEditByEmployeeCommand> {
+	constructor(
+		private readonly organizationDepartmentService: OrganizationProjectsService
+	) {
+		super(organizationDepartmentService);
+	}
+
+	public async execute(
+		command: OrganizationProjectEditByEmployeeCommand
+	): Promise<any> {
+		return this.executeCommand(command.input);
+	}
+}

--- a/apps/api/src/app/organization-projects/commands/organization-project.edit-by-employee.command.ts
+++ b/apps/api/src/app/organization-projects/commands/organization-project.edit-by-employee.command.ts
@@ -1,0 +1,10 @@
+import { ICommand } from '@nestjs/cqrs';
+import { EditEntityByMemberInput as IOrganizationProjectEditByEmployeeInput } from '@gauzy/models';
+
+export class OrganizationProjectEditByEmployeeCommand implements ICommand {
+	static readonly type = '[OrganizationProject] Edit By Employee';
+
+	constructor(
+		public readonly input: IOrganizationProjectEditByEmployeeInput
+	) {}
+}

--- a/apps/api/src/app/organization-projects/organization-projects.controller.ts
+++ b/apps/api/src/app/organization-projects/organization-projects.controller.ts
@@ -1,9 +1,21 @@
-import { Controller, Get, HttpStatus, Query } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
-import { CrudController } from '../core/crud/crud.controller';
-import { OrganizationProjectsService } from './organization-projects.service';
-import { OrganizationProjects } from './organization-projects.entity';
+import { EditEntityByMemberInput } from '@gauzy/models';
+import {
+	Body,
+	Controller,
+	Get,
+	HttpCode,
+	HttpStatus,
+	Param,
+	Put,
+	Query
+} from '@nestjs/common';
+import { CommandBus } from '@nestjs/cqrs';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { IPagination } from '../core';
+import { CrudController } from '../core/crud/crud.controller';
+import { OrganizationProjectEditByEmployeeCommand } from './commands/organization-project.edit-by-employee.command';
+import { OrganizationProjects } from './organization-projects.entity';
+import { OrganizationProjectsService } from './organization-projects.service';
 
 @ApiTags('Organization-Projects')
 @Controller()
@@ -11,17 +23,37 @@ export class OrganizationProjectsController extends CrudController<
 	OrganizationProjects
 > {
 	constructor(
-		private readonly organizationProjectsService: OrganizationProjectsService
+		private readonly organizationProjectsService: OrganizationProjectsService,
+		private readonly commandBus: CommandBus
 	) {
 		super(organizationProjectsService);
 	}
 
 	@ApiOperation({
-		summary: 'Find all organization projects recurring expense.'
+		summary: 'Find all organization projects by Employee.'
 	})
 	@ApiResponse({
 		status: HttpStatus.OK,
-		description: 'Found projects recurring expense',
+		description: 'Found projects',
+		type: OrganizationProjects
+	})
+	@ApiResponse({
+		status: HttpStatus.NOT_FOUND,
+		description: 'Record not found'
+	})
+	@Get('employee/:id')
+	async findByEmployee(
+		@Param('id') id: string
+	): Promise<IPagination<OrganizationProjects>> {
+		return this.organizationProjectsService.findByEmployee(id);
+	}
+
+	@ApiOperation({
+		summary: 'Find all organization projects.'
+	})
+	@ApiResponse({
+		status: HttpStatus.OK,
+		description: 'Found projects',
 		type: OrganizationProjects
 	})
 	@ApiResponse({
@@ -38,5 +70,29 @@ export class OrganizationProjectsController extends CrudController<
 			where: findInput,
 			relations
 		});
+	}
+
+	@ApiOperation({ summary: 'Update an existing record' })
+	@ApiResponse({
+		status: HttpStatus.CREATED,
+		description: 'The record has been successfully edited.'
+	})
+	@ApiResponse({
+		status: HttpStatus.NOT_FOUND,
+		description: 'Record not found'
+	})
+	@ApiResponse({
+		status: HttpStatus.BAD_REQUEST,
+		description:
+			'Invalid input, The response body may contain clues as to what went wrong'
+	})
+	@HttpCode(HttpStatus.ACCEPTED)
+	@Put('employee')
+	async updateEmployee(
+		@Body() entity: EditEntityByMemberInput
+	): Promise<any> {
+		return this.commandBus.execute(
+			new OrganizationProjectEditByEmployeeCommand(entity)
+		);
 	}
 }

--- a/apps/api/src/app/organization-projects/organization-projects.module.ts
+++ b/apps/api/src/app/organization-projects/organization-projects.module.ts
@@ -3,13 +3,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { OrganizationProjects } from './organization-projects.entity';
 import { OrganizationProjectsController } from './organization-projects.controller';
 import { OrganizationProjectsService } from './organization-projects.service';
+import { CqrsModule } from '@nestjs/cqrs';
+import { CommandHandlers } from './commands/handlers';
 
 @Module({
-    imports: [
-        TypeOrmModule.forFeature([OrganizationProjects]),
-    ],
-    controllers: [OrganizationProjectsController],
-    providers: [OrganizationProjectsService],
-    exports: [OrganizationProjectsService],
+	imports: [TypeOrmModule.forFeature([OrganizationProjects]), CqrsModule],
+	controllers: [OrganizationProjectsController],
+	providers: [OrganizationProjectsService, ...CommandHandlers],
+	exports: [OrganizationProjectsService]
 })
-export class OrganizationProjectsModule { }
+export class OrganizationProjectsModule {}

--- a/apps/api/src/app/organization-projects/organization-projects.service.ts
+++ b/apps/api/src/app/organization-projects/organization-projects.service.ts
@@ -5,10 +5,23 @@ import { CrudService } from '../core/crud/crud.service';
 import { OrganizationProjects } from './organization-projects.entity';
 
 @Injectable()
-export class OrganizationProjectsService extends CrudService<OrganizationProjects> {
-    constructor(
-        @InjectRepository(OrganizationProjects) private readonly organizationProjectsRepository: Repository<OrganizationProjects>
-    ) {
-        super(organizationProjectsRepository);
-    }
+export class OrganizationProjectsService extends CrudService<
+	OrganizationProjects
+> {
+	constructor(
+		@InjectRepository(OrganizationProjects)
+		private readonly organizationProjectsRepository: Repository<
+			OrganizationProjects
+		>
+	) {
+		super(organizationProjectsRepository);
+	}
+
+	async findByEmployee(id: string): Promise<any> {
+		return await this.organizationProjectsRepository
+			.createQueryBuilder('organization_project')
+			.leftJoin('organization_project.members', 'member')
+			.where('member.id = :id', { id })
+			.getMany();
+	}
 }

--- a/apps/api/src/app/shared/handlers/index.ts
+++ b/apps/api/src/app/shared/handlers/index.ts
@@ -1,0 +1,1 @@
+export * from './update-entity.by-member.handler';

--- a/apps/api/src/app/shared/handlers/update-entity.by-member.handler.ts
+++ b/apps/api/src/app/shared/handlers/update-entity.by-member.handler.ts
@@ -1,0 +1,52 @@
+import { EditEntityByMemberInput } from '@gauzy/models';
+import { In } from 'typeorm';
+import { CrudService } from '../../core/crud';
+
+export abstract class UpdateEntityByMembersHandler {
+	//TODO: Change CrudService<any> to be more specific
+	constructor(private readonly crudService: CrudService<any>) {}
+
+	public async executeCommand(input: EditEntityByMemberInput): Promise<any> {
+		const { addedEntityIds, removedEntityIds, member } = input;
+
+		if (addedEntityIds && addedEntityIds.length > 0) {
+			const departmentsToAdd = await this.crudService.findAll({
+				where: {
+					id: In(addedEntityIds)
+				}
+			});
+
+			for (let i = 0; i < departmentsToAdd.total; i++) {
+				const existingMembers = departmentsToAdd.items[i].members || [];
+
+				//Note: This does not really create anything, just calls repository.save on the given id.
+				//Cannot call update here because update will not update relations (members)
+				await this.crudService.create({
+					id: departmentsToAdd.items[i].id,
+					members: [...existingMembers, member]
+				});
+			}
+		}
+
+		if (removedEntityIds && removedEntityIds.length > 0) {
+			const departmentsToRemove = await this.crudService.findAll({
+				where: {
+					id: In(removedEntityIds)
+				}
+			});
+
+			for (let i = 0; i < departmentsToRemove.total; i++) {
+				//Note: This does not really create anything, just calls repository.save on the given id.
+				//Cannot call update here because update will not update relations (members)
+				await this.crudService.create({
+					id: departmentsToRemove.items[i].id,
+					members: (
+						departmentsToRemove.items[i].members || []
+					).filter((e) => e.id !== member.id)
+				});
+			}
+		}
+
+		return;
+	}
+}

--- a/apps/api/src/app/shared/index.ts
+++ b/apps/api/src/app/shared/index.ts
@@ -1,3 +1,3 @@
 export * from './shared.module';
 export { UUIDValidationPipe } from './pipes/uuid-validation.pipe';
-
+export * from './handlers';

--- a/apps/gauzy/src/app/@core/services/organization-clients.service .ts
+++ b/apps/gauzy/src/app/@core/services/organization-clients.service .ts
@@ -3,7 +3,8 @@ import { HttpClient } from '@angular/common/http';
 import {
 	OrganizationClientsCreateInput,
 	OrganizationClients,
-	OrganizationClientsFindInput
+	OrganizationClientsFindInput,
+	EditEntityByMemberInput
 } from '@gauzy/models';
 import { first } from 'rxjs/operators';
 
@@ -18,6 +19,15 @@ export class OrganizationClientsService {
 	): Promise<OrganizationClients> {
 		return this.http
 			.post<OrganizationClients>('/api/organization-clients', createInput)
+			.pipe(first())
+			.toPromise();
+	}
+
+	getAllByEmployee(id: string): Promise<OrganizationClients[]> {
+		return this.http
+			.get<OrganizationClients[]>(
+				`/api/organization-clients/employee/${id}`
+			)
 			.pipe(first())
 			.toPromise();
 	}
@@ -50,9 +60,9 @@ export class OrganizationClientsService {
 			.toPromise();
 	}
 
-	update(id: string, updateInput: any): Promise<any> {
+	updateByEmployee(updateInput: EditEntityByMemberInput): Promise<any> {
 		return this.http
-			.put(`/api/organization-clients/${id}`, updateInput)
+			.put(`/api/organization-clients/employee`, updateInput)
 			.pipe(first())
 			.toPromise();
 	}

--- a/apps/gauzy/src/app/@core/services/organization-departments.service.ts
+++ b/apps/gauzy/src/app/@core/services/organization-departments.service.ts
@@ -3,7 +3,8 @@ import { HttpClient } from '@angular/common/http';
 import {
 	OrganizationDepartmentCreateInput,
 	OrganizationDepartment,
-	OrganizationDepartmentFindInput
+	OrganizationDepartmentFindInput,
+	EditEntityByMemberInput
 } from '@gauzy/models';
 import { first } from 'rxjs/operators';
 
@@ -25,6 +26,15 @@ export class OrganizationDepartmentsService {
 			.toPromise();
 	}
 
+	getAllByEmployee(id: string): Promise<OrganizationDepartment[]> {
+		return this.http
+			.get<OrganizationDepartment[]>(
+				`/api/organization-department/employee/${id}`
+			)
+			.pipe(first())
+			.toPromise();
+	}
+
 	getAll(
 		findInput?: OrganizationDepartmentFindInput
 	): Promise<{ items: any[]; total: number }> {
@@ -41,9 +51,9 @@ export class OrganizationDepartmentsService {
 			.toPromise();
 	}
 
-	update(id: string, updateInput: any): Promise<any> {
+	updateByEmployee(updateInput: EditEntityByMemberInput): Promise<any> {
 		return this.http
-			.put(`/api/organization-department/${id}`, updateInput)
+			.put(`/api/organization-department/employee`, updateInput)
 			.pipe(first())
 			.toPromise();
 	}

--- a/apps/gauzy/src/app/@core/services/organization-projects.service.ts
+++ b/apps/gauzy/src/app/@core/services/organization-projects.service.ts
@@ -3,7 +3,8 @@ import { HttpClient } from '@angular/common/http';
 import {
 	OrganizationProjectsCreateInput,
 	OrganizationProjects,
-	OrganizationProjectsFindInput
+	OrganizationProjectsFindInput,
+	EditEntityByMemberInput
 } from '@gauzy/models';
 import { first } from 'rxjs/operators';
 
@@ -20,6 +21,15 @@ export class OrganizationProjectsService {
 			.post<OrganizationProjects>(
 				'/api/organization-projects',
 				createInput
+			)
+			.pipe(first())
+			.toPromise();
+	}
+
+	getAllByEmployee(id: string): Promise<OrganizationProjects[]> {
+		return this.http
+			.get<OrganizationProjects[]>(
+				`/api/organization-projects/employee/${id}`
 			)
 			.pipe(first())
 			.toPromise();
@@ -42,9 +52,9 @@ export class OrganizationProjectsService {
 			.toPromise();
 	}
 
-	update(id: string, updateInput: any): Promise<any> {
+	updateByEmployee(updateInput: EditEntityByMemberInput): Promise<any> {
 		return this.http
-			.put(`/api/organization-projects/${id}`, updateInput)
+			.put(`/api/organization-projects/employee`, updateInput)
 			.pipe(first())
 			.toPromise();
 	}

--- a/apps/gauzy/src/app/@shared/employee/edit-employee-membership-form/edit-employee-membership-form.component.html
+++ b/apps/gauzy/src/app/@shared/employee/edit-employee-membership-form/edit-employee-membership-form.component.html
@@ -1,0 +1,70 @@
+<nb-card>
+	<nb-card-header>
+		<button
+			*ngIf="!showAddCard"
+			(click)="showAddCard = !showAddCard"
+			nbButton
+			status="success"
+		>
+			<nb-icon class="mr-1" icon="plus-outline"></nb-icon
+			>{{ 'BUTTONS.ADD' | translate }}
+		</button>
+		<div *ngIf="showAddCard" class="row m-0">
+			<form [formGroup]="form" *ngIf="form" class="col">
+				<ng-select
+					id="departmentsSelect"
+					[hideSelected]="true"
+					multiple="true"
+					bindLabel="name"
+					formControlName="departments"
+					[placeholder]="placeholder"
+					fullWidth
+				>
+					<ng-option
+						*ngFor="let entity of organizationEntities"
+						value="{{ entity.id }}"
+						>{{ entity.name }}</ng-option
+					>
+				</ng-select>
+			</form>
+			<span class="col-2 pl-2 pr-1"
+				><button
+					class="w-100"
+					(click)="submitForm()"
+					nbButton
+					status="success"
+					[disabled]="!form.valid"
+				>
+					{{ 'BUTTONS.ADD' | translate }}
+				</button></span
+			>
+			<span class="col-2 pl-1 pr-0"
+				><button
+					class="w-100"
+					(click)="showAddCard = !showAddCard"
+					nbButton
+					status="danger"
+				>
+					{{ 'BUTTONS.CANCEL' | translate }}
+				</button>
+			</span>
+		</div>
+	</nb-card-header>
+	<nb-card-body *ngIf="employeeEntities?.length">
+		<div class="ml-3 mb-4">
+			<strong>{{ title }}</strong>
+		</div>
+		<nb-card *ngFor="let d of employeeEntities">
+			<nb-card-body>
+				{{ d.name }}
+				<nb-actions class="float-right" e="medium">
+					<nb-action
+						(click)="removeDepartment(d.id)"
+						class="d-inline pr-0"
+						icon="close"
+					></nb-action>
+				</nb-actions>
+			</nb-card-body>
+		</nb-card>
+	</nb-card-body>
+</nb-card>

--- a/apps/gauzy/src/app/@shared/employee/edit-employee-membership-form/edit-employee-membership-form.component.scss
+++ b/apps/gauzy/src/app/@shared/employee/edit-employee-membership-form/edit-employee-membership-form.component.scss
@@ -1,0 +1,3 @@
+.employee-form {
+	width: 100%;
+}

--- a/apps/gauzy/src/app/@shared/employee/edit-employee-membership-form/edit-employee-membership-form.component.ts
+++ b/apps/gauzy/src/app/@shared/employee/edit-employee-membership-form/edit-employee-membership-form.component.ts
@@ -5,7 +5,6 @@ import {
 	EditEntityByMemberInput,
 	Employee
 } from '@gauzy/models';
-import { EmployeeStore } from 'apps/gauzy/src/app/@core/services/employee-store.service';
 import { Subject } from 'rxjs';
 
 @Component({

--- a/apps/gauzy/src/app/@shared/employee/edit-employee-membership-form/edit-employee-membership-form.component.ts
+++ b/apps/gauzy/src/app/@shared/employee/edit-employee-membership-form/edit-employee-membership-form.component.ts
@@ -1,0 +1,61 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import {
+	BaseEntityWithMembers,
+	EditEntityByMemberInput,
+	Employee
+} from '@gauzy/models';
+import { EmployeeStore } from 'apps/gauzy/src/app/@core/services/employee-store.service';
+import { Subject } from 'rxjs';
+
+@Component({
+	selector: 'ga-edit-employee-membership',
+	templateUrl: './edit-employee-membership-form.component.html',
+	styleUrls: ['./edit-employee-membership-form.component.scss']
+})
+export class EditEmployeeMembershipFormComponent implements OnInit {
+	private _ngDestroy$ = new Subject<void>();
+
+	@Input() organizationEntities: BaseEntityWithMembers[];
+	@Input() employeeEntities: BaseEntityWithMembers[];
+	@Input() selectedEmployee: Employee;
+	@Input() placeholder: string;
+	@Input() title: string;
+
+	@Output() entitiesAdded = new EventEmitter<EditEntityByMemberInput>();
+	@Output() entitiesRemoved = new EventEmitter<EditEntityByMemberInput>();
+
+	showAddCard: boolean;
+
+	form: FormGroup;
+
+	constructor(private fb: FormBuilder) {}
+
+	ngOnInit() {
+		this._initializeForm();
+	}
+
+	private _initializeForm() {
+		this.form = this.fb.group({
+			departments: ['', Validators.required]
+		});
+	}
+
+	async removeDepartment(id: string) {
+		this.entitiesRemoved.emit({
+			member: this.selectedEmployee,
+			removedEntityIds: [id]
+		});
+	}
+
+	async submitForm() {
+		if (this.form.valid) {
+			this.entitiesAdded.emit({
+				member: this.selectedEmployee,
+				addedEntityIds: this.form.value.departments
+			});
+			this.showAddCard = !this.showAddCard;
+			this.form.reset();
+		}
+	}
+}

--- a/apps/gauzy/src/app/@shared/employee/edit-employee-membership-form/edit-employee-membership-form.module.ts
+++ b/apps/gauzy/src/app/@shared/employee/edit-employee-membership-form/edit-employee-membership-form.module.ts
@@ -1,0 +1,43 @@
+import { HttpClient } from '@angular/common/http';
+import { NgModule } from '@angular/core';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import {
+	NbActionsModule,
+	NbButtonModule,
+	NbCardModule,
+	NbIconModule
+} from '@nebular/theme';
+import { NgSelectModule } from '@ng-select/ng-select';
+import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
+import { TranslateHttpLoader } from '@ngx-translate/http-loader';
+import { ThemeModule } from '../../../@theme/theme.module';
+import { EditEmployeeMembershipFormComponent } from './edit-employee-membership-form.component';
+
+export function HttpLoaderFactory(http: HttpClient) {
+	return new TranslateHttpLoader(http, './assets/i18n/', '.json');
+}
+
+@NgModule({
+	imports: [
+		ThemeModule,
+		FormsModule,
+		ReactiveFormsModule,
+		NbCardModule,
+		NbButtonModule,
+		NgSelectModule,
+		NbIconModule,
+		NbActionsModule,
+		TranslateModule.forChild({
+			loader: {
+				provide: TranslateLoader,
+				useFactory: HttpLoaderFactory,
+				deps: [HttpClient]
+			}
+		})
+	],
+	exports: [EditEmployeeMembershipFormComponent],
+	declarations: [EditEmployeeMembershipFormComponent],
+	entryComponents: [EditEmployeeMembershipFormComponent],
+	providers: []
+})
+export class EditEmployeeMembershipFormModule {}

--- a/apps/gauzy/src/app/@shared/expenses/expenses-mutation/expenses-mutation.component.ts
+++ b/apps/gauzy/src/app/@shared/expenses/expenses-mutation/expenses-mutation.component.ts
@@ -2,7 +2,6 @@ import {
 	Component,
 	OnInit,
 	ViewChild,
-	ElementRef,
 	OnDestroy
 } from '@angular/core';
 import { NbDialogRef, NbDialogService } from '@nebular/theme';

--- a/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-client/edit-employee-client.component.html
+++ b/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-client/edit-employee-client.component.html
@@ -1,0 +1,10 @@
+<ga-edit-employee-membership
+	[selectedEmployee]="selectedEmployee"
+	[organizationEntities]="organizationClients"
+	[employeeEntities]="employeeClients"
+	placeholder="{{ 'FORM.PLACEHOLDERS.CLIENTS' | translate }}"
+	title="{{ 'EMPLOYEES_PAGE.EDIT_EMPLOYEE.EMPLOYEE_CLIENTS' | translate }}"
+	(entitiesAdded)="submitForm($event, false)"
+	(entitiesRemoved)="submitForm($event, true)"
+>
+</ga-edit-employee-membership>

--- a/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-client/edit-employee-client.component.ts
+++ b/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-client/edit-employee-client.component.ts
@@ -1,0 +1,107 @@
+import { Component, OnInit } from '@angular/core';
+import {
+	EditEntityByMemberInput,
+	Employee,
+	OrganizationClients
+} from '@gauzy/models';
+import { NbToastrService } from '@nebular/theme';
+import { TranslateService } from '@ngx-translate/core';
+import { EmployeeStore } from 'apps/gauzy/src/app/@core/services/employee-store.service';
+import { OrganizationClientsService } from 'apps/gauzy/src/app/@core/services/organization-clients.service ';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+
+@Component({
+	selector: 'ga-edit-employee-departments',
+	templateUrl: './edit-employee-client.component.html'
+})
+export class EditEmployeeClientComponent implements OnInit {
+	private _ngDestroy$ = new Subject<void>();
+
+	organizationClients: OrganizationClients[] = [];
+	employeeClients: OrganizationClients[] = [];
+
+	selectedEmployee: Employee;
+
+	constructor(
+		private readonly organizationClientsService: OrganizationClientsService,
+		private readonly toastrService: NbToastrService,
+		private readonly employeeStore: EmployeeStore,
+		private readonly translateService: TranslateService
+	) {}
+
+	ngOnInit() {
+		this.employeeStore.selectedEmployee$
+			.pipe(takeUntil(this._ngDestroy$))
+			.subscribe((emp) => {
+				this.selectedEmployee = emp;
+				if (this.selectedEmployee) {
+					this.loadDepartments();
+				}
+			});
+	}
+
+	async submitForm(formInput: EditEntityByMemberInput, removed: boolean) {
+		try {
+			if (formInput.member) {
+				await this.organizationClientsService.updateByEmployee(
+					formInput
+				);
+				this.loadDepartments();
+				this.toastrService.primary(
+					this.getTranslation(
+						removed
+							? 'TOASTR.MESSAGE.EMPLOYEE_CLIENT_REMOVED'
+							: 'TOASTR.MESSAGE.EMPLOYEE_CLIENT_ADDED'
+					),
+					this.getTranslation('TOASTR.TITLE.SUCCESS')
+				);
+			}
+		} catch (error) {
+			this.toastrService.danger(
+				this.getTranslation('TOASTR.MESSAGE.EMPLOYEE_EDIT_ERROR'),
+				this.getTranslation('TOASTR.TITLE.ERROR')
+			);
+		}
+	}
+
+	private async loadDepartments() {
+		await this.loadSelectedEmployeeDepartments();
+		const orgDepartments = await this.getOrganizationDepartments();
+		const selectedDepartmentIds = this.employeeClients.map((d) => d.id);
+		this.organizationClients = orgDepartments.filter(
+			(dep) => selectedDepartmentIds.indexOf(dep.id) < 0
+		);
+	}
+
+	private async loadSelectedEmployeeDepartments() {
+		if (!this.selectedEmployee) {
+			return;
+		}
+
+		this.employeeClients = await this.organizationClientsService.getAllByEmployee(
+			this.selectedEmployee.id
+		);
+	}
+
+	private async getOrganizationDepartments() {
+		if (!this.selectedEmployee.orgId) {
+			return;
+		}
+
+		const res = await this.organizationClientsService.getAll([], {
+			organizationId: this.selectedEmployee.orgId
+		});
+
+		return res ? res.items : [];
+	}
+
+	getTranslation(prefix: string) {
+		let result = '';
+		this.translateService.get(prefix).subscribe((res) => {
+			result = res;
+		});
+
+		return result;
+	}
+}

--- a/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-department/edit-employee-department.component.html
+++ b/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-department/edit-employee-department.component.html
@@ -1,0 +1,12 @@
+<ga-edit-employee-membership
+	[selectedEmployee]="selectedEmployee"
+	[organizationEntities]="organizationDepartments"
+	[employeeEntities]="employeeDepartments"
+	placeholder="{{ 'FORM.PLACEHOLDERS.DEPARTMENTS' | translate }}"
+	title="{{
+		'EMPLOYEES_PAGE.EDIT_EMPLOYEE.EMPLOYEE_DEPARTMENTS' | translate
+	}}"
+	(entitiesAdded)="submitForm($event, false)"
+	(entitiesRemoved)="submitForm($event, true)"
+>
+</ga-edit-employee-membership>

--- a/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-department/edit-employee-department.component.ts
+++ b/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-department/edit-employee-department.component.ts
@@ -1,0 +1,107 @@
+import { Component, OnInit } from '@angular/core';
+import {
+	EditEntityByMemberInput,
+	Employee,
+	OrganizationDepartment
+} from '@gauzy/models';
+import { NbToastrService } from '@nebular/theme';
+import { TranslateService } from '@ngx-translate/core';
+import { EmployeeStore } from 'apps/gauzy/src/app/@core/services/employee-store.service';
+import { OrganizationDepartmentsService } from 'apps/gauzy/src/app/@core/services/organization-departments.service';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+
+@Component({
+	selector: 'ga-edit-employee-departments',
+	templateUrl: './edit-employee-department.component.html'
+})
+export class EditEmployeeDepartmentComponent implements OnInit {
+	private _ngDestroy$ = new Subject<void>();
+
+	organizationDepartments: OrganizationDepartment[] = [];
+	employeeDepartments: OrganizationDepartment[] = [];
+
+	selectedEmployee: Employee;
+
+	constructor(
+		private readonly organizationDepartmentsService: OrganizationDepartmentsService,
+		private readonly toastrService: NbToastrService,
+		private readonly employeeStore: EmployeeStore,
+		private readonly translateService: TranslateService
+	) {}
+
+	ngOnInit() {
+		this.employeeStore.selectedEmployee$
+			.pipe(takeUntil(this._ngDestroy$))
+			.subscribe((emp) => {
+				this.selectedEmployee = emp;
+				if (this.selectedEmployee) {
+					this.loadDepartments();
+				}
+			});
+	}
+
+	async submitForm(formInput: EditEntityByMemberInput, removed: boolean) {
+		try {
+			if (formInput.member) {
+				await this.organizationDepartmentsService.updateByEmployee(
+					formInput
+				);
+				this.loadDepartments();
+				this.toastrService.primary(
+					this.getTranslation(
+						removed
+							? 'TOASTR.MESSAGE.EMPLOYEE_DEPARTMENT_REMOVED'
+							: 'TOASTR.MESSAGE.EMPLOYEE_DEPARTMENT_ADDED'
+					),
+					this.getTranslation('TOASTR.TITLE.SUCCESS')
+				);
+			}
+		} catch (error) {
+			this.toastrService.danger(
+				this.getTranslation('TOASTR.MESSAGE.EMPLOYEE_EDIT_ERROR'),
+				this.getTranslation('TOASTR.TITLE.ERROR')
+			);
+		}
+	}
+
+	private async loadDepartments() {
+		await this.loadSelectedEmployeeDepartments();
+		const orgDepartments = await this.getOrganizationDepartments();
+		const selectedDepartmentIds = this.employeeDepartments.map((d) => d.id);
+		this.organizationDepartments = orgDepartments.filter(
+			(dep) => selectedDepartmentIds.indexOf(dep.id) < 0
+		);
+	}
+
+	private async loadSelectedEmployeeDepartments() {
+		if (!this.selectedEmployee) {
+			return;
+		}
+
+		this.employeeDepartments = await this.organizationDepartmentsService.getAllByEmployee(
+			this.selectedEmployee.id
+		);
+	}
+
+	private async getOrganizationDepartments() {
+		if (!this.selectedEmployee.orgId) {
+			return;
+		}
+
+		const res = await this.organizationDepartmentsService.getAll({
+			organizationId: this.selectedEmployee.orgId
+		});
+
+		return res ? res.items : [];
+	}
+
+	getTranslation(prefix: string) {
+		let result = '';
+		this.translateService.get(prefix).subscribe((res) => {
+			result = res;
+		});
+
+		return result;
+	}
+}

--- a/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-profile.component.ts
+++ b/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-profile.component.ts
@@ -81,6 +81,24 @@ export class EditEmployeeProfileComponent implements OnInit, OnDestroy {
 				icon: 'pricetags-outline',
 				responsive: true,
 				route: `/pages/employees/edit/${this.routeParams.id}/profile/rates`
+			},
+			{
+				title: 'Departments',
+				icon: 'briefcase-outline',
+				responsive: true,
+				route: `/pages/employees/edit/${this.routeParams.id}/profile/departments`
+			},
+			{
+				title: 'Projects',
+				icon: 'book-outline',
+				responsive: true,
+				route: `/pages/employees/edit/${this.routeParams.id}/profile/projects`
+			},
+			{
+				title: 'Clients',
+				icon: 'book-open-outline',
+				responsive: true,
+				route: `/pages/employees/edit/${this.routeParams.id}/profile/clients`
 			}
 		];
 	}

--- a/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-projects/edit-employee-projects.component.html
+++ b/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-projects/edit-employee-projects.component.html
@@ -1,0 +1,10 @@
+<ga-edit-employee-membership
+	[selectedEmployee]="selectedEmployee"
+	[organizationEntities]="organizationProjects"
+	[employeeEntities]="employeeProjects"
+	placeholder="{{ 'FORM.PLACEHOLDERS.PROJECTS' | translate }}"
+	title="{{ 'EMPLOYEES_PAGE.EDIT_EMPLOYEE.EMPLOYEE_PROJECTS' | translate }}"
+	(entitiesAdded)="submitForm($event, false)"
+	(entitiesRemoved)="submitForm($event, true)"
+>
+</ga-edit-employee-membership>

--- a/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-projects/edit-employee-projects.component.ts
+++ b/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-projects/edit-employee-projects.component.ts
@@ -1,0 +1,107 @@
+import { Component, OnInit } from '@angular/core';
+import {
+	EditEntityByMemberInput,
+	Employee,
+	OrganizationProjects
+} from '@gauzy/models';
+import { NbToastrService } from '@nebular/theme';
+import { TranslateService } from '@ngx-translate/core';
+import { EmployeeStore } from 'apps/gauzy/src/app/@core/services/employee-store.service';
+import { OrganizationProjectsService } from 'apps/gauzy/src/app/@core/services/organization-projects.service';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+
+@Component({
+	selector: 'ga-edit-employee-departments',
+	templateUrl: './edit-employee-projects.component.html'
+})
+export class EditEmployeeProjectsComponent implements OnInit {
+	private _ngDestroy$ = new Subject<void>();
+
+	organizationProjects: OrganizationProjects[] = [];
+	employeeProjects: OrganizationProjects[] = [];
+
+	selectedEmployee: Employee;
+
+	constructor(
+		private readonly organizationProjectsService: OrganizationProjectsService,
+		private readonly toastrService: NbToastrService,
+		private readonly employeeStore: EmployeeStore,
+		private readonly translateService: TranslateService
+	) {}
+
+	ngOnInit() {
+		this.employeeStore.selectedEmployee$
+			.pipe(takeUntil(this._ngDestroy$))
+			.subscribe((emp) => {
+				this.selectedEmployee = emp;
+				if (this.selectedEmployee) {
+					this.loadDepartments();
+				}
+			});
+	}
+
+	async submitForm(formInput: EditEntityByMemberInput, removed: boolean) {
+		try {
+			if (formInput.member) {
+				await this.organizationProjectsService.updateByEmployee(
+					formInput
+				);
+				this.loadDepartments();
+				this.toastrService.primary(
+					this.getTranslation(
+						removed
+							? 'TOASTR.MESSAGE.EMPLOYEE_PROJECT_REMOVED'
+							: 'TOASTR.MESSAGE.EMPLOYEE_PROJECT_ADDED'
+					),
+					this.getTranslation('TOASTR.TITLE.SUCCESS')
+				);
+			}
+		} catch (error) {
+			this.toastrService.danger(
+				this.getTranslation('TOASTR.MESSAGE.EMPLOYEE_EDIT_ERROR'),
+				this.getTranslation('TOASTR.TITLE.ERROR')
+			);
+		}
+	}
+
+	private async loadDepartments() {
+		await this.loadSelectedEmployeeDepartments();
+		const orgDepartments = await this.getOrganizationDepartments();
+		const selectedDepartmentIds = this.employeeProjects.map((d) => d.id);
+		this.organizationProjects = orgDepartments.filter(
+			(dep) => selectedDepartmentIds.indexOf(dep.id) < 0
+		);
+	}
+
+	private async loadSelectedEmployeeDepartments() {
+		if (!this.selectedEmployee) {
+			return;
+		}
+
+		this.employeeProjects = await this.organizationProjectsService.getAllByEmployee(
+			this.selectedEmployee.id
+		);
+	}
+
+	private async getOrganizationDepartments() {
+		if (!this.selectedEmployee.orgId) {
+			return;
+		}
+
+		const res = await this.organizationProjectsService.getAll([], {
+			organizationId: this.selectedEmployee.orgId
+		});
+
+		return res ? res.items : [];
+	}
+
+	getTranslation(prefix: string) {
+		let result = '';
+		this.translateService.get(prefix).subscribe((res) => {
+			result = res;
+		});
+
+		return result;
+	}
+}

--- a/apps/gauzy/src/app/pages/employees/employees-routing.module.ts
+++ b/apps/gauzy/src/app/pages/employees/employees-routing.module.ts
@@ -6,6 +6,9 @@ import { EditEmployeeProfileComponent } from './edit-employee/edit-employee-prof
 import { EditEmployeeMainComponent } from './edit-employee/edit-employee-profile/edit-employee-main/edit-employee-main.component';
 import { EditEmployeeRatesComponent } from './edit-employee/edit-employee-profile/edit-employee-rate/edit-employee-rate.component';
 import { ManageEmployeeInviteComponent } from './manage-employee-invite/manage-employee-invite.component';
+import { EditEmployeeDepartmentComponent } from './edit-employee/edit-employee-profile/edit-employee-department/edit-employee-department.component';
+import { EditEmployeeProjectsComponent } from './edit-employee/edit-employee-profile/edit-employee-projects/edit-employee-projects.component';
+import { EditEmployeeClientComponent } from './edit-employee/edit-employee-profile/edit-employee-client/edit-employee-client.component';
 
 const routes: Routes = [
 	{
@@ -32,6 +35,18 @@ const routes: Routes = [
 			{
 				path: 'rates',
 				component: EditEmployeeRatesComponent
+			},
+			{
+				path: 'departments',
+				component: EditEmployeeDepartmentComponent
+			},
+			{
+				path: 'projects',
+				component: EditEmployeeProjectsComponent
+			},
+			{
+				path: 'clients',
+				component: EditEmployeeClientComponent
 			}
 		]
 	},

--- a/apps/gauzy/src/app/pages/employees/employees.module.ts
+++ b/apps/gauzy/src/app/pages/employees/employees.module.ts
@@ -12,7 +12,8 @@ import {
 	NbRouteTabsetModule,
 	NbSelectModule,
 	NbSpinnerModule,
-	NbTooltipModule
+	NbTooltipModule,
+	NbActionsModule
 } from '@nebular/theme';
 import { NgSelectModule } from '@ng-select/ng-select';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
@@ -40,6 +41,10 @@ import { EmployeeBonusComponent } from './table-components/employee-bonus/employ
 import { EmployeeFullNameComponent } from './table-components/employee-fullname/employee-fullname.component';
 import { EmployeeWorkStatusComponent } from './table-components/employee-work-status/employee-work-status.component';
 import { RecurringExpenseDeleteConfirmationModule } from '../../@shared/expenses/recurring-expense-delete-confirmation/recurring-expense-delete-confirmation.module';
+import { EditEmployeeDepartmentComponent } from './edit-employee/edit-employee-profile/edit-employee-department/edit-employee-department.component';
+import { EditEmployeeMembershipFormModule } from '../../@shared/employee/edit-employee-membership-form/edit-employee-membership-form.module';
+import { EditEmployeeProjectsComponent } from './edit-employee/edit-employee-profile/edit-employee-projects/edit-employee-projects.component';
+import { EditEmployeeClientComponent } from './edit-employee/edit-employee-profile/edit-employee-client/edit-employee-client.component';
 
 export function HttpLoaderFactory(http: HttpClient) {
 	return new TranslateHttpLoader(http, './assets/i18n/', '.json');
@@ -57,7 +62,10 @@ const COMPONENTS = [
 	EditEmployeeProfileComponent,
 	EditEmployeeMainComponent,
 	EditEmployeeRatesComponent,
-	ManageEmployeeInviteComponent
+	ManageEmployeeInviteComponent,
+	EditEmployeeDepartmentComponent,
+	EditEmployeeProjectsComponent,
+	EditEmployeeClientComponent
 ];
 
 @NgModule({
@@ -92,7 +100,9 @@ const COMPONENTS = [
 		NbSpinnerModule,
 		InviteMutationModule,
 		InviteTableModule,
-		RecurringExpenseDeleteConfirmationModule
+		RecurringExpenseDeleteConfirmationModule,
+		NbActionsModule,
+		EditEmployeeMembershipFormModule
 	],
 	declarations: [...COMPONENTS],
 	entryComponents: [

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -111,7 +111,8 @@
 			"EMAILS": "Email Addresses",
 			"PROJECTS_OPTIONAL": "Projects (Optional)",
 			"CLIENTS_OPTIONAL": "Clients (Optional)",
-			"DEPARTMENTS_OPTIONAL": "Departments (Optional)"
+			"DEPARTMENTS_OPTIONAL": "Departments (Optional)",
+			"PROJECTS": "Projects"
 		},
 		"PLACEHOLDERS": {
 			"NAME": "Name",
@@ -267,7 +268,10 @@
 			"HEADER": "Manage Employee",
 			"DEVELOPER": "Developer",
 			"DEPARTMENT": "Department",
-			"POSITION": "Position"
+			"POSITION": "Position",
+			"EMPLOYEE_DEPARTMENTS": "Employee's Departments:",
+			"EMPLOYEE_PROJECTS": "Employee's Projects:",
+			"EMPLOYEE_CLIENTS": "Employee's Clients:"
 		}
 	},
 	"ORGANIZATIONS_PAGE": {
@@ -439,7 +443,14 @@
 			"PROJECT_LOAD": "Could Not Load Projects",
 			"COPIED": "Link copied to clipboard",
 			"INVITES_LOAD": "Could Not Load Invites",
-			"INVITES_RESEND": "Invite has been resent to {{ email }}."
+			"INVITES_RESEND": "Invite has been resent to {{ email }}.",
+			"EMPLOYEE_DEPARTMENT_ADDED": "Employee added to department",
+			"EMPLOYEE_DEPARTMENT_REMOVED": "Employee removed from department",
+			"EMPLOYEE_PROJECT_ADDED": "Employee added to project",
+			"EMPLOYEE_PROJECT_REMOVED": "Employee removed from project",
+			"EMPLOYEE_CLIENT_ADDED": "Employee added to the client",
+			"EMPLOYEE_CLIENT_REMOVED": "Employee removed from the client",
+			"EMPLOYEE_EDIT_ERROR": "Error in editing employee"
 		}
 	}
 }

--- a/libs/models/src/index.ts
+++ b/libs/models/src/index.ts
@@ -19,6 +19,7 @@ export * from './lib/country.model';
 export * from './lib/invite.model';
 export * from './lib/email-template.model';
 export * from './lib/time-off.model';
+export * from './lib/entity-with-members.model';
 
 export { Role, RolesEnum } from './lib/role.model';
 export { BaseEntityModel } from './lib/base-entity.model';

--- a/libs/models/src/lib/entity-with-members.model.ts
+++ b/libs/models/src/lib/entity-with-members.model.ts
@@ -1,0 +1,13 @@
+import { Employee } from './employee.model';
+import { BaseEntityModel as IBaseEntityModel } from './base-entity.model';
+
+export interface BaseEntityWithMembers extends IBaseEntityModel {
+	members?: Employee[];
+	name?: string;
+}
+
+export interface EditEntityByMemberInput {
+	addedEntityIds?: string[];
+	removedEntityIds?: string[];
+	member: Employee;
+}

--- a/libs/models/src/lib/organization-clients.model.ts
+++ b/libs/models/src/lib/organization-clients.model.ts
@@ -1,8 +1,9 @@
 import { BaseEntityModel as IBaseEntityModel } from './base-entity.model';
 import { OrganizationProjects } from './organization-projects.model';
 import { Employee } from './employee.model';
+import { BaseEntityWithMembers as IBaseEntityWithMembers } from './entity-with-members.model';
 
-export interface OrganizationClients extends IBaseEntityModel {
+export interface OrganizationClients extends IBaseEntityWithMembers {
 	name: string;
 	organizationId: string;
 	primaryEmail: string;

--- a/libs/models/src/lib/organization-department.model.ts
+++ b/libs/models/src/lib/organization-department.model.ts
@@ -1,15 +1,19 @@
 import { BaseEntityModel as IBaseEntityModel } from './base-entity.model';
-import { Employee } from './employee.model';
+import { BaseEntityWithMembers as IBaseEntityWithMembers } from './entity-with-members.model';
 
-export interface OrganizationDepartment extends IBaseEntityModel {
+export interface OrganizationDepartment extends IBaseEntityWithMembers {
 	name: string;
 	organizationId: string;
-	members?: Employee[];
 }
 
 export interface OrganizationDepartmentFindInput extends IBaseEntityModel {
 	name?: string;
 	organizationId?: string;
+}
+
+export interface OrganizationDepartmentFindByMemberInput
+	extends IBaseEntityModel {
+	memberId: string;
 }
 
 export interface OrganizationDepartmentCreateInput {

--- a/libs/models/src/lib/organization-projects.model.ts
+++ b/libs/models/src/lib/organization-projects.model.ts
@@ -2,8 +2,9 @@ import { BaseEntityModel as IBaseEntityModel } from './base-entity.model';
 import { Employee } from './employee.model';
 import { OrganizationClients } from './organization-clients.model';
 import { CurrenciesEnum, ProjectTypeEnum } from './organization.model';
+import { BaseEntityWithMembers as IBaseEntityWithMembers } from './entity-with-members.model';
 
-export interface OrganizationProjects extends IBaseEntityModel {
+export interface OrganizationProjects extends IBaseEntityWithMembers {
 	name: string;
 	organizationId: string;
 	client?: OrganizationClients;


### PR DESCRIPTION
For #452 
This adds three tabs in Employees for Projects, Departments & Clients,
Currently, the UI is extremely basic, just like the existing Edit Organizations UI.

1. All three tabs are based on a single shared form module
2. In the backend as well, all 3 commands call a shared handler

Will merge it after some testing & fixing DeepScan issues by tonight

After this, for the second part of #452 we need to add the ability to add employees through Organization.

<img width="1393" alt="Screen Shot 2020-01-23 at 8 30 26 PM" src="https://user-images.githubusercontent.com/6750734/72995603-35752780-3e1f-11ea-9f9b-10e166e0c6bb.png">

<img width="1378" alt="Screen Shot 2020-01-23 at 8 30 16 PM" src="https://user-images.githubusercontent.com/6750734/72995656-49b92480-3e1f-11ea-9102-f4613869d93b.png">
