### PR TITLE
feat: #467 bonus and statistics improvements

### DIFF
--- a/apps/gauzy/src/app/@shared/dashboard/info-block/info-block.component.html
+++ b/apps/gauzy/src/app/@shared/dashboard/info-block/info-block.component.html
@@ -1,4 +1,7 @@
-<div class="info-block" (click)="handleClick()">
+<div
+	class="info-block {{ blockType && 'info-block--' + blockType }}"
+	(click)="handleClick()"
+>
 	<div class="info-text">
 		{{ title }}
 		<div *ngIf="meta" class="meta-text">

--- a/apps/gauzy/src/app/@shared/dashboard/info-block/info-block.component.scss
+++ b/apps/gauzy/src/app/@shared/dashboard/info-block/info-block.component.scss
@@ -38,4 +38,9 @@
 	.meta-text {
 		font-size: 10px;
 	}
+
+	&--highlight {
+		background: #cacaca;
+		font-weight: 600;
+	}
 }

--- a/apps/gauzy/src/app/@shared/dashboard/info-block/info-block.component.ts
+++ b/apps/gauzy/src/app/@shared/dashboard/info-block/info-block.component.ts
@@ -10,6 +10,7 @@ export class InfoBlockComponent {
 	@Input() meta: string;
 	@Input() value: string;
 	@Input() color: string;
+	@Input() blockType: boolean;
 
 	@Output() openInfo = new EventEmitter<void>();
 

--- a/apps/gauzy/src/app/pages/dashboard/employee-statistics/employee-statistics.component.html
+++ b/apps/gauzy/src/app/pages/dashboard/employee-statistics/employee-statistics.component.html
@@ -30,14 +30,26 @@
 						{{ selectedEmployee.lastName }}</span
 					>
 					<div class="employee-position">
-						{{ 'DASHBOARD_PAGE.DEVELOPER.DEVELOPER' | translate }}
+						{{ 'DASHBOARD_PAGE.DEVELOPER.DEVELOPER' | translate }} |
+						Level A
 					</div>
 				</div>
 			</div>
 
-			<div *ngIf="avarageBonus" class="employee-details">
-				{{ 'DASHBOARD_PAGE.DEVELOPER.AVERAGE_BONUS' | translate }}:
-				{{ avarageBonus | currency: defaultCurrency }}
+			<div>
+				<div
+					*ngIf="totalSalary !== 0"
+					class="employee-details employee-salary"
+				>
+					{{ 'DASHBOARD_PAGE.TITLE.SALARY' | translate }}:
+					{{ expenseCurrency }}
+					{{ totalSalary }}
+				</div>
+
+				<div *ngIf="avarageBonus" class="employee-details">
+					{{ 'DASHBOARD_PAGE.DEVELOPER.AVERAGE_BONUS' | translate }}:
+					{{ avarageBonus | currency: defaultCurrency }}
+				</div>
 			</div>
 		</div>
 
@@ -87,7 +99,18 @@
 						'DASHBOARD_PAGE.DEVELOPER.TOTAL_INCOME' | translate
 					}}"
 					meta="{{
-						'DASHBOARD_PAGE.TITLE.TOTAL_INCOME_CALC' | translate
+						'DASHBOARD_PAGE.TITLE.TOTAL_INCOME_CALC'
+							| translate
+								: {
+										totalNonBonusIncome: incomeCurrency
+											? (totalNonBonusIncome
+											  | currency: incomeCurrency)
+											: totalNonBonusIncome,
+										totalBonusIncome: incomeCurrency
+											? (totalBonusIncome
+											  | currency: incomeCurrency)
+											: totalBonusIncome
+								  }
 					}}"
 					value="{{
 						incomeCurrency
@@ -115,18 +138,6 @@
 				</ga-info-block>
 
 				<ga-info-block
-					*ngIf="totalSalary !== 0"
-					title="{{ 'DASHBOARD_PAGE.TITLE.SALARY' | translate }}"
-					value="{{
-						expenseCurrency
-							? (totalSalary | currency: expenseCurrency)
-							: totalSalary
-					}}"
-					(openInfo)="openHistoryDialog('SALARY')"
-				>
-				</ga-info-block>
-
-				<ga-info-block
 					title="{{
 						'DASHBOARD_PAGE.DEVELOPER.TOTAL_EXPENSES' | translate
 					}}"
@@ -146,14 +157,26 @@
 				<ga-info-block
 					title="{{ 'DASHBOARD_PAGE.DEVELOPER.PROFIT' | translate }}"
 					meta="{{
-						'DASHBOARD_PAGE.DEVELOPER.PROFIT_CALC' | translate
+						'DASHBOARD_PAGE.DEVELOPER.PROFIT_CALC'
+							| translate
+								: {
+										totalAllIncome: incomeCurrency
+											? (totalAllIncome
+											  | currency: incomeCurrency)
+											: totalAllIncome,
+										totalExpense: expenseCurrency
+											? (totalExpense
+											  | currency: expenseCurrency)
+											: totalExpense
+								  }
 					}}"
 					value="{{
 						defaultCurrency
 							? (difference | currency: defaultCurrency)
 							: difference
 					}}"
-					color="{{ difference >= 0 ? '#66de0b' : '#ff7b00' }}"
+					color="{{ difference >= 0 ? '#089c17' : '#ff7b00' }}"
+					blockType="highlight"
 					(openInfo)="openProfitDialog()"
 				>
 				</ga-info-block>
