### PR TITLE
feat: #790 removed shared date object to avoid side effects

### DIFF
--- a/apps/gauzy/src/app/@theme/components/header/selectors/date/date.component.ts
+++ b/apps/gauzy/src/app/@theme/components/header/selectors/date/date.component.ts
@@ -71,7 +71,7 @@ export class DateSelectorComponent implements OnInit {
 			this.store.selectedOrganization &&
 			this.store.selectedOrganization.registrationDate
 				? new Date(this.store.selectedOrganization.registrationDate)
-				: subYears(currentDate.setMonth(11), 15);
+				: subYears(new Date().setMonth(11), 15);
 
 		this.loadCalendar = true;
 	}


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
What got changed?
Max and Min limit shared the same date object which was causing some side effect of max limit being overridden to Dec instead of the current month. 
Now, Max and Min use a separate date object to avoid such side effects.