### PR TITLE
Feat/401 bonuses

### DIFF
--- a/apps/api/src/app/organization/organization.entity.ts
+++ b/apps/api/src/app/organization/organization.entity.ts
@@ -6,7 +6,9 @@ import {
 	IsDate,
 	IsOptional,
 	IsEnum,
-	IsNumber
+	IsNumber,
+	Min,
+	Max
 } from 'class-validator';
 import { Base } from '../core/entities/base';
 import {
@@ -146,6 +148,8 @@ export class Organization extends Base implements IOrganization {
 
 	@ApiProperty({ type: Number })
 	@IsNumber()
+	@Min(0)
+	@Max(100)
 	@Column({ nullable: true })
 	bonusPercentage?: number;
 }

--- a/apps/api/src/app/organization/organization.entity.ts
+++ b/apps/api/src/app/organization/organization.entity.ts
@@ -5,14 +5,16 @@ import {
 	IsString,
 	IsDate,
 	IsOptional,
-	IsEnum
+	IsEnum,
+	IsNumber
 } from 'class-validator';
 import { Base } from '../core/entities/base';
 import {
 	Organization as IOrganization,
 	CurrenciesEnum,
 	DefaultValueDateTypeEnum,
-	WeekDaysEnum
+	WeekDaysEnum,
+	BonusTypeEnum
 } from '@gauzy/models';
 
 @Entity('organization')
@@ -136,4 +138,14 @@ export class Organization extends Base implements IOrganization {
 	@IsOptional()
 	@Column({ nullable: true })
 	numberFormat?: string;
+
+	@ApiProperty({ type: String, enum: BonusTypeEnum })
+	@IsEnum(BonusTypeEnum)
+	@Column({ nullable: true })
+	bonusType?: string;
+
+	@ApiProperty({ type: Number })
+	@IsNumber()
+	@Column({ nullable: true })
+	bonusPercentage?: number;
 }

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.html
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.html
@@ -218,6 +218,64 @@
 			</div>
 		</nb-card-body>
 	</nb-card>
+
+	<nb-card>
+		<nb-card-header>
+			{{ 'ORGANIZATIONS_PAGE.EDIT.BONUS' | translate }}
+		</nb-card-header>
+		<nb-card-body>
+			<div class="fields">
+				<div class="row">
+					<div class="col-6">
+						<div class="form-group">
+							<label class="label">
+								{{ 'FORM.LABELS.TYPE_OF_BONUS' | translate }}
+							</label>
+							<nb-select
+								class="d-block"
+								size="medium"
+								formControlName="bonusType"
+								placeholder="{{
+									'FORM.PLACEHOLDERS.TYPE_OF_BONUS'
+										| translate
+								}}"
+								fullWidth
+							>
+								<nb-option
+									*ngFor="let type of defaultBonusTypes"
+									[value]="type"
+								>
+									{{ 'SM_TABLE.' + type | translate }}
+								</nb-option>
+							</nb-select>
+						</div>
+					</div>
+					<div class="col-6">
+						<div class="form-group">
+							<label class="label">
+								{{ 'FORM.LABELS.BONUS_PERCENTAGE' | translate }}
+							</label>
+							<input
+								nbInput
+								type="number"
+								formControlName="bonusPercentage"
+								placeholder="{{
+									'FORM.PLACEHOLDERS.BONUS_PERCENTAGE'
+										| translate
+								}}"
+								fullWidth
+								class="d-block"
+								[ngClass]="{
+									'status-danger': form.get('bonusPercentage')
+										.invalid
+								}"
+							/>
+						</div>
+					</div>
+				</div>
+			</div>
+		</nb-card-body>
+	</nb-card>
 	<div class="actions">
 		<button
 			[disabled]="this.form.invalid"

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.html
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.html
@@ -239,6 +239,9 @@
 									'FORM.PLACEHOLDERS.TYPE_OF_BONUS'
 										| translate
 								}}"
+								(selectedChange)="
+									loadDefaultBonusPercentage($event)
+								"
 								fullWidth
 							>
 								<nb-option

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.ts
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.ts
@@ -128,6 +128,16 @@ export class EditOrganizationOtherSettingsComponent
 		);
 	}
 
