### PR TITLE
feat: #433 invite expiry setting and permission

### DIFF
--- a/apps/api/src/app/organization/organization.entity.ts
+++ b/apps/api/src/app/organization/organization.entity.ts
@@ -16,7 +16,8 @@ import {
 	IsEnum,
 	IsNumber,
 	Min,
-	Max
+	Max,
+	IsBoolean
 } from 'class-validator';
 import { Base } from '../core/entities/base';
 import {
@@ -169,4 +170,14 @@ export class Organization extends Base implements IOrganization {
 	@Max(100)
 	@Column({ nullable: true })
 	bonusPercentage?: number;
+
+	@ApiProperty({ type: Boolean })
+	@IsBoolean()
+	@Column({ nullable: true })
+	invitesAllowed?: boolean;
+
+	@ApiProperty({ type: Number })
+	@IsNumber()
+	@Column({ nullable: true })
+	inviteExpiryPeriod?: number;
 }

--- a/apps/api/src/app/role-permissions/role-permissions.seed.ts
+++ b/apps/api/src/app/role-permissions/role-permissions.seed.ts
@@ -28,7 +28,9 @@ const defaultRolePermissions = [
 			PermissionsEnum.POLICY_VIEW,
 			PermissionsEnum.CHANGE_SELECTED_EMPLOYEE,
 			PermissionsEnum.CHANGE_SELECTED_ORGANIZATION,
-			PermissionsEnum.CHANGE_ROLES_PERMISSIONS
+			PermissionsEnum.CHANGE_ROLES_PERMISSIONS,
+			PermissionsEnum.ORG_INVITE_VIEW,
+			PermissionsEnum.ORG_INVITE_EDIT
 		]
 	},
 	{

--- a/apps/gauzy/src/app/@shared/invite/invites/invites.component.html
+++ b/apps/gauzy/src/app/@shared/invite/invites/invites.component.html
@@ -6,7 +6,7 @@
 		</h4>
 	</nb-card-header>
 	<nb-card-body>
-		<div class="mb-3">
+		<div *ngIf="hasInviteEditPermission" class="mb-3">
 			<button nbButton status="primary" (click)="invite()" class="mr-2">
 				<nb-icon class="mr-1" icon="email-outline"></nb-icon
 				>{{ 'BUTTONS.INVITE' | translate }}

--- a/apps/gauzy/src/app/@shared/invite/invites/invites.component.ts
+++ b/apps/gauzy/src/app/@shared/invite/invites/invites.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { InvitationTypeEnum, RolesEnum } from '@gauzy/models';
+import { InvitationTypeEnum, RolesEnum, PermissionsEnum } from '@gauzy/models';
 import { NbDialogService, NbToastrService } from '@nebular/theme';
 import { TranslateService } from '@ngx-translate/core';
 import { LocalDataSource } from 'ng2-smart-table';
@@ -50,6 +50,8 @@ export class InvitesComponent implements OnInit, OnDestroy {
 
 	loading = true;
 
+	hasInviteEditPermission = false;
+
 	@ViewChild('employeesTable', { static: false }) employeesTable;
 
 	constructor(
@@ -68,6 +70,13 @@ export class InvitesComponent implements OnInit, OnDestroy {
 					this.selectedOrganizationId = organization.id;
 					this.loadPage();
 				}
+			});
+		this.store.userRolePermissions$
+			.pipe(takeUntil(this._ngDestroy$))
+			.subscribe(() => {
+				this.hasInviteEditPermission = this.store.hasPermission(
+					PermissionsEnum.ORG_INVITE_EDIT
+				);
 			});
 
 		this._loadSmartTableSettings();

--- a/apps/gauzy/src/app/pages/employees/employees.component.html
+++ b/apps/gauzy/src/app/pages/employees/employees.component.html
@@ -16,7 +16,13 @@
 	</nb-card-header>
 	<nb-card-body>
 		<div class="mb-3" *ngIf="hasEditPermission">
-			<button nbButton status="primary" (click)="invite()" class="mr-2">
+			<button
+				nbButton
+				*ngIf="hasInviteEditPermission"
+				status="primary"
+				(click)="invite()"
+				class="mr-2"
+			>
 				<nb-icon class="mr-1" icon="email-outline"></nb-icon
 				>{{ 'BUTTONS.INVITE' | translate }}
 			</button>

--- a/apps/gauzy/src/app/pages/employees/employees.component.ts
+++ b/apps/gauzy/src/app/pages/employees/employees.component.ts
@@ -62,6 +62,7 @@ export class EmployeesComponent implements OnInit, OnDestroy {
 	includeDeleted = false;
 	loading = true;
 	hasEditPermission = false;
+	hasInviteEditPermission = false;
 
 	@ViewChild('employeesTable', { static: false }) employeesTable;
 
@@ -83,6 +84,9 @@ export class EmployeesComponent implements OnInit, OnDestroy {
 			.subscribe(() => {
 				this.hasEditPermission = this.store.hasPermission(
 					PermissionsEnum.ORG_EMPLOYEES_EDIT
+				);
+				this.hasInviteEditPermission = this.store.hasPermission(
+					PermissionsEnum.ORG_INVITE_EDIT
 				);
 			});
 

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.html
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.html
@@ -279,6 +279,66 @@
 			</div>
 		</nb-card-body>
 	</nb-card>
+
+	<nb-card>
+		<nb-card-header>
+			{{ 'ORGANIZATIONS_PAGE.EDIT.INVITE' | translate }}
+		</nb-card-header>
+		<nb-card-body>
+			<div class="fields">
+				<div class="row">
+					<div class="col-6">
+						<div class="form-group invite-toggle">
+							<label class="label">
+								{{
+									'FORM.LABELS.ENABLE_DISABLE_INVITES'
+										| translate
+								}}
+							</label>
+							<nb-toggle
+								class="d-block"
+								formControlName="invitesAllowed"
+								status="primary"
+								labelPosition="start"
+								(checkedChange)="toggleExpiry($event)"
+							>
+								{{
+									'FORM.LABELS.ALLOW_USER_INVITES' | translate
+								}}
+							</nb-toggle>
+						</div>
+					</div>
+					<div class="col-6">
+						<div class="form-group">
+							<label class="label">
+								{{
+									'FORM.LABELS.INVITE_EXPIRY_PERIOD'
+										| translate
+								}}
+							</label>
+							<input
+								nbInput
+								type="number"
+								formControlName="inviteExpiryPeriod"
+								placeholder="{{
+									'FORM.PLACEHOLDERS.INVITE_EXPIRY_PERIOD'
+										| translate
+								}}"
+								fullWidth
+								class="d-block"
+								[ngClass]="{
+									'status-danger': form.get(
+										'inviteExpiryPeriod'
+									).invalid
+								}"
+							/>
+						</div>
+					</div>
+				</div>
+			</div>
+		</nb-card-body>
+	</nb-card>
+
 	<div class="actions">
 		<button
 			[disabled]="this.form.invalid"

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.scss
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.scss
@@ -6,3 +6,14 @@
 	display: flex;
 	padding: 50px 0px;
 }
