### PR TITLE
fix: #397 non user without change selected employee permission

### DIFF
--- a/apps/gauzy/src/app/@core/services/store.service.ts
+++ b/apps/gauzy/src/app/@core/services/store.service.ts
@@ -38,15 +38,6 @@ export class Store {
 	}
 
 	set selectedEmployee(employee: SelectedEmployee) {
-		if (!employee) {
-			employee = {
-				id: null,
-				firstName: 'All Employees',
-				lastName: '',
-				imageUrl: 'https://i.imgur.com/XwA2T62.jpg'
-			};
-		}
-
 		this._selectedEmployee = employee;
 		this.selectedEmployee$.next(employee);
 	}

--- a/apps/gauzy/src/app/@theme/components/header/selectors/employee/employee.component.ts
+++ b/apps/gauzy/src/app/@theme/components/header/selectors/employee/employee.component.ts
@@ -4,12 +4,37 @@ import { first, takeUntil } from 'rxjs/operators';
 import { Store } from 'apps/gauzy/src/app/@core/services/store.service';
 import { Subject } from 'rxjs';
 
+//TODO: Currently the whole application assumes that if employee or id is null then you need to get data for All Employees
+//That should not be the case, sometimes due to permissions like CHANGE_SELECTED_EMPLOYEE not being available
+//we need to handle cases where No Employee is selected too
 export interface SelectedEmployee {
 	id: string;
 	firstName: string;
 	lastName: string;
 	imageUrl: string;
+	defaultType?: DEFAULT_TYPE;
 }
+
+export enum DEFAULT_TYPE {
+	ALL_EMPLOYEE = 'ALL_EMPLOYEE',
+	NO_EMPLOYEE = 'NO_EMPLOYEE'
+}
+
+export const ALL_EMPLOYEES_SELECTED: SelectedEmployee = {
+	id: null,
+	firstName: 'All Employees',
+	lastName: '',
+	imageUrl: 'https://i.imgur.com/XwA2T62.jpg',
+	defaultType: DEFAULT_TYPE.ALL_EMPLOYEE
+};
+
+export const NO_EMPLOYEE_SELECTED: SelectedEmployee = {
+	id: null,
+	firstName: '',
+	lastName: '',
+	imageUrl: '',
+	defaultType: DEFAULT_TYPE.NO_EMPLOYEE
+};
 
 @Component({
 	selector: 'ga-employee-selector',
@@ -52,7 +77,7 @@ export class EmployeeSelectorComponent implements OnInit, OnDestroy {
 
 	selectEmployee(employee: SelectedEmployee) {
 		if (!this.skipGlobalChange) {
-			this.store.selectedEmployee = employee;
+			this.store.selectedEmployee = employee || ALL_EMPLOYEES_SELECTED;
 		}
 	}
 
@@ -86,12 +111,7 @@ export class EmployeeSelectorComponent implements OnInit, OnDestroy {
 
 		const load = (loadItems) => {
 			this.people = [
-				{
-					id: null,
-					firstName: 'All Employees',
-					lastName: '',
-					imageUrl: 'https://i.imgur.com/XwA2T62.jpg'
-				},
+				ALL_EMPLOYEES_SELECTED,
 				...loadItems.map((e) => {
 					return {
 						id: e.id,
@@ -117,13 +137,14 @@ export class EmployeeSelectorComponent implements OnInit, OnDestroy {
 		);
 
 		if (items.length > 0 && !this.store.selectedEmployee) {
-			this.store.selectedEmployee = this.people[0];
+			this.store.selectedEmployee =
+				this.people[0] || ALL_EMPLOYEES_SELECTED;
 		}
 
 		if (!this.selectedEmployee) {
 			// This is so selected employee doesn't get reset when it's already set from somewhere else
 			this.selectEmployee(this.people[0]);
-			this.selectedEmployee = this.people[0];
+			this.selectedEmployee = this.people[0] || ALL_EMPLOYEES_SELECTED;
 			this.store.selectedEmployee.id = null;
 		}
 	}

--- a/apps/gauzy/src/app/@theme/layouts/one-column/one-column.layout.ts
+++ b/apps/gauzy/src/app/@theme/layouts/one-column/one-column.layout.ts
@@ -21,6 +21,7 @@ import { OrganizationsService } from '../../../@core/services/organizations.serv
 import { first } from 'rxjs/operators';
 import { EmployeesService } from '../../../@core/services';
 import { PermissionsEnum } from '@gauzy/models';
+import { NO_EMPLOYEE_SELECTED } from '../../components/header/selectors/employee/employee.component';
 
 @Component({
 	selector: 'ngx-one-column-layout',
@@ -102,13 +103,16 @@ export class OneColumnLayoutComponent implements OnInit, AfterViewInit {
 				.getAll([], { user: this.user })
 				.pipe(first())
 				.toPromise();
-
-			this.store.selectedEmployee = {
-				id: emp[0].id,
-				firstName: this.user.firstName,
-				lastName: this.user.lastName,
-				imageUrl: this.user.imageUrl
-			};
+			if (emp && emp.length > 0) {
+				this.store.selectedEmployee = {
+					id: emp[0].id,
+					firstName: this.user.firstName,
+					lastName: this.user.lastName,
+					imageUrl: this.user.imageUrl
+				};
+			} else {
+				this.store.selectedEmployee = NO_EMPLOYEE_SELECTED;
+			}
 		}
 	}
 }

--- a/apps/gauzy/src/app/pages/expenses/expenses.component.ts
+++ b/apps/gauzy/src/app/pages/expenses/expenses.component.ts
@@ -440,11 +440,13 @@ export class ExpensesComponent implements OnInit, OnDestroy {
 				this.getTranslation('TOASTR.TITLE.ERROR')
 			);
 		}
-		this.employeeName = (
-			this.store.selectedEmployee.firstName +
-			' ' +
-			this.store.selectedEmployee.lastName
-		).trim();
+		this.employeeName = this.store.selectedEmployee
+			? (
+					this.store.selectedEmployee.firstName +
+					' ' +
+					this.store.selectedEmployee.lastName
+			  ).trim()
+			: '';
 	}
 
 	getTranslation(prefix: string, params?: Object) {

--- a/apps/gauzy/src/app/pages/income/income.component.ts
+++ b/apps/gauzy/src/app/pages/income/income.component.ts
@@ -356,11 +356,13 @@ export class IncomeComponent implements OnInit, OnDestroy {
 			findObj,
 			this.selectedDate
 		);
-		this.employeeName = (
-			this.store.selectedEmployee.firstName +
-			' ' +
-			this.store.selectedEmployee.lastName
-		).trim();
+		this.employeeName = this.store.selectedEmployee
+			? (
+					this.store.selectedEmployee.firstName +
+					' ' +
+					this.store.selectedEmployee.lastName
+			  ).trim()
+			: '';
 		this.smartTableSource.load(items);
 		this.showTable = true;
 	}


### PR DESCRIPTION
For #397 
1. Fixed application crash when a non-employee user logs in without the change selected employee permission.
2. Created two default constants called `ALL_EMPLOYEES_SELECTED` and `NO_EMPLOYEE_SELECTED`
3. Also created an enum `DEFAULT_TYPE` with two values `ALL_EMPLOYEE` and `NO_EMPLOYEE`
4. Removed code to select `All Employees` if selected employee is null from store

We need to handle the `No Employee` selection in all pages, created a ticket #563 for that