### PR TITLE
fix: #816 organization split recurring expenses in employee stat chart

### DIFF
--- a/apps/api/src/app/employee-statistics/employee-statistics.module.ts
+++ b/apps/api/src/app/employee-statistics/employee-statistics.module.ts
@@ -12,6 +12,10 @@ import { Organization, OrganizationService } from '../organization';
 import { EmployeeStatisticsController } from './employee-statistics.controller';
 import { EmployeeStatisticsService } from './employee-statistics.service';
 import { QueryHandlers } from './queries/handlers';
+import {
+	OrganizationRecurringExpenseService,
+	OrganizationRecurringExpense
+} from '../organization-recurring-expense';
 
 @Module({
 	imports: [
@@ -20,7 +24,8 @@ import { QueryHandlers } from './queries/handlers';
 			Expense,
 			Employee,
 			Organization,
-			EmployeeRecurringExpense
+			EmployeeRecurringExpense,
+			OrganizationRecurringExpense
 		]),
 		CqrsModule
 	],
@@ -32,6 +37,7 @@ import { QueryHandlers } from './queries/handlers';
 		EmployeeService,
 		OrganizationService,
 		EmployeeRecurringExpenseService,
+		OrganizationRecurringExpenseService,
 		...QueryHandlers
 	],
 	exports: [EmployeeStatisticsService]


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
What got added?
The organization's split expenses were not taken into account for calculating the employee's expense in the employee-statistics chart. This has now been added.

2 new issues(#822 #825) were identified during the implementation of this ticket, which makes the discrepancies still exist between the calculations shown in the chart and employee statistics. Fixing these issues will help overcome these discrepancies.