+
+.invite-toggle {
+	nb-toggle {
+		display: flex;
+		::ng-deep .toggle-label {
+			display: flex;
+			justify-content: space-between;
+			flex-grow: 1;
+		}
+	}
+}

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.ts
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.ts
@@ -161,8 +161,21 @@ export class EditOrganizationOtherSettingsComponent
 			bonusPercentage: [
 				this.organization.bonusPercentage || 75,
 				[Validators.min(0), Validators.max(100)]
+			],
+			invitesAllowed: [this.organization.invitesAllowed || false],
+			inviteExpiryPeriod: [
+				{
+					value: this.organization.inviteExpiryPeriod || 7,
+					disabled: !this.organization.invitesAllowed
+				},
+				[Validators.min(1)]
 			]
 		});
+	}
+
+	toggleExpiry(checked) {
+		const inviteExpiryControl = this.form.get('inviteExpiryPeriod');
+		checked ? inviteExpiryControl.enable() : inviteExpiryControl.disable();
 	}
 
 	ngOnDestroy() {

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-settings.module.ts
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-settings.module.ts
@@ -13,7 +13,8 @@ import {
 	NbRouteTabsetModule,
 	NbSelectModule,
 	NbSpinnerModule,
-	NbTabsetModule
+	NbTabsetModule,
+	NbToggleModule
 } from '@nebular/theme';
 import { NgSelectModule } from '@ng-select/ng-select';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
@@ -82,6 +83,7 @@ import { EditOrganizationProjectsMutationComponent } from './edit-organization-p
 		NbTabsetModule,
 		NbRouteTabsetModule,
 		NbDatepickerModule,
+		NbToggleModule,
 		EmployeeSelectorsModule,
 		EntityWithMembersModule,
 		EmployeeMultiSelectModule

--- a/apps/gauzy/src/app/pages/users/users.component.html
+++ b/apps/gauzy/src/app/pages/users/users.component.html
@@ -16,7 +16,13 @@
 	</nb-card-header>
 	<nb-card-body>
 		<div class="mb-3" *ngIf="hasEditPermission">
-			<button nbButton status="primary" (click)="invite()" class="mr-2">
+			<button
+				nbButton
+				*ngIf="hasInviteEditPermission"
+				status="primary"
+				(click)="invite()"
+				class="mr-2"
+			>
 				<nb-icon class="mr-1" icon="email-outline"></nb-icon
 				>{{ 'BUTTONS.INVITE' | translate }}
 			</button>

--- a/apps/gauzy/src/app/pages/users/users.component.ts
+++ b/apps/gauzy/src/app/pages/users/users.component.ts
@@ -44,6 +44,7 @@ export class UsersComponent implements OnInit, OnDestroy {
 
 	loading = true;
 	hasEditPermission = false;
+	hasInviteEditPermission = false;
 
 	@ViewChild('usersTable', { static: false }) usersTable;
 
@@ -75,6 +76,9 @@ export class UsersComponent implements OnInit, OnDestroy {
 			.subscribe(() => {
 				this.hasEditPermission = this.store.hasPermission(
 					PermissionsEnum.ORG_USERS_EDIT
+				);
+				this.hasInviteEditPermission = this.store.hasPermission(
+					PermissionsEnum.ORG_INVITE_EDIT
 				);
 			});
 

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -118,7 +118,10 @@
 			"ADD_NEW_DEPARTMENT": "Add New Department",
 			"EDIT_DEPARTMENT": "Edit Department",
 			"TYPE_OF_BONUS": "Bonus Type",
-			"BONUS_PERCENTAGE": "Bonus Percentage"
+			"BONUS_PERCENTAGE": "Bonus Percentage",
+			"ENABLE_DISABLE_INVITES": "Enable/Disable Invites",
+			"ALLOW_USER_INVITES": "Allow Users to send invites",
+			"INVITE_EXPIRY_PERIOD": "Invite Expiry Period (in Days)"
 		},
 		"PLACEHOLDERS": {
 			"NAME": "Name",
@@ -171,7 +174,9 @@
 			"VALUE": "Value",
 			"SELECT_CURRENCY": "Select Currency",
 			"TYPE_OF_BONUS": "Type of Bonus",
-			"BONUS_PERCENTAGE": "Bonus Percentage"
+			"BONUS_PERCENTAGE": "Bonus Percentage",
+			"ENABLE_INVITES": "Enable Invites",
+			"INVITE_EXPIRY_PERIOD": "Invites valid upto"
 		},
 		"RATES": {
 			"DEFAULT_RATE": "Default Rate",
@@ -360,6 +365,7 @@
 			"GENERAL_SETTINGS": "General Settings",
 			"DESIGN": "Design",
 			"BONUS": "Bonus",
+			"INVITE": "Invites",
 			"CLICK_EMPLOYEE": "Click to edit employee",
 			"EDIT_PROJECT": "Edit Project",
 			"REGIONS": "Regions",
@@ -378,6 +384,8 @@
 			"ORG_EMPLOYEES_EDIT": "Create/Edit/Delete Organization Employees",
 			"ORG_USERS_VIEW": "View Organization Users",
 			"ORG_USERS_EDIT": "Create/Edit/Delete Organization Users",
+			"ORG_INVITE_VIEW": "View Organization Invites",
+			"ORG_INVITE_EDIT": "Create/Resend/Delete Invites",
 			"ALL_ORG_VIEW": "View All Organizations",
 			"ALL_ORG_EDIT": "Create/Edit/Delete All Organizations",
 			"POLICY_VIEW": "View Time Off Policy",

--- a/libs/models/src/lib/organization.model.ts
+++ b/libs/models/src/lib/organization.model.ts
@@ -27,6 +27,8 @@ export interface Organization extends IBaseEntityModel {
 	bonusType?: string;
 	bonusPercentage?: number;
 	tenant: Tenant;
+	invitesAllowed?: boolean;
+	inviteExpiryPeriod?: number;
 }
 
 export interface OrganizationFindInput extends IBaseEntityModel {

--- a/libs/models/src/lib/role-permission.model.ts
+++ b/libs/models/src/lib/role-permission.model.ts
@@ -31,6 +31,8 @@ export enum PermissionsEnum {
 	ORG_EMPLOYEES_EDIT = 'ORG_EMPLOYEES_EDIT',
 	ORG_USERS_VIEW = 'ORG_USERS_VIEW',
 	ORG_USERS_EDIT = 'ORG_USERS_EDIT',
+	ORG_INVITE_VIEW = 'ORG_INVITE_VIEW',
+	ORG_INVITE_EDIT = 'ORG_INVITE_EDIT',
 	ALL_ORG_VIEW = 'ALL_ORG_VIEW',
 	ALL_ORG_EDIT = 'ALL_ORG_EDIT',
 	POLICY_VIEW = 'POLICY_VIEW',
@@ -50,9 +52,11 @@ export const PermissionGroups = {
 		PermissionsEnum.ORG_INCOMES_VIEW,
 		PermissionsEnum.ORG_PROPOSALS_EDIT,
 		PermissionsEnum.ORG_PROPOSALS_VIEW,
-    PermissionsEnum.ORG_TIME_OFF_VIEW,
-    PermissionsEnum.POLICY_VIEW,
-    PermissionsEnum.POLICY_EDIT
+		PermissionsEnum.ORG_TIME_OFF_VIEW,
+		PermissionsEnum.ORG_INVITE_VIEW,
+		PermissionsEnum.ORG_INVITE_EDIT,
+		PermissionsEnum.POLICY_VIEW,
+		PermissionsEnum.POLICY_EDIT
 	],
 
 	//Readonly permissions, are only enabled for admin role


### PR DESCRIPTION
1. Under Organization > Edit Organization > Settings, added fields to enable or disable invites for the selected organization and an invite expiry period field defaulting to 7 days.
![image](https://user-images.githubusercontent.com/32574315/74904724-894d3f00-53d2-11ea-82aa-dcf7fa545bd3.png)
2. Under Settings> Roles & Permissions, the General panel now contains 2 new permissions to view and edit the invites.
![image](https://user-images.githubusercontent.com/32574315/74905061-3fb12400-53d3-11ea-8202-a5455b3d2f30.png)
3. Invite button in Employee and User Tab is displayed only if the user has edit permission.
![image](https://user-images.githubusercontent.com/32574315/74907189-e3e99980-53d8-11ea-90e0-69400d8d5da0.png)

![image](https://user-images.githubusercontent.com/32574315/74907241-ff54a480-53d8-11ea-8348-e73c1e55498d.png)

4. Manage invites page does not show Invite, Copy Link, Resend and Delete buttons if the user does not have invite edit permission.

![image](https://user-images.githubusercontent.com/32574315/74907296-16939200-53d9-11ea-8e2a-3eff56435fd3.png)

5. Added permission guards in the backend to prevent users from creating, resending or deleting invites when edit permission is revoked for the user.
![image](https://user-images.githubusercontent.com/32574315/74907523-83a72780-53d9-11ea-8745-9f50522ead17.png)


Todo:
Use the newly inviteExpiryPeriod from the organization table to calculate the validity of invites.
Disable invites page for users who do not have 'view invite' permission.
 