### PR TITLE
fix: #613 #591 dashboard loading issue

### DIFF
--- a/apps/gauzy/src/app/pages/dashboard/dashboard.component.ts
+++ b/apps/gauzy/src/app/pages/dashboard/dashboard.component.ts
@@ -32,14 +32,12 @@ export class DashboardComponent implements OnInit, OnDestroy {
 				this.store.selectedEmployee$
 					.pipe(takeUntil(this._ngDestroy$))
 					.subscribe((emp) => {
-						if (emp) {
-							this._loadDashboard(emp);
-						}
+						this._loadDashboard(emp);
 					});
 			});
 	}
 
-	_loadDashboard(emp: SelectedEmployee) {
+	_loadDashboard(emp?: SelectedEmployee) {
 		if (this.store.hasPermission(PermissionsEnum.ADMIN_DASHBOARD_VIEW)) {
 			this.selectedEmployee = emp;
 			this.dashboardType =


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

Fixes #613 
Fixes #591 

1. Removed the `if(emp)` check from dashboard component so that dashboard always loads even when emp is null, which happens when we switch over from editing an organization or a page where the organization is changed
2. This results in a slight flicker in the dashboard when an employee logs in, which we will need to see how to remove later.