### PR TITLE
fix: #600 email template seeding in Windows

### DIFF
--- a/apps/api/src/app/email-template/email-template.seed.ts
+++ b/apps/api/src/app/email-template/email-template.seed.ts
@@ -49,7 +49,7 @@ const pathToEmailTemplate = async (
 	fullPath: string
 ): Promise<EmailTemplate> => {
 	const template = new EmailTemplate();
-	const templatePath = path.split('/');
+	const templatePath = path.replace(/\\/g, '/').split('/');
 	if (templatePath.length !== 3) {
 		return;
 	}


### PR DESCRIPTION
The path string in Windows FS looks like `password\\bg\\html.mjml` and the same in Linux based FS is `password/bg/html.mjml`
The string was split on `/` to extract the file extension which worked fine in Mac and Linux but not on windows. 
Have added fix to replace `\\` in the string to `/` and the email_template table is seeding as expected.

![image](https://user-images.githubusercontent.com/32574315/75094910-878fa100-55b5-11ea-8154-819df4133bec.png)