### PR TITLE
feat: disabled currency dropdowns #404

### DIFF
--- a/apps/gauzy/src/app/@shared/employee/employee-recurring-expense-mutation/employee-recurring-expense-mutation.component.html
+++ b/apps/gauzy/src/app/@shared/employee/employee-recurring-expense-mutation/employee-recurring-expense-mutation.component.html
@@ -40,8 +40,8 @@
 				<div class="col-sm-6">
 					<nb-select
 						class="d-block"
-						placeholder="Select Showcase"
 						formControlName="currency"
+						disabled
 					>
 						<nb-option
 							*ngFor="let currency of currencies"

--- a/apps/gauzy/src/app/@shared/expenses/expenses-mutation/expenses-mutation.component.html
+++ b/apps/gauzy/src/app/@shared/expenses/expenses-mutation/expenses-mutation.component.html
@@ -93,8 +93,8 @@
 				<div class="col-sm-6">
 					<nb-select
 						class="d-block"
-						placeholder="Select Showcase"
 						formControlName="currency"
+						disabled
 					>
 						<nb-option
 							*ngFor="let currency of currencies"

--- a/apps/gauzy/src/app/@shared/income/income-mutation/income-mutation.component.html
+++ b/apps/gauzy/src/app/@shared/income/income-mutation/income-mutation.component.html
@@ -82,8 +82,8 @@
 				<div class="col-sm-6">
 					<nb-select
 						class="d-block"
-						placeholder="Select Showcase"
 						formControlName="currency"
+						disabled
 					>
 						<nb-option
 							*ngFor="let currency of currencies"

