### PR TITLE
fix: added when a tag is edited to show tag.name

### DIFF
--- a/apps/gauzy/src/app/@shared/tags/tags-mutation.component.ts
+++ b/apps/gauzy/src/app/@shared/tags/tags-mutation.component.ts
@@ -62,6 +62,7 @@ export class TagsMutationComponent extends TranslationBaseComponent
 	async initializeForm() {
 		if (this.tag) {
 			this.color = this.tag.color;
+			this.name = this.tag.name;
 			this.form = this.fb.group({
 				name: [this.tag.name],
 				color: [this.tag.color],


### PR DESCRIPTION
tag.name wasnt showing now is :)
![tag-correct](https://user-images.githubusercontent.com/36041324/77232437-8ac47f80-6ba9-11ea-841f-4b6ae53bb8e7.PNG)
