### PR TITLE
fix: #822 organization split expense

### DIFF
--- a/apps/api/src/app/shared/handlers/recurring-expense.delete.handler.ts
+++ b/apps/api/src/app/shared/handlers/recurring-expense.delete.handler.ts
@@ -151,6 +151,7 @@ export abstract class RecurringExpenseDeleteHandler<
 			};
 			if (originalExpense.orgId) {
 				createOptions.orgId = originalExpense.orgId;
+				createOptions.splitExpense = originalExpense.splitExpense;
 			} else if (originalExpense.employeeId) {
 				createOptions.employeeId = originalExpense.employeeId;
 			}

--- a/apps/api/src/app/shared/handlers/recurring-expense.edit.handler.ts
+++ b/apps/api/src/app/shared/handlers/recurring-expense.edit.handler.ts
@@ -72,6 +72,7 @@ export abstract class RecurringExpenseEditHandler<
 		}
 		if (originalExpense.orgId) {
 			createObject.orgId = originalExpense.orgId;
+			createObject.splitExpense = originalExpense.splitExpense;
 		}
 		const newExpense = await this.crudService.create(createObject);
 


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

This PR Fixes #822 

![screencast 2020-03-22 16-27-45](https://user-images.githubusercontent.com/6750734/77247977-0aab2200-6c5c-11ea-942b-d513a9fb0f2c.gif)

Split expenses were not being copied when creating a new DB entry for a recurring expense from an existing entry. Fixed that for delete and edit both. 