### PR TITLE
feat: removed position name header if no positions

### DIFF
--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-positions/edit-organization-positions.component.html
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-positions/edit-organization-positions.component.html
@@ -40,7 +40,9 @@
 			>
 		</div>
 	</nb-card-header>
-	<div class="ml-3 mb-4"><strong>Position name</strong></div>
+	<div class="ml-3 mb-4" *ngIf="positionsExist">
+		<strong>Position name</strong>
+	</div>
 
 	<nb-card *ngFor="let p of positions">
 		<nb-card-body>

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-positions/edit-organization-positions.component.ts
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-positions/edit-organization-positions.component.ts
@@ -26,6 +26,8 @@ export class EditOrganizationPositionsComponent extends TranslationBaseComponent
 
 	showEditDiv: boolean;
 
+	positionsExist: boolean;
+
 	constructor(
 		private readonly organizationPositionsService: OrganizationPositionsService,
 		private readonly toastrService: NbToastrService,
@@ -117,6 +119,12 @@ export class EditOrganizationPositionsComponent extends TranslationBaseComponent
 		});
 		if (res) {
 			this.positions = res.items;
+
+			if (this.positions.length <= 0) {
+				this.positionsExist = false;
+			} else {
+				this.positionsExist = true;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Added "positionExists" boolean property and set it to false if 
organizationPositionsService.getAll() in loadPositions() returns empty array and true if not empty. Then added *ngif to Position name header that renders it if positionExists is true.
![Screenshot (19)](https://user-images.githubusercontent.com/25152459/76952294-8c761500-6915-11ea-9610-7af505da494b.png)
![Screenshot (20)](https://user-images.githubusercontent.com/25152459/76952299-8da74200-6915-11ea-9c3c-4a53a173e46a.png)
![Screenshot (21)](https://user-images.githubusercontent.com/25152459/76952300-8e3fd880-6915-11ea-9823-40fa62d982a4.png)