+	loadDefaultBonusPercentage(bonusType: BonusTypeEnum) {
+		switch (bonusType) {
+			case BonusTypeEnum.PROFIT_BASED_BONUS:
+				this.form.get('bonusPercentage').setValue(75);
+				break;
+			case BonusTypeEnum.REVENUE_BASED_BONUS:
+				this.form.get('bonusPercentage').setValue(10);
+				break;
+		}
+	}
 	private _initializedForm() {
 		if (!this.organization) {
 			return;
@@ -145,9 +155,11 @@ export class EditOrganizationOtherSettingsComponent
 			timeZone: [this.organization.timeZone],
 			startWeekOn: [this.organization.startWeekOn],
 			numberFormat: [this.organization.numberFormat],
-			bonusType: [this.organization.bonusType],
+			bonusType: [
+				this.organization.bonusType || BonusTypeEnum.PROFIT_BASED_BONUS
+			],
 			bonusPercentage: [
-				this.organization.bonusPercentage,
+				this.organization.bonusPercentage || 75,
 				[Validators.min(0), Validators.max(100)]
 			]
 		});

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.ts
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.ts
@@ -6,7 +6,8 @@ import {
 	Organization,
 	WeekDaysEnum,
 	RegionsEnum,
-	CurrenciesEnum
+	CurrenciesEnum,
+	BonusTypeEnum
 } from '@gauzy/models';
 import { NbToastrService } from '@nebular/theme';
 import { OrganizationEditStore } from 'apps/gauzy/src/app/@core/services/organization-edit-store.service';
@@ -35,6 +36,8 @@ export class EditOrganizationOtherSettingsComponent
 			return type[0] + type.substr(1, type.length).toLowerCase();
 		}
 	);
+	defaultBonusTypes: string[] = Object.values(BonusTypeEnum);
+
 	listOfZones = timezone.tz.names().filter((zone) => zone.includes('/'));
 	// todo: maybe its better to place listOfDateFormats somewhere more global for the app?
 	listOfDateFormats = ['L', 'L hh:mm', 'LL', 'LLL', 'LLLL'];
@@ -141,7 +144,12 @@ export class EditOrganizationOtherSettingsComponent
 			dateFormat: [this.organization.dateFormat],
 			timeZone: [this.organization.timeZone],
 			startWeekOn: [this.organization.startWeekOn],
-			numberFormat: [this.organization.numberFormat]
+			numberFormat: [this.organization.numberFormat],
+			bonusType: [this.organization.bonusType],
+			bonusPercentage: [
+				this.organization.bonusPercentage,
+				[Validators.min(0), Validators.max(100)]
+			]
 		});
 	}
 

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -39,6 +39,8 @@
 		"EXPENSES": "Expenses (Average)",
 		"BONUS": "Bonus",
 		"BONUS_AVG": "Bonus (Average)",
+		"PROFIT_BASED_BONUS": "Profit Based Bonus",
+		"REVENUE_BASED_BONUS": "Revenue Based Bonus",
 		"STATUS": "Status",
 		"WORK_STATUS": "Work Status",
 		"TODAY": "Today",
@@ -114,7 +116,9 @@
 			"DEPARTMENTS_OPTIONAL": "Departments (Optional)",
 			"PROJECTS": "Projects",
 			"ADD_NEW_DEPARTMENT": "Add New Department",
-			"EDIT_DEPARTMENT": "Edit Department"
+			"EDIT_DEPARTMENT": "Edit Department",
+			"TYPE_OF_BONUS": "Bonus Type",
+			"BONUS_PERCENTAGE": "Bonus Percentage"
 		},
 		"PLACEHOLDERS": {
 			"NAME": "Name",
@@ -165,7 +169,9 @@
 			"ADD_REMOVE_EMPLOYEES": "Add or Remove Employees",
 			"DATE": "Date",
 			"VALUE": "Value",
-			"SELECT_CURRENCY": "Select Currency"
+			"SELECT_CURRENCY": "Select Currency",
+			"TYPE_OF_BONUS": "Type of Bonus",
+			"BONUS_PERCENTAGE": "Bonus Percentage"
 		},
 		"RATES": {
 			"DEFAULT_RATE": "Default Rate",
@@ -347,6 +353,7 @@
 			"ADD_NEW_CLIENT": "Add new client",
 			"GENERAL_SETTINGS": "General Settings",
 			"DESIGN": "Design",
+			"BONUS": "Bonus",
 			"CLICK_EMPLOYEE": "Click to edit employee",
 			"EDIT_PROJECT": "Edit Project",
 			"REGIONS": "Regions",

--- a/libs/models/src/lib/organization.model.ts
+++ b/libs/models/src/lib/organization.model.ts
@@ -23,6 +23,8 @@ export interface Organization extends IBaseEntityModel {
 	postcode?: string;
 	regionCode?: string;
 	numberFormat?: string;
+	bonusType?: string;
+	bonusPercentage?: number;
 }
 
 export interface OrganizationFindInput extends IBaseEntityModel {
@@ -91,4 +93,9 @@ export enum WeekDaysEnum {
 	FRIDAY = 'FRIDAY',
 	SATURDAY = 'SATURDAY',
 	SUNDAY = 'SUNDAY'
+}
+
+export enum BonusTypeEnum {
+	PROFIT_BASED_BONUS = 'PROFIT_BASED_BONUS',
+	REVENUE_BASED_BONUS = 'REVENUE_BASED_BONUS'
 }


### PR DESCRIPTION
Added 2 new fields in the organization settings form to take manage bonus type and percentage for a given organization. Profit-based Bonus is the default bonus type. The bonus percentage for Profit-based Bonus is hardcoded to 75%, and Revenue-based Bonus to 10%