--- a/apps/gauzy/src/app/@shared/table-components/income-amount/income-amount.component.ts
+++ b/apps/gauzy/src/app/@shared/table-components/income-amount/income-amount.component.ts
@@ -4,7 +4,7 @@ import { Component, Input } from '@angular/core';
 	selector: 'ga-income-amount',
 	template: `
 		<span
-			>{{ value }}
+			>{{ rowData.currency }} {{ value }}
 			<nb-icon
 				*ngIf="rowData?.isBonus"
 				nbTooltip="{{ 'INCOME_PAGE.BONUS_TOOLTIP' | translate }}"

--- a/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-rate/edit-employee-rate.component.html
+++ b/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-rate/edit-employee-rate.component.html
@@ -5,9 +5,7 @@
 				<div class="col">
 					<nb-card>
 						<nb-card-header>
-							{{
-								'FORM.RATES.DEFAULT_RATE' | translate
-							}}
+							{{ 'FORM.RATES.DEFAULT_RATE' | translate }}
 						</nb-card-header>
 						<nb-card-body>
 							<div class="form-group">
@@ -74,6 +72,7 @@
 										}}"
 										class="d-block"
 										size="medium"
+										disabled
 									>
 										<nb-option
 											*ngFor="let currency of currencies"
@@ -90,10 +89,7 @@
 				<div class="col">
 					<nb-card>
 						<nb-card-header>
-							{{
-								'FORM.RATES.LIMITS'
-									| translate
-							}}
+							{{ 'FORM.RATES.LIMITS' | translate }}
 						</nb-card-header>
 						<nb-card-body>
 							<div class="form-group">

--- a/apps/gauzy/src/app/pages/expenses/expenses.component.ts
+++ b/apps/gauzy/src/app/pages/expenses/expenses.component.ts
@@ -13,6 +13,7 @@ import { DateViewComponent } from '../../@shared/table-components/date-view/date
 import { ActivatedRoute } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { ErrorHandlingService } from '../../@core/services/error-handling.service';
+import { IncomeAmountComponent } from '../../@shared/table-components/income-amount/income-amount.component';
 
 export interface ExpenseViewModel {
 	id: string;
@@ -89,9 +90,10 @@ export class ExpensesComponent implements OnInit, OnDestroy {
 				},
 				amount: {
 					title: this.getTranslation('SM_TABLE.VALUE'),
-					type: 'number',
+					type: 'custom',
 					width: '10%',
-					filter: false
+					filter: false,
+					renderComponent: IncomeAmountComponent
 				},
 				notes: {
 					title: this.getTranslation('SM_TABLE.NOTES'),

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-projects/edit-organization-projects-mutation/edit-organization-projects-mutation.component.html
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-projects/edit-organization-projects-mutation/edit-organization-projects-mutation.component.html
@@ -18,7 +18,7 @@
 				{{ 'BUTTONS.CANCEL' | translate }}
 			</button>
 		</div>
-		<form [formGroup]="form" class="row">
+		<form [formGroup]="form" *ngIf="form" class="row">
 			<div class="form-group col-4">
 				<input
 					type="text"
@@ -58,6 +58,7 @@
 					fullWidth
 					placeholder="{{ 'FORM.PLACEHOLDERS.CURRENCY' | translate }}"
 					formControlName="currency"
+					disabled
 				>
 					<nb-option
 						*ngFor="let currency of currencies"

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-projects/edit-organization-projects-mutation/edit-organization-projects-mutation.component.ts
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-projects/edit-organization-projects-mutation/edit-organization-projects-mutation.component.ts
@@ -55,11 +55,15 @@ export class EditOrganizationProjectsMutationComponent implements OnInit {
 
 		this.form = this.fb.group({
 			name: [this.project ? this.project.name : ''],
-			client: [this.project ? this.project.client.id : ''],
+			client: [
+				this.project && this.project.client
+					? this.project.client.id
+					: ''
+			],
 			type: [this.project ? this.project.type : 'RATE'],
 			currency: [this.project ? this.project.currency : defaultCurrency],
-			startDate: [this.project ? this.project.startDate : undefined],
-			endDate: [this.project ? this.project.endDate : undefined]
+			startDate: [this.project ? this.project.startDate : null],
+			endDate: [this.project ? this.project.endDate : null]
 		});
 	}
 

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization.component.html
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization.component.html
@@ -1,6 +1,4 @@
-<nb-card class="org-edit"
-[nbSpinner]="loading" nbSpinnerStatus="primary"
->
+<nb-card class="org-edit" [nbSpinner]="loading" nbSpinnerStatus="primary">
 	<nb-card-header class="header">
 		<div
 			class="header-container"
@@ -53,7 +51,7 @@
 			<h6>{{ 'POP_UPS.SELECT_ORGANZIATION' | translate }}</h6>
 		</ng-template>
 	</nb-card-header>
-	<nb-card-body 
+	<nb-card-body
 		class="settings-body"
 		*ngIf="selectedDate && selectedOrgFromHeader"
 	>
@@ -67,7 +65,9 @@
 				<span *ngIf="!showAddCard">
 					<button
 						(click)="
-							showAddCard = !showAddCard; date = getDefaultDate()
+							showAddCard = !showAddCard;
+							date = getDefaultDate();
+							selectedCurrency = selectedOrg.currency
 						"
 						nbButton
 						status="success"
@@ -116,6 +116,7 @@
 								class="d-block"
 								placeholder="Select Currency"
 								[(selected)]="selectedCurrency"
+								disabled
 							>
 								<nb-option
 									*ngFor="let currency of currencies"

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization.component.ts
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization.component.ts
@@ -200,7 +200,8 @@ export class EditOrganizationComponent implements OnInit, OnDestroy {
 			const month = ('0' + editExpense.month).slice(-2);
 			this.date = `${editExpense.year}-${month}`;
 			this.editExpenseId = editExpense.id;
-
+			this.selectedCurrency =
+				editExpense.currency || this.selectedOrg.currency;
 			this.showAddCard = true;
 		}
 	}
@@ -215,7 +216,6 @@ export class EditOrganizationComponent implements OnInit, OnDestroy {
 	}
 
 	private async _loadOrgRecurringExpense() {
-		
 		if (this.selectedOrg && this.selectedDate) {
 			this.selectedOrgRecurringExpense = (await this.organizationRecurringExpenseService.getAll(
 				[],
@@ -227,7 +227,6 @@ export class EditOrganizationComponent implements OnInit, OnDestroy {
 			)).items;
 			this.loading = false;
 		}
-
 	}
 
 	private clearMutationCard() {


### PR DESCRIPTION
Currency drop downs made read-only and it will default to the organization currency in create-mode in the following places:
1. Income mutation popup
1. Expense mutation popup
1. Employee Recurring Expense
1. Edit Employee > Rates
1. Edit Organisation Recurring Expense
1. Edit Organisation > Projects

<img width="539" alt="Screen Shot 2020-01-31 at 2 33 39 PM" src="https://user-images.githubusercontent.com/6750734/73526206-b7280f00-4436-11ea-8fcb-7d614d6e80e2.png">

Added currency to the following tables:
1. Income table - added currency to the value
1. Expense table - added currency to the value

<img width="1377" alt="Screen Shot 2020-01-31 at 2 33 04 PM" src="https://user-images.githubusercontent.com/6750734/73526170-9d86c780-4436-11ea-88cb-f4b63305a943.png">

Solves the initial part of #404 