### PR TITLE
fix: #825 set boundaries fetch org recurring split expenses

### DIFF
--- a/apps/api/src/app/organization-recurring-expense/queries/handlers/organization-recurring-expense.find-split-expense.handler.ts
+++ b/apps/api/src/app/organization-recurring-expense/queries/handlers/organization-recurring-expense.find-split-expense.handler.ts
@@ -5,7 +5,7 @@ import { EmployeeService } from '../../../employee';
 import { OrganizationService } from '../../../organization';
 import { OrganizationRecurringExpenseService } from '../../organization-recurring-expense.service';
 import { OrganizationRecurringExpenseFindSplitExpenseQuery } from '../organization-recurring-expense.find-split-expense.query';
-
+import { MoreThanOrEqual, IsNull, LessThanOrEqual } from 'typeorm';
 /**
  * Finds the split recurring expense for a given organization.
  *
@@ -26,14 +26,32 @@ export class OrganizationRecurringExpenseFindSplitExpenseHandler
 	public async execute(
 		query: OrganizationRecurringExpenseFindSplitExpenseQuery
 	): Promise<IPagination<OrganizationRecurringExpenseForEmployeeOutput>> {
-		const { orgId, findInput } = query;
+		const {
+			orgId,
+			findInput: { year, month }
+		} = query;
+
+		const filterDate = new Date(year, month, 1);
 
 		//1. Find all recurring expenses for the organization which have splitExpense = true
 		const {
 			items,
 			total
 		} = await this.organizationRecurringExpenseService.findAll({
-			where: { ...findInput, splitExpense: true, orgId }
+			where: [
+				{
+					splitExpense: true,
+					orgId,
+					startDate: LessThanOrEqual(filterDate),
+					endDate: IsNull()
+				},
+				{
+					splitExpense: true,
+					orgId,
+					startDate: LessThanOrEqual(filterDate),
+					endDate: MoreThanOrEqual(filterDate)
+				}
+			]
 		});
 
 		const organization = await this.organizationService.findOne({

--- a/apps/api/src/app/organization-recurring-expense/queries/organization-recurring-expense.find-split-expense.query.ts
+++ b/apps/api/src/app/organization-recurring-expense/queries/organization-recurring-expense.find-split-expense.query.ts
@@ -1,6 +1,5 @@
 import { IQuery } from '@nestjs/cqrs';
-import { FindConditions } from 'typeorm';
-import { OrganizationRecurringExpense } from '../organization-recurring-expense.entity';
+import { OrganizationRecurringExpenseFindInput } from '@gauzy/models';
 
 export class OrganizationRecurringExpenseFindSplitExpenseQuery
 	implements IQuery {
@@ -8,6 +7,6 @@ export class OrganizationRecurringExpenseFindSplitExpenseQuery
 
 	constructor(
 		public readonly orgId: string,
-		public readonly findInput: FindConditions<OrganizationRecurringExpense>
+		public readonly findInput: OrganizationRecurringExpenseFindInput
 	) {}
 }

--- a/apps/gauzy/src/app/pages/dashboard/human-resources/human-resources.component.ts
+++ b/apps/gauzy/src/app/pages/dashboard/human-resources/human-resources.component.ts
@@ -301,7 +301,7 @@ export class HumanResourcesComponent implements OnInit, OnDestroy {
 							this.store.selectedOrganization.id,
 							{
 								year: this.selectedDate.getFullYear(),
-								month: this.selectedDate.getMonth() + 1
+								month: this.selectedDate.getMonth()
 							}
 						)
 				  ).items


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

**What got fixed?**
Expense details in Employee Dashboard page showed organization split recurring expenses of the organization employee belonged to. However, expenses that had ended or begin after the chosen period also showed up. Added a filter to select only desired expenses from the DB.

**Demo**

https://www.loom.com/share/8ce20e4a599840e98d00e7b3499f37c3
