### PR TITLE
feat: #397 data entry dashboard with shortcuts

### DIFF
--- a/apps/gauzy/src/app/pages/dashboard/dashboard.component.html
+++ b/apps/gauzy/src/app/pages/dashboard/dashboard.component.html
@@ -1,19 +1,10 @@
-<nb-spinner *ngIf="loading"> </nb-spinner>
-
-<div *ngIf="!loading">
-	<div
-		*ngIf="
-			selectedEmployee && selectedEmployee.id;
-			then employeeStats;
-			else orgEmployees
-		"
-	></div>
+<div [ngSwitch]="dashboardType">
+	<ga-organization-employees *ngSwitchCase="'ORGANIZATION_EMPLOYEES'">
+	</ga-organization-employees>
+	<ga-employee-statistics *ngSwitchCase="'EMPLOYEE_STATISTICS'">
+	</ga-employee-statistics>
+	<ga-data-entry-shortcuts
+		*ngSwitchCase="'DATA_ENTRY_SHORTCUTS'"
+	></ga-data-entry-shortcuts>
+	<nb-spinner *ngSwitchDefault> </nb-spinner>
 </div>
-
-<ng-template #employeeStats>
-	<ga-employee-statistics> </ga-employee-statistics>
-</ng-template>
-
-<ng-template #orgEmployees>
-	<ga-organization-employees> </ga-organization-employees>
-</ng-template>

--- a/apps/gauzy/src/app/pages/dashboard/dashboard.component.ts
+++ b/apps/gauzy/src/app/pages/dashboard/dashboard.component.ts
@@ -1,8 +1,16 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
-import { SelectedEmployee } from '../../@theme/components/header/selectors/employee/employee.component';
-import { Store } from '../../@core/services/store.service';
-import { takeUntil } from 'rxjs/operators';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { PermissionsEnum } from '@gauzy/models';
 import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { Store } from '../../@core/services/store.service';
