### PR TITLE
feat(#401): employee statistics bonus calculation

### DIFF
--- a/apps/api/src/app/employee-statistics/employee-statistics.module.ts
+++ b/apps/api/src/app/employee-statistics/employee-statistics.module.ts
@@ -6,11 +6,12 @@ import { Expense, ExpenseService } from '../expense';
 import { Income, IncomeService } from '../income';
 import { EmployeeStatisticsController } from './employee-statistics.controller';
 import { EmployeeStatisticsService } from './employee-statistics.service';
+import { Organization, OrganizationService } from '../organization';
 import { QueryHandlers } from './queries/handlers';
 
 @Module({
 	imports: [
-		TypeOrmModule.forFeature([Income, Expense, Employee]),
+		TypeOrmModule.forFeature([Income, Expense, Employee, Organization]),
 		CqrsModule
 	],
 	controllers: [EmployeeStatisticsController],
@@ -19,6 +20,7 @@ import { QueryHandlers } from './queries/handlers';
 		IncomeService,
 		ExpenseService,
 		EmployeeService,
+		OrganizationService,
 		...QueryHandlers
 	],
 	exports: [EmployeeStatisticsService]

--- a/apps/api/src/app/employee-statistics/employee-statistics.service.ts
+++ b/apps/api/src/app/employee-statistics/employee-statistics.service.ts
@@ -6,8 +6,6 @@ import {
 } from '@gauzy/models';
 import { IncomeService } from '../income';
 import { ExpenseService } from '../expense';
-import { OrganizationService } from '../organization';
-
 @Injectable()
 export class EmployeeStatisticsService {
 	private _monthNames = [

--- a/apps/api/src/app/employee-statistics/employee-statistics.service.ts
+++ b/apps/api/src/app/employee-statistics/employee-statistics.service.ts
@@ -1,7 +1,12 @@
 import { Injectable } from '@nestjs/common';
-import { EmployeeStatisticsFindInput, EmployeeStatistics } from '@gauzy/models';
+import {
+	EmployeeStatisticsFindInput,
+	EmployeeStatistics,
+	BonusTypeEnum
+} from '@gauzy/models';
 import { IncomeService } from '../income';
 import { ExpenseService } from '../expense';
+import { OrganizationService } from '../organization';
 
 @Injectable()
 export class EmployeeStatisticsService {
@@ -29,16 +34,18 @@ export class EmployeeStatisticsService {
 		employeeId: string,
 		findInput?: EmployeeStatisticsFindInput
 	): Promise<EmployeeStatistics> {
-		const mappedEmployeeIncome = (await this.incomeService.findAll(
-			{
-				where: {
-					employee: {
-						id: employeeId
+		const mappedEmployeeIncome = (
+			await this.incomeService.findAll(
+				{
+					where: {
+						employee: {
+							id: employeeId
+						}
 					}
-				}
-			},
-			findInput ? findInput.valueDate.toString() : null
-		)).items.map((e) => {
+				},
+				findInput ? findInput.valueDate.toString() : null
+			)
+		).items.map((e) => {
 			const obj = {};
 			const formattedDate = this._formatDate(e.valueDate);
 
@@ -47,16 +54,18 @@ export class EmployeeStatisticsService {
 			return obj;
 		});
 
-		const mappedEmployeeExpenses = (await this.expenseService.findAll(
-			{
-				where: {
-					employee: {
-						id: employeeId
+		const mappedEmployeeExpenses = (
+			await this.expenseService.findAll(
+				{
+					where: {
+						employee: {
+							id: employeeId
+						}
 					}
-				}
-			},
-			findInput ? findInput.valueDate.toString() : null
-		)).items.map((e) => {
+				},
+				findInput ? findInput.valueDate.toString() : null
+			)
+		).items.map((e) => {
 			const obj = {};
 			const formattedDate = this._formatDate(e.valueDate);
 
@@ -118,13 +127,26 @@ export class EmployeeStatisticsService {
 				: expenseStatistics.push(0);
 		});
 
+		const {
+			organization: { bonusType, bonusPercentage }
+		} = await this.incomeService.findOne({
+			where: { employee: { id: employeeId } },
+			relations: ['organization']
+		});
 		let profitStatistics = [];
 		let bonusStatistics = [];
 
 		expenseStatistics.forEach((expenseStat, index) => {
-			const profit = incomeStatistics[index] - expenseStat;
+			const income = incomeStatistics[index];
+			const profit = income - expenseStat;
+			const bonus = this.calculateEmployeeBonus(
+				bonusType,
+				bonusPercentage,
+				income,
+				profit
+			);
 			profitStatistics.push(profit);
-			bonusStatistics.push((profit * 75) / 100);
+			bonusStatistics.push(bonus);
 		});
 
 		if (findInput && findInput.valueDate) {
@@ -166,4 +188,20 @@ export class EmployeeStatisticsService {
 		return `${this._monthNames[date.getMonth()]} '${date.getFullYear() -
 			2000}`;
 	}
+
+	calculateEmployeeBonus = (
+		bonusType: string,
+		bonusPercentage: number,
+		income: number,
+		profit: number
+	) => {
+		switch (bonusType) {
+			case BonusTypeEnum.PROFIT_BASED_BONUS:
+				return (profit * bonusPercentage) / 100;
+			case BonusTypeEnum.REVENUE_BASED_BONUS:
+				return (income * bonusPercentage) / 100;
+			default:
+				return 0;
+		}
+	};
 }


### PR DESCRIPTION
Added bonus calculation logic in the dashboard page to calculate bonus based on the organization's bonus type and percentage preferences. The calculations are shown:

1. In the Employee table in Dashboard with All Employees selection.
![image](https://user-images.githubusercontent.com/32574315/74078084-1811a180-4a4c-11ea-8bd7-d114b4cb35fa.png)

2. In the Dashboard page with a single employee selected and the employee chart.
![image](https://user-images.githubusercontent.com/32574315/74078120-6cb51c80-4a4c-11ea-92af-39e38c23a623.png)


@evereq Bonus calculation logic is common for both the frontend and the backend. Currently, the calculation code is duplicated in employee-statistics.component and employee-statistics.service files. Can we move this to a shared file? If yes, please suggest.