### PR TITLE
Feat/397 auth roles employee

### DIFF
--- a/apps/api/src/app/employee/employee.controller.ts
+++ b/apps/api/src/app/employee/employee.controller.ts
@@ -5,18 +5,14 @@ import {
 	Query,
 	Post,
 	Body,
-	Param,
-	UseGuards
+	Param
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { EmployeeService } from './employee.service';
 import { Employee } from './employee.entity';
 import { CrudController } from '../core/crud/crud.controller';
 import { IPagination } from '../core';
-import {
-	EmployeeCreateInput as IEmployeeCreateInput,
-	RolesEnum
-} from '@gauzy/models';
+import { EmployeeCreateInput as IEmployeeCreateInput } from '@gauzy/models';
 import { CommandBus } from '@nestjs/cqrs';
 import { EmployeeCreateCommand } from './commands';
 

--- a/apps/api/src/app/employee/employee.controller.ts
+++ b/apps/api/src/app/employee/employee.controller.ts
@@ -19,11 +19,7 @@ import {
 } from '@gauzy/models';
 import { CommandBus } from '@nestjs/cqrs';
 import { EmployeeCreateCommand } from './commands';
-import { RoleGuard } from '../shared/guards/auth/role.guard';
-import { Roles } from '../shared/decorators/roles';
 
-@UseGuards(RoleGuard)
-@Roles(RolesEnum.ADMIN)
 @ApiTags('Employee')
 @Controller()
 export class EmployeeController extends CrudController<Employee> {

--- a/apps/api/src/app/income/income.controller.ts
+++ b/apps/api/src/app/income/income.controller.ts
@@ -18,8 +18,6 @@ import {
 import { CommandBus } from '@nestjs/cqrs';
 import { IncomeCreateCommand } from './commands/income.create.command';
 import { IPagination } from '../core';
-import { PermissionGuard } from '../shared/guards/auth/permission.guard';
-import { Permissions } from '../shared/decorators/permissions';
 
 @ApiTags('Income')
 @Controller()
@@ -42,8 +40,6 @@ export class IncomeController extends CrudController<Income> {
 		description: 'Record not found'
 	})
 	@Get()
-	@Permissions(PermissionsEnum.ORG_INCOMES_VIEW)
-	@UseGuards(PermissionGuard)
 	async findAllIncome(
 		@Query('data') data: string
 	): Promise<IPagination<Income>> {
@@ -65,8 +61,6 @@ export class IncomeController extends CrudController<Income> {
 			'Invalid input, The response body may contain clues as to what went wrong'
 	})
 	@Post('/create')
-	@Permissions(PermissionsEnum.ORG_INCOMES_EDIT)
-	@UseGuards(PermissionGuard)
 	async create(
 		@Body() entity: IIncomeCreateInput,
 		...options: any[]

--- a/apps/api/src/app/income/income.controller.ts
+++ b/apps/api/src/app/income/income.controller.ts
@@ -1,20 +1,9 @@
-import {
-	Controller,
-	HttpStatus,
-	Post,
-	Body,
-	Get,
-	Query,
-	UseGuards
-} from '@nestjs/common';
+import { Controller, HttpStatus, Post, Body, Get, Query } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { IncomeService } from './income.service';
 import { Income } from './income.entity';
 import { CrudController } from '../core/crud/crud.controller';
-import {
-	IncomeCreateInput as IIncomeCreateInput,
-	PermissionsEnum
-} from '@gauzy/models';
+import { IncomeCreateInput as IIncomeCreateInput } from '@gauzy/models';
 import { CommandBus } from '@nestjs/cqrs';
 import { IncomeCreateCommand } from './commands/income.create.command';
 import { IPagination } from '../core';

--- a/apps/api/src/app/role-permissions/role-permissions.controller.ts
+++ b/apps/api/src/app/role-permissions/role-permissions.controller.ts
@@ -1,4 +1,15 @@
-import { Controller, Get, HttpStatus, Query } from '@nestjs/common';
+import {
+	Controller,
+	Get,
+	HttpStatus,
+	Query,
+	HttpCode,
+	Body,
+	Post,
+	Put,
+	Param,
+	UseGuards
+} from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { IPagination } from '../core';
 import { CrudController } from '../core/crud/crud.controller';
@@ -8,14 +19,16 @@ import { RolePermissionsService } from './role-permissions.service';
 @ApiTags('Role')
 @Controller()
 export class RolePermissionsController extends CrudController<RolePermissions> {
-	constructor(private readonly roleService: RolePermissionsService) {
-		super(roleService);
+	constructor(
+		private readonly rolePermissionsService: RolePermissionsService
+	) {
+		super(rolePermissionsService);
 	}
 
-	@ApiOperation({ summary: 'Find role.' })
+	@ApiOperation({ summary: 'Find role permissions.' })
 	@ApiResponse({
 		status: HttpStatus.OK,
-		description: 'Found role',
+		description: 'Found role permissions.',
 		type: RolePermissions
 	})
 	@ApiResponse({
@@ -28,6 +41,49 @@ export class RolePermissionsController extends CrudController<RolePermissions> {
 	): Promise<IPagination<RolePermissions>> {
 		const { findInput } = JSON.parse(data);
 
-		return this.roleService.findAll({ where: findInput });
+		return this.rolePermissionsService.findAll({ where: findInput });
+	}
+
+	@ApiOperation({ summary: 'Create new record' })
+	@ApiResponse({
+		status: HttpStatus.CREATED,
+		description: 'The record has been successfully created.'
+	})
+	@ApiResponse({
+		status: HttpStatus.BAD_REQUEST,
+		description:
+			'Invalid input, The response body may contain clues as to what went wrong'
+	})
+	@HttpCode(HttpStatus.CREATED)
+	@Post()
+	async create(
+		@Body() entity: RolePermissions,
+		...options: any[]
+	): Promise<RolePermissions> {
+		return this.rolePermissionsService.create(entity);
+	}
+
+	@ApiOperation({ summary: 'Update an existing record' })
+	@ApiResponse({
+		status: HttpStatus.CREATED,
+		description: 'The record has been successfully edited.'
+	})
+	@ApiResponse({
+		status: HttpStatus.NOT_FOUND,
+		description: 'Record not found'
+	})
+	@ApiResponse({
+		status: HttpStatus.BAD_REQUEST,
+		description:
+			'Invalid input, The response body may contain clues as to what went wrong'
+	})
+	@HttpCode(HttpStatus.ACCEPTED)
+	@Put(':id')
+	async update(
+		@Param('id') id: string,
+		@Body() entity: RolePermissions,
+		...options: any[]
+	): Promise<any> {
+		return this.rolePermissionsService.update(id, entity);
 	}
 }

--- a/apps/api/src/app/role-permissions/role-permissions.controller.ts
+++ b/apps/api/src/app/role-permissions/role-permissions.controller.ts
@@ -7,8 +7,7 @@ import {
 	Body,
 	Post,
 	Put,
-	Param,
-	UseGuards
+	Param
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { IPagination } from '../core';

--- a/apps/api/src/app/role-permissions/role-permissions.seed.ts
+++ b/apps/api/src/app/role-permissions/role-permissions.seed.ts
@@ -25,7 +25,10 @@ const defaultRolePermissions = [
 			PermissionsEnum.ALL_ORG_VIEW,
 			PermissionsEnum.ALL_ORG_EDIT,
 			PermissionsEnum.POLICY_EDIT,
-			PermissionsEnum.POLICY_VIEW
+			PermissionsEnum.POLICY_VIEW,
+			PermissionsEnum.CHANGE_SELECTED_EMPLOYEE,
+			PermissionsEnum.CHANGE_SELECTED_ORGANIZATION,
+			PermissionsEnum.CHANGE_ROLES_PERMISSIONS
 		]
 	},
 	{
@@ -35,6 +38,14 @@ const defaultRolePermissions = [
 			PermissionsEnum.ORG_EXPENSES_VIEW,
 			PermissionsEnum.ORG_INCOMES_EDIT,
 			PermissionsEnum.ORG_INCOMES_VIEW
+		]
+	},
+	{
+		role: RolesEnum.EMPLOYEE,
+		defaultEnabledPermissions: [
+			PermissionsEnum.ADMIN_DASHBOARD_VIEW,
+			PermissionsEnum.ORG_PROPOSALS_VIEW,
+			PermissionsEnum.ORG_TIME_OFF_VIEW
 		]
 	}
 ];

--- a/apps/gauzy/src/app/@core/services/store.service.ts
+++ b/apps/gauzy/src/app/@core/services/store.service.ts
@@ -57,7 +57,6 @@ export class Store {
 
 	set selectedOrganization(organization: Organization) {
 		this.selectedOrganization$.next(organization);
-		this.selectedEmployee = null;
 		this._selectedOrganization = organization;
 	}
 

--- a/apps/gauzy/src/app/@theme/components/header/header.component.ts
+++ b/apps/gauzy/src/app/@theme/components/header/header.component.ts
@@ -7,7 +7,7 @@ import {
 } from '@nebular/theme';
 import { LayoutService } from '../../../@core/utils';
 import { Subject } from 'rxjs';
-import { Router, NavigationEnd } from '@angular/router';
+import { Router } from '@angular/router';
 import { filter, takeUntil } from 'rxjs/operators';
 import { TranslateService } from '@ngx-translate/core';
 import { Store } from '../../../@core/services/store.service';

--- a/apps/gauzy/src/app/@theme/components/header/header.component.ts
+++ b/apps/gauzy/src/app/@theme/components/header/header.component.ts
@@ -13,6 +13,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { Store } from '../../../@core/services/store.service';
 import { SelectorService } from '../../../@core/utils/selector.service';
 import { PermissionsEnum } from '@gauzy/models';
+import { User } from '@gauzy/models';
 
 @Component({
 	selector: 'ngx-header',
@@ -28,10 +29,12 @@ export class HeaderComponent implements OnInit, OnDestroy {
 	hasPermissionPEdit = false;
 
 	@Input() position = 'normal';
+	@Input() user: User;
+	@Input() showEmployeesSelector;
+	@Input() showOrganizationsSelector;
 
-	showEmployeesSelector = true;
 	showDateSelector = true;
-	showOrganizationsSelector = true;
+	organizationSelected = false;
 	theme: string;
 	createContextMenu: NbMenuItem[];
 	supportContextMenu: NbMenuItem[];
@@ -53,14 +56,14 @@ export class HeaderComponent implements OnInit, OnDestroy {
 	) {}
 
 	ngOnInit() {
-		this.showSelectors(this.router.url);
+		// this.showSelectors(this.router.url);
 
-		this.router.events
-			.pipe(filter((event) => event instanceof NavigationEnd))
-			.pipe(takeUntil(this._ngDestroy$))
-			.subscribe((e) => {
-				this.showSelectors(e['url']);
-			});
+		// this.router.events
+		// 	.pipe(filter((event) => event instanceof NavigationEnd))
+		// 	.pipe(takeUntil(this._ngDestroy$))
+		// 	.subscribe((e) => {
+		// 		this.showSelectors(e['url']);
+		// 	});
 
 		this.menuService
 			.onItemClick()
@@ -94,12 +97,12 @@ export class HeaderComponent implements OnInit, OnDestroy {
 		this._applyTranslationOnSmartTable();
 	}
 
-	showSelectors(url: string) {
-		const selectors = this.selectorService.showSelectors(url);
-		this.showDateSelector = selectors.showDateSelector;
-		this.showEmployeesSelector = selectors.showEmployeesSelector;
-		this.showOrganizationsSelector = selectors.showOrganizationsSelector;
-	}
+	// showSelectors(url: string) {
+	// 	const selectors = this.selectorService.showSelectors(url);
+	// 	this.showDateSelector = selectors.showDateSelector;
+	// 	this.showEmployeesSelector = selectors.showEmployeesSelector;
+	// 	this.showOrganizationsSelector = selectors.showOrganizationsSelector;
+	// }
 
 	toggleSidebar(): boolean {
 		if (this.showExtraActions) {

--- a/apps/gauzy/src/app/@theme/components/header/selectors/organization/organization.component.ts
+++ b/apps/gauzy/src/app/@theme/components/header/selectors/organization/organization.component.ts
@@ -29,6 +29,7 @@ export class OrganizationSelectorComponent implements OnInit, OnDestroy {
 	selectOrganiztion(organization: Organization) {
 		if (organization) {
 			this.store.selectedOrganization = organization;
+			this.store.selectedEmployee = null;
 		}
 	}
 

--- a/apps/gauzy/src/app/@theme/layouts/one-column/one-column.layout.html
+++ b/apps/gauzy/src/app/@theme/layouts/one-column/one-column.layout.html
@@ -1,6 +1,9 @@
 <nb-layout windowMode>
 	<nb-layout-header fixed>
-		<ngx-header></ngx-header>
+		<ngx-header
+			[showEmployeesSelector]="showEmployeesSelector"
+			[showOrganizationsSelector]="showOrganizationsSelector"
+		></ngx-header>
 	</nb-layout-header>
 
 	<nb-sidebar

--- a/apps/gauzy/src/app/@theme/layouts/one-column/one-column.layout.ts
+++ b/apps/gauzy/src/app/@theme/layouts/one-column/one-column.layout.ts
@@ -16,6 +16,11 @@ import { UsersService } from '../../../@core/services/users.service';
 
 import { WindowModeBlockScrollService } from '../../services/window-mode-block-scroll.service';
 import { Store } from '../../../@core/services/store.service';
+import { UsersOrganizationsService } from '../../../@core/services/users-organizations.service';
+import { OrganizationsService } from '../../../@core/services/organizations.service';
+import { first } from 'rxjs/operators';
+import { EmployeesService } from '../../../@core/services';
+import { PermissionsEnum } from '@gauzy/models';
 
 @Component({
 	selector: 'ngx-one-column-layout',
@@ -27,12 +32,17 @@ export class OneColumnLayoutComponent implements OnInit, AfterViewInit {
 		@Inject(PLATFORM_ID) private platformId,
 		private windowModeBlockScrollService: WindowModeBlockScrollService,
 		private usersService: UsersService,
+		private usersOrganizationsService: UsersOrganizationsService,
+		private organizationsService: OrganizationsService,
+		private employeesService: EmployeesService,
 		private store: Store,
 		private directionService: NbLayoutDirectionService
 	) {}
 	@ViewChild(NbLayoutComponent, { static: false }) layout: NbLayoutComponent;
 
 	user: any;
+	showOrganizationsSelector = false;
+	showEmployeesSelector = false;
 
 	userMenu = [
 		{ title: 'Profile', link: '/pages/auth/profile' },
@@ -65,11 +75,40 @@ export class OneColumnLayoutComponent implements OnInit, AfterViewInit {
 		this.user = items[0];
 		this.store.userRolePermissions = items[0].role.rolePermissions;
 
-		// We did not doing nothing with the result?
-		// Also if user still did not have organization?
-		// const { orgId } = await this.usersOrganizationsService.findOne({ userId: id }).pipe(first()).toPromise();
+		if (
+			this.store.hasPermission(
+				PermissionsEnum.CHANGE_SELECTED_ORGANIZATION
+			)
+		) {
+			this.showOrganizationsSelector = true;
+		} else {
+			const {
+				items: userOrg
+			} = await this.usersOrganizationsService.getAll([], { userId: id });
+			const org = await this.organizationsService
+				.getById(userOrg[0].orgId)
+				.pipe(first())
+				.toPromise();
+			this.store.selectedOrganization = org;
+		}
 
-		// TODO: Fix me!
-		// this.store.selectedOrganizationId = orgId;
+		if (
+			this.store.hasPermission(PermissionsEnum.CHANGE_SELECTED_EMPLOYEE)
+		) {
+			this.showEmployeesSelector = true;
+			this.store.selectedEmployee = null;
+		} else {
+			const { items: emp } = await this.employeesService
+				.getAll([], { user: this.user })
+				.pipe(first())
+				.toPromise();
+
+			this.store.selectedEmployee = {
+				id: emp[0].id,
+				firstName: this.user.firstName,
+				lastName: this.user.lastName,
+				imageUrl: this.user.imageUrl
+			};
+		}
 	}
 }

--- a/apps/gauzy/src/app/@theme/theme.module.ts
+++ b/apps/gauzy/src/app/@theme/theme.module.ts
@@ -48,6 +48,8 @@ import { TranslateModule, TranslateLoader } from '@ngx-translate/core';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 import { EmployeeSelectorsModule } from './components/header/selectors/employee/employee.module';
 import { SelectorService } from '../@core/utils/selector.service';
+import { UsersOrganizationsService } from '../@core/services/users-organizations.service';
+import { OrganizationsService } from '../@core/services/organizations.service';
 
 export function HttpLoaderFactory(http: HttpClient) {
 	return new TranslateHttpLoader(http, './assets/i18n/', '.json');
@@ -99,7 +101,12 @@ const PIPES = [
 	imports: [CommonModule, ...NB_MODULES],
 	exports: [CommonModule, ...PIPES, ...COMPONENTS],
 	declarations: [...COMPONENTS, ...PIPES],
-	providers: [UsersService, SelectorService]
+	providers: [
+		UsersService,
+		SelectorService,
+		UsersOrganizationsService,
+		OrganizationsService
+	]
 })
 export class ThemeModule {
 	static forRoot(): ModuleWithProviders {

--- a/apps/gauzy/src/app/pages/dashboard/dashboard.component.html
+++ b/apps/gauzy/src/app/pages/dashboard/dashboard.component.html
@@ -1,10 +1,14 @@
-<div
-	*ngIf="
-		selectedEmployee && selectedEmployee.id;
-		then employeeStats;
-		else orgEmployees
-	"
-></div>
+<nb-spinner *ngIf="loading"> </nb-spinner>
+
+<div *ngIf="!loading">
+	<div
+		*ngIf="
+			selectedEmployee && selectedEmployee.id;
+			then employeeStats;
+			else orgEmployees
+		"
+	></div>
+</div>
 
 <ng-template #employeeStats>
 	<ga-employee-statistics> </ga-employee-statistics>

--- a/apps/gauzy/src/app/pages/dashboard/dashboard.component.ts
+++ b/apps/gauzy/src/app/pages/dashboard/dashboard.component.ts
@@ -12,6 +12,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
 	private _ngDestroy$ = new Subject<void>();
 
 	selectedEmployee: SelectedEmployee;
+	loading = true;
 
 	constructor(private store: Store) {}
 
@@ -20,6 +21,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
 			.pipe(takeUntil(this._ngDestroy$))
 			.subscribe((emp) => {
 				if (emp) {
+					this.loading = false;
 					this.selectedEmployee = emp;
 				}
 			});

--- a/apps/gauzy/src/app/pages/dashboard/dashboard.module.ts
+++ b/apps/gauzy/src/app/pages/dashboard/dashboard.module.ts
@@ -46,6 +46,7 @@ export function HttpLoaderFactory(http: HttpClient) {
 		NbTreeGridModule,
 		NbIconModule,
 		NbTooltipModule,
+		NbSpinnerModule,
 		ProfitHistoryModule,
 		TranslateModule.forChild({
 			loader: {

--- a/apps/gauzy/src/app/pages/dashboard/employee-statistics/employee-statistics.component.html
+++ b/apps/gauzy/src/app/pages/dashboard/employee-statistics/employee-statistics.component.html
@@ -35,7 +35,7 @@
 	</nb-card-header>
 
 	<nb-card-body class="body">
-		<div class="half-content" *ngIf="hasRole; else noRole">
+		<div class="half-content">
 			<div *ngIf="selectedDate; else notSelected">
 				<div
 					class="info-block open"

--- a/apps/gauzy/src/app/pages/dashboard/employee-statistics/employee-statistics.component.ts
+++ b/apps/gauzy/src/app/pages/dashboard/employee-statistics/employee-statistics.component.ts
@@ -1,12 +1,11 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { IncomeService } from '../../../@core/services/income.service';
-import { first, takeUntil } from 'rxjs/operators';
+import { takeUntil } from 'rxjs/operators';
 import { Store } from '../../../@core/services/store.service';
 import { Subject } from 'rxjs';
 import { ExpensesService } from '../../../@core/services/expenses.service';
 import { AuthService } from '../../../@core/services/auth.service';
 import {
-	RolesEnum,
 	Income,
 	Expense,
 	EmployeeRecurringExpense,

--- a/apps/gauzy/src/app/pages/dashboard/employee-statistics/employee-statistics.component.ts
+++ b/apps/gauzy/src/app/pages/dashboard/employee-statistics/employee-statistics.component.ts
@@ -42,7 +42,6 @@ export interface ViewDashboardExpenseHistory {
 })
 export class EmployeeStatisticsComponent implements OnInit, OnDestroy {
 	private _ngDestroy$ = new Subject<void>();
-	hasRole: boolean;
 	loading = true;
 
 	selectedDate: Date;
@@ -78,11 +77,6 @@ export class EmployeeStatisticsComponent implements OnInit, OnDestroy {
 	) {}
 
 	async ngOnInit() {
-		this.hasRole = await this.authService
-			.hasRole([RolesEnum.ADMIN, RolesEnum.DATA_ENTRY])
-			.pipe(first())
-			.toPromise();
-
 		this.store.selectedEmployee$
 			.pipe(takeUntil(this._ngDestroy$))
 			.subscribe((emp) => {

--- a/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee.component.ts
+++ b/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee.component.ts
@@ -240,14 +240,13 @@ export class EditEmployeeComponent implements OnInit, OnDestroy {
 	}
 
 	private async _loadEmployeeRecurringExpense() {
-		this.selectedEmployeeRecurringExpense = (await this.employeeRecurringExpenseService.getAll(
-			[],
-			{
+		this.selectedEmployeeRecurringExpense = (
+			await this.employeeRecurringExpenseService.getAll([], {
 				employeeId: this.selectedEmployee.id,
 				year: this.selectedDate.getFullYear(),
 				month: this.selectedDate.getMonth() + 1
-			}
-		)).items;
+			})
+		).items;
 	}
 
 	ngOnDestroy() {

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization.component.ts
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization.component.ts
@@ -77,6 +77,7 @@ export class EditOrganizationComponent implements OnInit, OnDestroy {
 				this.loadEmployeesCount();
 				this._loadOrgRecurringExpense();
 				this.store.selectedOrganization = this.selectedOrg;
+				this.store.selectedEmployee = null;
 
 				this.store.selectedOrganization$
 					.pipe(takeUntil(this._ngDestroy$))

--- a/apps/gauzy/src/app/pages/pages-routing.module.ts
+++ b/apps/gauzy/src/app/pages/pages-routing.module.ts
@@ -30,112 +30,110 @@ const routes: Routes = [
 			{
 				path: 'income',
 				loadChildren: () =>
-					import('./income/income.module').then(
-						(m) => m.IncomeModule
-					),
-				canActivate: [RoleGuard],
-				data: {
-					expectedRole: [
-						// RolesEnum.DATA_ENTRY,
-						// RolesEnum.EMPLOYEE,
-						RolesEnum.ADMIN
-					]
-				}
+					import('./income/income.module').then((m) => m.IncomeModule)
+				// canActivate: [RoleGuard],
+				// data: {
+				// 	expectedRole: [
+				// 		// RolesEnum.DATA_ENTRY,
+				// 		// RolesEnum.EMPLOYEE,
+				// 		RolesEnum.ADMIN
+				// 	]
+				// }
 			},
 			{
 				path: 'expenses',
 				loadChildren: () =>
 					import('./expenses/expenses.module').then(
 						(m) => m.ExpensesModule
-					),
-				canActivate: [RoleGuard],
-				data: {
-					expectedRole: [
-						// RolesEnum.DATA_ENTRY,
-						// RolesEnum.EMPLOYEE,
-						RolesEnum.ADMIN
-					]
-				}
+					)
+				// canActivate: [RoleGuard],
+				// data: {
+				// 	expectedRole: [
+				// 		// RolesEnum.DATA_ENTRY,
+				// 		// RolesEnum.EMPLOYEE,
+				// 		RolesEnum.ADMIN
+				// 	]
+				// }
 			},
 			{
 				path: 'proposals',
 				loadChildren: () =>
 					import('./proposals/proposals.module').then(
 						(m) => m.ProposalsModule
-					),
-				canActivate: [RoleGuard],
-				data: {
-					expectedRole: [
-						// RolesEnum.DATA_ENTRY,
-						// RolesEnum.EMPLOYEE,
-						RolesEnum.ADMIN
-					]
-				}
+					)
+				// canActivate: [RoleGuard],
+				// data: {
+				// 	expectedRole: [
+				// 		// RolesEnum.DATA_ENTRY,
+				// 		// RolesEnum.EMPLOYEE,
+				// 		RolesEnum.ADMIN
+				// 	]
+				// }
 			},
 			{
 				path: 'time-off',
 				loadChildren: () =>
 					import('./time-off/time-off.module').then(
 						(m) => m.TimeOffModule
-					),
-				canActivate: [RoleGuard],
-				data: {
-					expectedRole: [
-						// RolesEnum.EMPLOYEE,
-						RolesEnum.ADMIN
-					]
-				}
+					)
+				// canActivate: [RoleGuard],
+				// data: {
+				// 	expectedRole: [
+				// 		// RolesEnum.EMPLOYEE,
+				// 		RolesEnum.ADMIN
+				// 	]
+				// }
 			},
 			{
 				path: 'help',
 				loadChildren: () =>
-					import('./help/help.module').then((m) => m.HelpModule),
-				canActivate: [RoleGuard],
-				data: {
-					expectedRole: [
-						// RolesEnum.DATA_ENTRY,
-						// RolesEnum.EMPLOYEE,
-						RolesEnum.ADMIN
-					]
-				}
+					import('./help/help.module').then((m) => m.HelpModule)
+				// canActivate: [RoleGuard],
+				// data: {
+				// 	expectedRole: [
+				// 		// RolesEnum.DATA_ENTRY,
+				// 		// RolesEnum.EMPLOYEE,
+				// 		RolesEnum.ADMIN
+				// 	]
+				// }
 			},
 			{
 				path: 'about',
 				loadChildren: () =>
-					import('./about/about.module').then((m) => m.AboutModule),
-				canActivate: [RoleGuard],
-				data: {
-					expectedRole: [
-						// RolesEnum.DATA_ENTRY,
-						// RolesEnum.EMPLOYEE,
-						RolesEnum.ADMIN
-					]
-				}
+					import('./about/about.module').then((m) => m.AboutModule)
+				// canActivate: [RoleGuard],
+				// data: {
+				// 	expectedRole: [
+				// 		// RolesEnum.DATA_ENTRY,
+				// 		// RolesEnum.EMPLOYEE,
+				// 		RolesEnum.ADMIN
+				// 	]
+				// }
 			},
 			{
 				path: 'employees',
 				loadChildren: () =>
 					import('./employees/employees.module').then(
 						(m) => m.EmployeesModule
-					),
-				canActivate: [RoleGuard],
-				data: { expectedRole: [RolesEnum.ADMIN] }
+					)
+				// canActivate: [RoleGuard],
+				// data: { expectedRole: [RolesEnum.ADMIN] }
 			},
 			{
 				path: 'users',
 				loadChildren: () =>
-					import('./users/users.module').then((m) => m.UsersModule),
-				canActivate: [RoleGuard],
-				data: { expectedRole: [RolesEnum.ADMIN] }
+					import('./users/users.module').then((m) => m.UsersModule)
+				// canActivate: [RoleGuard],
+				// data: { expectedRole: [RolesEnum.ADMIN] }
 			},
 			{
 				path: 'organizations',
 				loadChildren: () =>
 					import('./organizations/organizations.module').then(
 						(m) => m.OrganizationsModule
-					),
-				canActivate: [RoleGuard],
-				data: { expectedRole: [RolesEnum.ADMIN] }
+					)
+				// canActivate: [RoleGuard],
+				// data: { expectedRole: [RolesEnum.ADMIN] }
 			},
 			{
 				path: 'auth',

--- a/apps/gauzy/src/app/pages/pages-routing.module.ts
+++ b/apps/gauzy/src/app/pages/pages-routing.module.ts
@@ -3,8 +3,8 @@ import { NgModule } from '@angular/core';
 
 import { PagesComponent } from './pages.component';
 import { NotFoundComponent } from './miscellaneous/not-found/not-found.component';
-import { RoleGuard } from '../@core/role/role.guard';
-import { RolesEnum } from '@gauzy/models';
+// import { RoleGuard } from '../@core/role/role.guard';
+// import { RolesEnum } from '@gauzy/models';
 
 const routes: Routes = [
 	{

--- a/apps/gauzy/src/app/pages/pages.component.ts
+++ b/apps/gauzy/src/app/pages/pages.component.ts
@@ -227,7 +227,10 @@ export class PagesComponent implements OnInit, OnDestroy {
 					link: '/pages/settings/roles',
 					data: {
 						translated: false,
-						translationKey: 'MENU.ROLES'
+						translationKey: 'MENU.ROLES',
+						permissionKeys: [
+							PermissionsEnum.CHANGE_ROLES_PERMISSIONS
+						]
 					}
 				}
 			]

--- a/apps/gauzy/src/app/pages/settings/edit-roles-permissions/edit-roles-permissions.component.html
+++ b/apps/gauzy/src/app/pages/settings/edit-roles-permissions/edit-roles-permissions.component.html
@@ -59,10 +59,21 @@
 				</div>
 				<div class="col-6">
 					<nb-card>
-						<nb-card-header>{{
-							'ORGANIZATIONS_PAGE.PERMISSIONS.GROUPS.ADMINISTRATION'
-								| translate
-						}}</nb-card-header>
+						<nb-card-header
+							>{{
+								'ORGANIZATIONS_PAGE.PERMISSIONS.GROUPS.ADMINISTRATION'
+									| translate
+							}}
+							<nb-icon
+								nbTooltip="{{
+									'ORGANIZATIONS_PAGE.PERMISSIONS.ONLY_ADMIN'
+										| translate
+								}}"
+								class="mr-1"
+								icon="question-mark-circle-outline"
+							>
+							</nb-icon>
+						</nb-card-header>
 						<nb-card-body class="permission-items-col">
 							<nb-toggle
 								*ngFor="
@@ -75,11 +86,15 @@
 								labelPosition="start"
 								status="basic"
 								[(checked)]="enabledPermissions[permission]"
+								(checkedChange)="
+									permissionChanged(permission, $event)
+								"
+								disabled
 								>{{
 									'ORGANIZATIONS_PAGE.PERMISSIONS.' +
 										permission | translate
-								}}</nb-toggle
-							>
+								}}
+							</nb-toggle>
 						</nb-card-body>
 					</nb-card>
 				</div>

--- a/apps/gauzy/src/app/pages/settings/edit-roles-permissions/edit-roles-permissions.component.ts
+++ b/apps/gauzy/src/app/pages/settings/edit-roles-permissions/edit-roles-permissions.component.ts
@@ -1,9 +1,9 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import {
 	Organization,
-	PermissionsEnum,
 	RolePermissions,
-	RolesEnum
+	RolesEnum,
+	PermissionGroups
 } from '@gauzy/models';
 import { NbToastrService } from '@nebular/theme';
 import { TranslateService } from '@ngx-translate/core';
@@ -29,28 +29,7 @@ export class EditRolesPermissionsComponent implements OnInit, OnDestroy {
 
 	loading = true;
 
-	permissionGroups = {
-		GENERAL: [
-			PermissionsEnum.ADMIN_DASHBOARD_VIEW,
-			PermissionsEnum.ORG_EXPENSES_VIEW,
-			PermissionsEnum.ORG_EXPENSES_EDIT,
-			PermissionsEnum.ORG_INCOMES_EDIT,
-			PermissionsEnum.ORG_INCOMES_VIEW,
-			PermissionsEnum.ORG_PROPOSALS_EDIT,
-			PermissionsEnum.ORG_PROPOSALS_VIEW,
-			PermissionsEnum.ORG_TIME_OFF_VIEW
-		],
-		ADMINISTRATION: [
-			PermissionsEnum.ORG_EMPLOYEES_VIEW,
-			PermissionsEnum.ORG_EMPLOYEES_EDIT,
-			PermissionsEnum.ORG_USERS_VIEW,
-			PermissionsEnum.ORG_USERS_EDIT,
-			PermissionsEnum.ALL_ORG_VIEW,
-			PermissionsEnum.ALL_ORG_EDIT,
-			PermissionsEnum.POLICY_VIEW,
-			PermissionsEnum.POLICY_EDIT
-		]
-	};
+	permissionGroups = PermissionGroups;
 
 	enabledPermissions = {};
 	allPermissions: RolePermissions[] = [];

--- a/apps/gauzy/src/app/pages/settings/settings.module.ts
+++ b/apps/gauzy/src/app/pages/settings/settings.module.ts
@@ -7,7 +7,9 @@ import {
 	NbInputModule,
 	NbSelectModule,
 	NbSpinnerModule,
-	NbToggleModule
+	NbToggleModule,
+	NbIconModule,
+	NbTooltipModule
 } from '@nebular/theme';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
@@ -33,6 +35,8 @@ export function HttpLoaderFactory(http: HttpClient) {
 		NbSelectModule,
 		NbToggleModule,
 		NbSpinnerModule,
+		NbIconModule,
+		NbTooltipModule,
 		TranslateModule.forChild({
 			loader: {
 				provide: TranslateLoader,

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -376,10 +376,14 @@
 			"ALL_ORG_EDIT": "Create/Edit/Delete All Organizations",
 			"POLICY_VIEW": "View Time Off Policy",
 			"POLICY_EDIT": "Edit Time Off Policy",
+			"CHANGE_SELECTED_EMPLOYEE": "Change Selected Employee",
+			"CHANGE_SELECTED_ORGANIZATION": "Change Selected Organization",
+			"CHANGE_ROLES_PERMISSIONS": "Change Roles & Permissions",
 			"GROUPS": {
 				"GENERAL": "General",
 				"ADMINISTRATION": "Administration"
-			}
+			},
+			"ONLY_ADMIN": "These permissions are read-only and enabled only for admin"
 		}
 	},
 	"PROPOSALS_PAGE": {

--- a/libs/models/src/lib/role-permission.model.ts
+++ b/libs/models/src/lib/role-permission.model.ts
@@ -34,5 +34,37 @@ export enum PermissionsEnum {
 	ALL_ORG_VIEW = 'ALL_ORG_VIEW',
 	ALL_ORG_EDIT = 'ALL_ORG_EDIT',
 	POLICY_VIEW = 'POLICY_VIEW',
-	POLICY_EDIT = 'POLICY_EDIT'
+	POLICY_EDIT = 'POLICY_EDIT',
+	CHANGE_SELECTED_EMPLOYEE = 'CHANGE_SELECTED_EMPLOYEE',
+	CHANGE_SELECTED_ORGANIZATION = 'CHANGE_SELECTED_ORGANIZATION',
+	CHANGE_ROLES_PERMISSIONS = 'CHANGE_ROLES_PERMISSIONS'
 }
+
+export const PermissionGroups = {
+	//Permissions which can be given to any role
+	GENERAL: [
+		PermissionsEnum.ADMIN_DASHBOARD_VIEW,
+		PermissionsEnum.ORG_EXPENSES_VIEW,
+		PermissionsEnum.ORG_EXPENSES_EDIT,
+		PermissionsEnum.ORG_INCOMES_EDIT,
+		PermissionsEnum.ORG_INCOMES_VIEW,
+		PermissionsEnum.ORG_PROPOSALS_EDIT,
+		PermissionsEnum.ORG_PROPOSALS_VIEW,
+    PermissionsEnum.ORG_TIME_OFF_VIEW,
+    PermissionsEnum.POLICY_VIEW,
+    PermissionsEnum.POLICY_EDIT
+	],
+
+	//Readonly permissions, are only enabled for admin role
+	ADMINISTRATION: [
+		PermissionsEnum.ORG_EMPLOYEES_VIEW,
+		PermissionsEnum.ORG_EMPLOYEES_EDIT,
+		PermissionsEnum.ORG_USERS_VIEW,
+		PermissionsEnum.ORG_USERS_EDIT,
+		PermissionsEnum.ALL_ORG_VIEW,
+		PermissionsEnum.ALL_ORG_EDIT,
+		PermissionsEnum.CHANGE_SELECTED_EMPLOYEE,
+		PermissionsEnum.CHANGE_SELECTED_ORGANIZATION,
+		PermissionsEnum.CHANGE_ROLES_PERMISSIONS
+	]
+};


### PR DESCRIPTION
Improvement for #397 

What is new?
1. Employee Dashboard view. Without any employee or organization selector.
2. Admin permissions are now read-only.
3. Permissions for Employee added in the seed.

<img width="1661" alt="Screen Shot 2020-02-11 at 1 12 11 AM" src="https://user-images.githubusercontent.com/6750734/74184175-5ab1c480-4c6c-11ea-948c-238bfa327494.png">

<img width="1300" alt="Screen Shot 2020-02-11 at 1 08 51 AM" src="https://user-images.githubusercontent.com/6750734/74184195-60a7a580-4c6c-11ea-9180-61c7144b689a.png">

What is left
1. **Backend security** 
1.1 Guards are causing some circular dependencies which I'll have to check in deep
1.2 Some APIs need to be created, for example, even if the `Income View` permission is not given, a user should be able to view his own dashboard, which uses the /income API. So we need to create some APIs like `/income/me` which will not have the permission guard.
2. Creating the Data Entry dashboard

@evereq After 1 (tricky) and 2 (simple) above are implemented we'll finally have a complete permissions implementation .. phew!