### PR TITLE
feat: #790 limit period selection to organization registration date

### DIFF
--- a/apps/api/src/app/organization/organization.entity.ts
+++ b/apps/api/src/app/organization/organization.entity.ts
@@ -166,6 +166,12 @@ export class Organization extends LocationBase implements IOrganization {
 	@IsDate()
 	fiscalEndDate?: Date;
 
+	@ApiProperty({ type: Date })
+	@Column({ nullable: true })
+	@IsOptional()
+	@IsDate()
+	registrationDate?: Date;
+
 	@ApiProperty({ type: Boolean })
 	@IsBoolean()
 	@Column({ nullable: true })

--- a/apps/api/src/app/organization/organization.seed.ts
+++ b/apps/api/src/app/organization/organization.seed.ts
@@ -34,6 +34,7 @@ export const createOrganizations = async (
 	defaultOrganization.invitesAllowed = true;
 	defaultOrganization.bonusType = BonusTypeEnum.REVENUE_BASED_BONUS;
 	defaultOrganization.bonusPercentage = 10;
+	defaultOrganization.registrationDate = faker.date.past(5);
 
 	await insertOrganization(connection, defaultOrganization);
 
@@ -56,6 +57,9 @@ export const createOrganizations = async (
 		const { bonusType, bonusPercentage } = randomBonus();
 		organization.bonusType = bonusType;
 		organization.bonusPercentage = bonusPercentage;
+		organization.registrationDate = faker.date.past(
+			Math.floor(Math.random() * 10) + 1
+		);
 
 		await insertOrganization(connection, organization);
 		randomOrganizations.push(organization);

--- a/apps/gauzy/src/app/@theme/components/header/selectors/date/date.component.html
+++ b/apps/gauzy/src/app/@theme/components/header/selectors/date/date.component.html
@@ -17,6 +17,7 @@
 		<nb-calendar-year-picker
 			[year]="date"
 			[max]="max"
+			[min]="min"
 			(yearChange)="handleDateChange($event)"
 		>
 		</nb-calendar-year-picker>
@@ -24,6 +25,7 @@
 			#month
 			[month]="date"
 			[max]="max"
+			[min]="min"
 			(monthChange)="handleDateChange($event)"
 		>
 		</nb-calendar-month-picker>

--- a/apps/gauzy/src/app/@theme/components/header/selectors/date/date.component.ts
+++ b/apps/gauzy/src/app/@theme/components/header/selectors/date/date.component.ts
@@ -1,8 +1,5 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
-import {
-	NbCalendarMonthPickerComponent,
-	NbCalendarYearPickerComponent
-} from '@nebular/theme';
+import { NbCalendarMonthPickerComponent } from '@nebular/theme';
 import { Store } from 'apps/gauzy/src/app/@core/services/store.service';
 import { monthNames } from '../../../../../@core/utils/date';
 import { min, addYears, subYears } from 'date-fns';

--- a/apps/gauzy/src/app/@theme/components/header/selectors/date/date.component.ts
+++ b/apps/gauzy/src/app/@theme/components/header/selectors/date/date.component.ts
@@ -1,8 +1,11 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
-import { NbCalendarMonthPickerComponent } from '@nebular/theme';
+import {
+	NbCalendarMonthPickerComponent,
+	NbCalendarYearPickerComponent
+} from '@nebular/theme';
 import { Store } from 'apps/gauzy/src/app/@core/services/store.service';
 import { monthNames } from '../../../../../@core/utils/date';
-import { min, addYears } from 'date-fns';
+import { min, addYears, subYears } from 'date-fns';
 @Component({
 	selector: 'ga-date-selector',
 	templateUrl: './date.component.html',
@@ -16,6 +19,7 @@ export class DateSelectorComponent implements OnInit {
 	dateInputValue: string;
 	date = new Date();
 	max;
+	min;
 	@ViewChild('month', { static: false })
 	monthRef: NbCalendarMonthPickerComponent<any, any>;
 
@@ -65,6 +69,13 @@ export class DateSelectorComponent implements OnInit {
 			this.store.selectedOrganization.futureDateAllowed
 				? addYears(currentDate.setMonth(11), 10)
 				: currentDate;
+
+		this.min =
+			this.store.selectedOrganization &&
+			this.store.selectedOrganization.registrationDate
+				? new Date(this.store.selectedOrganization.registrationDate)
+				: subYears(currentDate.setMonth(11), 15);
+
 		this.loadCalendar = true;
 	}
 	clear() {

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-main/edit-organization-main.component.html
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-main/edit-organization-main.component.html
@@ -138,6 +138,27 @@
 					</div>
 				</div>
 			</div>
+			<div class="row">
+				<div class="col-6">
+					<div class="form-group">
+						<label class="label" for="registrationDate">{{
+							'FORM.LABELS.REGISTRATION_DATE' | translate
+						}}</label>
+						<input
+							nbInput
+							fullWidth
+							id="registrationDate"
+							placeholder="{{
+								'FORM.PLACEHOLDERS.REGISTRATION_DATE'
+									| translate
+							}}"
+							[nbDatepicker]="registrationDate"
+							formControlName="registrationDate"
+						/>
+						<nb-datepicker #registrationDate></nb-datepicker>
+					</div>
+				</div>
+			</div>
 		</div>
 
 		<div class="actions">

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-main/edit-organization-main.component.ts
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-main/edit-organization-main.component.ts
@@ -94,7 +94,12 @@ export class EditOrganizationMainComponent extends TranslationBaseComponent
 			currency: [this.organization.currency, Validators.required],
 			name: [this.organization.name, Validators.required],
 			officialName: [this.organization.officialName],
-			taxId: [this.organization.taxId]
+			taxId: [this.organization.taxId],
+			registrationDate: [
+				this.organization.registrationDate
+					? new Date(this.organization.registrationDate)
+					: null
+			]
 		});
 	}
 }

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -134,7 +134,8 @@
 			"REJECT_DATE": "Reject Date (optional)",
 			"EMAIL_INVITATION": "Enter email to send invitation",
 			"ENABLE_DISABLE_FUTURE_DATE": "Enable/Disable future dates",
-			"ALLOW_FUTURE_DATE": "Allow switching to future periods"
+			"ALLOW_FUTURE_DATE": "Allow switching to future periods",
+			"REGISTRATION_DATE": "Registration Date"
 		},
 		"PLACEHOLDERS": {
 			"NAME": "Name",
@@ -191,7 +192,8 @@
 			"ENABLE_INVITES": "Enable Invites",
 			"INVITE_EXPIRY_PERIOD": "Invites valid upto",
 			"SWITCH_PROJECT_STATE": "Public",
-			"EMPLOYMENT_TYPES": "Employment Type"
+			"EMPLOYMENT_TYPES": "Employment Type",
+			"REGISTRATION_DATE": "Organization Registration Date"
 		},
 		"RATES": {
 			"DEFAULT_RATE": "Default Rate",

--- a/libs/models/src/lib/organization.model.ts
+++ b/libs/models/src/lib/organization.model.ts
@@ -27,6 +27,7 @@ export interface Organization extends IBaseEntityModel, ILocation {
 	inviteExpiryPeriod?: number;
 	tags: Tag[];
 	futureDateAllowed?: boolean;
+	registrationDate?: Date;
 }
 
 export interface OrganizationFindInput extends IBaseEntityModel {


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
**What got added?**
1. The organization entity has a new field to store the organization registration date.
2. The value of the organization registration date can be updated from the Organization edit page.
3. Seed organization registration date with random past dates.
4. Dates before the selected organization's registration date are disabled for selection through the header component's Period selector.  

**Sample screenshots:**
![image](https://user-images.githubusercontent.com/32574315/76706880-ca561c00-6710-11ea-8156-371e7c79ca85.png)

![image](https://user-images.githubusercontent.com/32574315/76706905-07baa980-6711-11ea-87e4-6ed06355445b.png)
