### PR TITLE
feat: #467 disable bonus in dashboard if bonus type is none

### DIFF
--- a/apps/gauzy/src/app/pages/dashboard/employee-statistics/employee-statistics.component.html
+++ b/apps/gauzy/src/app/pages/dashboard/employee-statistics/employee-statistics.component.html
@@ -209,7 +209,10 @@
 				</ga-info-block>
 
 				<ga-info-block
-					*ngIf="totalBonusIncome !== 0"
+					*ngIf="
+						selectedOrganization?.bonusType &&
+						totalBonusIncome !== 0
+					"
 					title="{{
 						'DASHBOARD_PAGE.TITLE.TOTAL_DIRECT_BONUS' | translate
 					}}"
@@ -229,7 +232,7 @@
 
 				<ga-info-block
 					*ngIf="
-						(bonusType === 'PROFIT_BASED_BONUS' || !bonusType) &&
+						bonusType === 'PROFIT_BASED_BONUS' &&
 						totalBonusIncome !== 0
 					"
 					title="{{


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

**If bonus is set to None in organization settings then it should also be disabled in the dashboard**

1. With bonus not set to null
<img width="653" alt="Screen Shot 2020-03-04 at 6 06 30 PM" src="https://user-images.githubusercontent.com/6750734/75880263-f2a56700-5e42-11ea-9ccb-1cd13ef95b3a.png">


2. With bonus set to null
<img width="644" alt="Screen Shot 2020-03-04 at 6 06 49 PM" src="https://user-images.githubusercontent.com/6750734/75880272-f5a05780-5e42-11ea-8f5e-90ed94b13aa9.png">