@@ -178,7 +201,10 @@
 				</ga-info-block>
 
 				<ga-info-block
-					*ngIf="bonusType === 'PROFIT_BASED_BONUS' || !bonusType"
+					*ngIf="
+						(bonusType === 'PROFIT_BASED_BONUS' || !bonusType) &&
+						totalBonusIncome !== 0
+					"
 					title="{{
 						'DASHBOARD_PAGE.TITLE.TOTAL_PROFIT_BONUS' | translate
 					}}"
@@ -196,7 +222,10 @@
 				</ga-info-block>
 
 				<ga-info-block
-					*ngIf="bonusType === 'REVENUE_BASED_BONUS'"
+					*ngIf="
+						bonusType === 'REVENUE_BASED_BONUS' &&
+						totalBonusIncome !== 0
+					"
 					title="{{
 						'DASHBOARD_PAGE.TITLE.TOTAL_INCOME_BONUS' | translate
 					}}"
@@ -216,8 +245,15 @@
 
 				<div *ngIf="selectedOrganization?.bonusType" class="bonus">
 					<div class="bonus-value">
-						<div>
+						<div *ngIf="totalBonusIncome !== 0">
 							{{ 'DASHBOARD_PAGE.TITLE.TOTAL_BONUS' | translate }}
+						</div>
+						<div *ngIf="totalBonusIncome === 0">
+							{{
+								'DASHBOARD_PAGE.TITLE.TOTAL_INCOME_BONUS_INFO'
+									| translate
+										: { bonusPercentage: bonusPercentage }
+							}}
 						</div>
 						<div
 							*ngIf="defaultCurrency"

--- a/apps/gauzy/src/app/pages/dashboard/employee-statistics/employee-statistics.component.scss
+++ b/apps/gauzy/src/app/pages/dashboard/employee-statistics/employee-statistics.component.scss
@@ -36,6 +36,12 @@
 				font-size: 14px;
 			}
 		}
+
+		.employee-salary {
+			font-size: 24px;
+			font-weight: bold;
+			color: #0091ff;
+		}
 	}
 }
 

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -285,7 +285,7 @@
 			"TOTAL_DIRECT_INCOME": "Direct Income",
 			"SALARY": "Salary",
 			"TOTAL_DIRECT_INCOME_INFO": "Income from direct bonus",
-			"TOTAL_INCOME_CALC": "Total Income = Income + Direct Income",
+			"TOTAL_INCOME_CALC": "Total Income = Income {{ totalNonBonusIncome }} + Direct Income {{ totalBonusIncome }}",
 			"TOTAL_PROFIT_BONUS": "Total Profit Bonus",
 			"TOTAL_DIRECT_BONUS": "Direct Income Bonus",
 			"TOTAL_DIRECT_BONUS_INFO": "This is equal to the direct income",
@@ -300,7 +300,7 @@
 			"TOTAL_INCOME": "Total Income",
 			"TOTAL_EXPENSES": "Total Expenses",
 			"PROFIT": "Profit",
-			"PROFIT_CALC": "Profit (Net Income) = Total Income - Total Expenses",
+			"PROFIT_CALC": "Profit (Net Income) = Total Income {{ totalAllIncome }} - Total Expenses {{ totalExpense }}",
 			"NOTE": "Note: negative bonuses should be deducted in the upcoming months from the positive bonuses before final bonus payments",
 			"BONUS": "Bonus"
 		},


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

Improvements for #467 

**Following improvements done:**

1. Where we show formulas (e.g. 10% of the income). We can also show how it's calculated, e.g. "10% from income 4100 BGN"
Profit (Net Income) = Total Income 4100 BGN - Total Expenses 3063.64 BGN

2. I would also highlight more Salary //Check the 7th point on what to do with Salary

3. I would also highlight more Profit
(in both salary and Profit best to increase size of font I think
i.e. biggest attention should be drawn to this (in that order):
- top attention - Total Bonus
- next, Profit
- next Salary (because it shows "level" of employee)

4. Ah, also, I would add employee level near Salary
like below "Salary"
we can show "Level A"
hardcode to Level A
like Senior Software Engineer | Level A

7. Move Salary outside, above "Average Monthly Bonus"

8. If it's without direct income bonus, we should hide line "Total Income Bonus" because it duplicates to Total Bonus 

**Not done**

5. Also there more I think it seems better to group things together and make it "+" (i.e. expand)
So we can put Total Income as visible with "+" symbol near to it to expand
and inside show Direct Income and Income values like you did
it's not same as that clickable icon i.e. it should expand below, not open popup with table

6. Add one more row called "Total Expenses without Salary"

9. Btw, it's also the same for Total Bonus if it's Profit based with or without direct bonus - we always need to show below Total Bonus formula how it is calculated. E.g. you have 877.27, but it's not clear right away that it's 100 + 777.27  

---

<img width="1377" alt="Screen Shot 2020-02-29 at 1 18 51 AM" src="https://user-images.githubusercontent.com/6750734/75582393-78b35d80-5a91-11ea-97bf-669fa1fe6223.png">

<img width="1361" alt="Screen Shot 2020-02-29 at 1 19 13 AM" src="https://user-images.githubusercontent.com/6750734/75582408-87017980-5a91-11ea-9d67-f50486fab68d.png">