+import { SelectedEmployee } from '../../@theme/components/header/selectors/employee/employee.component';
+
+enum DASHBOARD_TYPES {
+	LOADING = 'LOADING',
+	ORGANIZATION_EMPLOYEES = 'ORGANIZATION_EMPLOYEES',
+	EMPLOYEE_STATISTICS = 'EMPLOYEE_STATISTICS',
+	DATA_ENTRY_SHORTCUTS = 'DATA_ENTRY_SHORTCUTS'
+}
 
 @Component({
 	templateUrl: './dashboard.component.html',
@@ -12,19 +20,35 @@ export class DashboardComponent implements OnInit, OnDestroy {
 	private _ngDestroy$ = new Subject<void>();
 
 	selectedEmployee: SelectedEmployee;
-	loading = true;
+
+	dashboardType = DASHBOARD_TYPES.LOADING;
 
 	constructor(private store: Store) {}
 
 	ngOnInit(): void {
-		this.store.selectedEmployee$
+		this.store.userRolePermissions$
 			.pipe(takeUntil(this._ngDestroy$))
-			.subscribe((emp) => {
-				if (emp) {
-					this.loading = false;
-					this.selectedEmployee = emp;
-				}
+			.subscribe(() => {
+				this.store.selectedEmployee$
+					.pipe(takeUntil(this._ngDestroy$))
+					.subscribe((emp) => {
+						if (emp) {
+							this._loadDashboard(emp);
+						}
+					});
 			});
+	}
+
+	_loadDashboard(emp: SelectedEmployee) {
+		if (this.store.hasPermission(PermissionsEnum.ADMIN_DASHBOARD_VIEW)) {
+			this.selectedEmployee = emp;
+			this.dashboardType =
+				emp && emp.id
+					? DASHBOARD_TYPES.EMPLOYEE_STATISTICS
+					: DASHBOARD_TYPES.ORGANIZATION_EMPLOYEES;
+		} else {
+			this.dashboardType = DASHBOARD_TYPES.DATA_ENTRY_SHORTCUTS;
+		}
 	}
 
 	ngOnDestroy() {

--- a/apps/gauzy/src/app/pages/dashboard/dashboard.module.ts
+++ b/apps/gauzy/src/app/pages/dashboard/dashboard.module.ts
@@ -1,33 +1,34 @@
-import { DashboardComponent } from './dashboard.component';
+import { HttpClient } from '@angular/common/http';
 import { NgModule } from '@angular/core';
-import { DashboardRoutingModule } from './dashboard-routing.module';
-import { ThemeModule } from '../../@theme/theme.module';
+import { FormsModule } from '@angular/forms';
 import {
-	NbCardModule,
+	NbAlertModule,
 	NbButtonModule,
-	NbInputModule,
+	NbCardModule,
 	NbDialogModule,
-	NbTreeGridModule,
 	NbIconModule,
-	NbTooltipModule,
+	NbInputModule,
 	NbSpinnerModule,
-	NbAlertModule
+	NbTooltipModule,
+	NbTreeGridModule
 } from '@nebular/theme';
 import { NgSelectModule } from '@ng-select/ng-select';
-import { FormsModule } from '@angular/forms';
-import { IncomeService } from '../../@core/services/income.service';
-import { ExpensesService } from '../../@core/services/expenses.service';
-import { AuthService } from '../../@core/services/auth.service';
-import { RecordsHistoryModule } from '../../@shared/dashboard/records-history/records-history.module';
-import { ChartModule } from 'angular2-chartjs';
-import { HttpClient } from '@angular/common/http';
-import { TranslateModule, TranslateLoader } from '@ngx-translate/core';
+import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
-import { EmployeeChartComponent } from './employee-chart/employee-chart.component';
+import { ChartModule } from 'angular2-chartjs';
+import { AuthService } from '../../@core/services/auth.service';
+import { ExpensesService } from '../../@core/services/expenses.service';
+import { IncomeService } from '../../@core/services/income.service';
 import { ProfitHistoryModule } from '../../@shared/dashboard/profit-history/profit-history.module';
-import { OrganizationEmployeesComponent } from './organization-employees/organization-employees.component';
+import { RecordsHistoryModule } from '../../@shared/dashboard/records-history/records-history.module';
 import { SingleStatisticModule } from '../../@shared/single-statistic/single-statistic.module';
+import { ThemeModule } from '../../@theme/theme.module';
+import { DashboardRoutingModule } from './dashboard-routing.module';
+import { DashboardComponent } from './dashboard.component';
+import { DataEntryShortcutsComponent } from './data-entry-shortcuts/data-entry-shortcuts.component';
+import { EmployeeChartComponent } from './employee-chart/employee-chart.component';
 import { EmployeeStatisticsComponent } from './employee-statistics/employee-statistics.component';
+import { OrganizationEmployeesComponent } from './organization-employees/organization-employees.component';
 
 export function HttpLoaderFactory(http: HttpClient) {
 	return new TranslateHttpLoader(http, './assets/i18n/', '.json');
@@ -65,7 +66,8 @@ export function HttpLoaderFactory(http: HttpClient) {
 		DashboardComponent,
 		EmployeeChartComponent,
 		OrganizationEmployeesComponent,
-		EmployeeStatisticsComponent
+		EmployeeStatisticsComponent,
+		DataEntryShortcutsComponent
 	],
 	providers: [IncomeService, ExpensesService, AuthService]
 })

--- a/apps/gauzy/src/app/pages/dashboard/data-entry-shortcuts/data-entry-shortcuts.component.html
+++ b/apps/gauzy/src/app/pages/dashboard/data-entry-shortcuts/data-entry-shortcuts.component.html
@@ -1,0 +1,45 @@
+<nb-card>
+	<nb-card-header class="header">Data Entry Shortcuts</nb-card-header>
+	<nb-card-body class="body">
+		<div class="row">
+			<div class="col-4" *ngIf="hasPermissionI && hasPermissionIEdit">
+				<nb-card
+					status="success"
+					class="shortcut-card"
+					(click)="addIncome()"
+				>
+					<nb-card-header>
+						<nb-icon icon="plus-circle"></nb-icon>
+						{{ 'MENU.INCOME' | translate }}
+					</nb-card-header>
+					<nb-card-body>
+						<div class="shortcut">
+							<div>
+								{{ 'DASHBOARD_PAGE.ADD_INCOME' | translate }}
+							</div>
+						</div>
+					</nb-card-body>
+				</nb-card>
+			</div>
+			<div class="col-4" *ngIf="hasPermissionE && hasPermissionEEdit">
+				<nb-card
+					status="danger"
+					class="shortcut-card"
+					(click)="addExpense()"
+				>
+					<nb-card-header>
+						<nb-icon icon="minus-circle"></nb-icon>
+						{{ 'MENU.EXPENSES' | translate }}
+					</nb-card-header>
+					<nb-card-body>
+						<div class="shortcut" class="shortcut">
+							<div>
+								{{ 'DASHBOARD_PAGE.ADD_EXPENSE' | translate }}
+							</div>
+						</div>
+					</nb-card-body>
+				</nb-card>
+			</div>
+		</div>
+	</nb-card-body>
+</nb-card>

--- a/apps/gauzy/src/app/pages/dashboard/data-entry-shortcuts/data-entry-shortcuts.component.scss
+++ b/apps/gauzy/src/app/pages/dashboard/data-entry-shortcuts/data-entry-shortcuts.component.scss
@@ -1,0 +1,13 @@
+.shortcut-card {
+	&:hover {
+		box-shadow: 0 2px 9px 0 rgba(0, 0, 0, 0.26);
+		transform: translateY(-1px);
+	}
+	cursor: pointer;
+	.shortcut {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		padding: 50px 0px;
+	}
+}

--- a/apps/gauzy/src/app/pages/dashboard/data-entry-shortcuts/data-entry-shortcuts.component.ts
+++ b/apps/gauzy/src/app/pages/dashboard/data-entry-shortcuts/data-entry-shortcuts.component.ts
@@ -1,0 +1,57 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Subject } from 'rxjs';
+import { Router } from '@angular/router';
+import { Store } from '../../../@core/services/store.service';
+import { takeUntil } from 'rxjs/operators';
+import { PermissionsEnum } from '@gauzy/models';
+
+@Component({
+	selector: 'ga-data-entry-shortcuts',
+	templateUrl: './data-entry-shortcuts.component.html',
+	styleUrls: ['./data-entry-shortcuts.component.scss']
+})
+export class DataEntryShortcutsComponent implements OnInit, OnDestroy {
+	private _ngDestroy$ = new Subject<void>();
+
+	constructor(
+		private readonly router: Router,
+		private readonly store: Store
+	) {}
+
+	hasPermissionE = false;
+	hasPermissionI = false;
+	hasPermissionIEdit = false;
+	hasPermissionEEdit = false;
+
+	async ngOnInit() {
+		this.store.userRolePermissions$
+			.pipe(takeUntil(this._ngDestroy$))
+			.subscribe(() => {
+				this.hasPermissionE = this.store.hasPermission(
+					PermissionsEnum.ORG_EXPENSES_VIEW
+				);
+				this.hasPermissionI = this.store.hasPermission(
+					PermissionsEnum.ORG_INCOMES_VIEW
+				);
+				this.hasPermissionEEdit = this.store.hasPermission(
+					PermissionsEnum.ORG_EXPENSES_EDIT
+				);
+				this.hasPermissionIEdit = this.store.hasPermission(
+					PermissionsEnum.ORG_INCOMES_EDIT
+				);
+			});
+	}
+
+	async addIncome() {
+		this.router.navigateByUrl('pages/income?openAddDialog=true');
+	}
+
+	async addExpense() {
+		this.router.navigateByUrl('pages/expenses?openAddDialog=true');
+	}
+
+	ngOnDestroy() {
+		this._ngDestroy$.next();
+		this._ngDestroy$.complete();
+	}
+}

--- a/apps/gauzy/src/app/pages/pages.component.ts
+++ b/apps/gauzy/src/app/pages/pages.component.ts
@@ -34,8 +34,7 @@ export class PagesComponent implements OnInit, OnDestroy {
 			home: true,
 			data: {
 				translated: false,
-				translationKey: 'MENU.DASHBOARD',
-				permissionKeys: [PermissionsEnum.ADMIN_DASHBOARD_VIEW]
+				translationKey: 'MENU.DASHBOARD'
 			}
 		},
 		{

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -278,7 +278,9 @@
 			"PROFIT_CALC": "Profit (Net Income) = Total Income - Total Expenses",
 			"NOTE": "Note: negative bonuses should be deducted in the upcoming months from the positive bonuses before final bonus payments",
 			"BONUS": "Bonus"
-		}
+		},
+		"ADD_INCOME": "Add New Income Entry",
+		"ADD_EXPENSE": "Add New Expense Entry"
 	},
 	"INCOME_PAGE": {
 		"INCOME": "Income",


### PR DESCRIPTION
For #397 

<img width="1678" alt="Screen Shot 2020-02-13 at 5 41 43 PM" src="https://user-images.githubusercontent.com/6750734/74435656-f1f46300-4e8a-11ea-80fe-b7a8b4286b22.png">

What's new
1. A new dashboard that is visible to people who do not have access to the Admin Dashboard, which is basically our 'shortcut' dashboard which will display shortcuts to add/remove items like Expenses, Income, etc based on permissions.
2. Removed the 'dashboard' check from the sidebar, since no matter what role, they will always have a dashboard

This completes the basic 'structure' for supporting multiple roles through permissions within the system.