### PR TITLE
feat: #676 edit recurring expense start date

### DIFF
--- a/apps/api/src/app/core/utils.ts
+++ b/apps/api/src/app/core/utils.ts
@@ -37,3 +37,11 @@ export function reflect(promise) {
 		(error) => ({ error, status: 'rejected' })
 	);
 }
+
+/**
+ * To calculate the last day of a month, we need to set date=0 and month as the next month.
+ * So, if we want the last day of February (February is month = 1) we'll need to perform 'new Date(year, 2, 0).getDate()'
+ */
+export function getLastDayOfMonth(year, month) {
+	return new Date(year, month + 1, 0).getDate();
+}

--- a/apps/api/src/app/employee-recurring-expense/employee-recurring-expense.controller.ts
+++ b/apps/api/src/app/employee-recurring-expense/employee-recurring-expense.controller.ts
@@ -1,4 +1,8 @@
-import { RecurringExpenseEditInput, PermissionsEnum } from '@gauzy/models';
+import {
+	IStartUpdateTypeInfo,
+	PermissionsEnum,
+	RecurringExpenseEditInput
+} from '@gauzy/models';
 import {
 	Body,
 	Controller,
@@ -7,24 +11,25 @@ import {
 	HttpCode,
 	HttpStatus,
 	Param,
+	Post,
 	Put,
 	Query,
-	UseGuards,
-	Post
+	UseGuards
 } from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
+import { AuthGuard } from '@nestjs/passport';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { IPagination } from '../core';
 import { CrudController } from '../core/crud/crud.controller';
+import { Permissions } from '../shared/decorators/permissions';
+import { PermissionGuard } from '../shared/guards/auth/permission.guard';
+import { EmployeeRecurringExpenseCreateCommand } from './commands/employee-recurring-expense.create.command';
 import { EmployeeRecurringExpenseDeleteCommand } from './commands/employee-recurring-expense.delete.command';
 import { EmployeeRecurringExpenseEditCommand } from './commands/employee-recurring-expense.edit.command';
 import { EmployeeRecurringExpense } from './employee-recurring-expense.entity';
 import { EmployeeRecurringExpenseService } from './employee-recurring-expense.service';
 import { EmployeeRecurringExpenseByMonthQuery } from './queries/employee-recurring-expense.by-month.query';
-import { AuthGuard } from '@nestjs/passport';
-import { PermissionGuard } from '../shared/guards/auth/permission.guard';
-import { Permissions } from '../shared/decorators/permissions';
-import { EmployeeRecurringExpenseCreateCommand } from './commands/employee-recurring-expense.create.command';
+import { EmployeeRecurringExpenseStartDateUpdateTypeQuery } from './queries/employee-recurring-expense.update-type.query';
 
 @ApiTags('EmployeeRecurringExpense')
 @UseGuards(AuthGuard('jwt'))
@@ -152,5 +157,27 @@ export class EmployeeRecurringExpenseController extends CrudController<
 			where: findInput,
 			order: order
 		});
+	}
+
+	@ApiOperation({
+		summary: 'Find the start date update type for a recurring expense.'
+	})
+	@ApiResponse({
+		status: HttpStatus.OK,
+		description: 'Found start date update type'
+	})
+	@ApiResponse({
+		status: HttpStatus.NOT_FOUND,
+		description: 'Record not found'
+	})
+	@Get('/date-update-type')
+	async findStartDateUpdateType(
+		@Query('data') data: string
+	): Promise<IStartUpdateTypeInfo> {
+		const { findInput } = JSON.parse(data);
+
+		return this.queryBus.execute(
+			new EmployeeRecurringExpenseStartDateUpdateTypeQuery(findInput)
+		);
 	}
 }

--- a/apps/api/src/app/employee-recurring-expense/queries/employee-recurring-expense.update-type.query.ts
+++ b/apps/api/src/app/employee-recurring-expense/queries/employee-recurring-expense.update-type.query.ts
@@ -1,0 +1,9 @@
+import { IFindStartDateUpdateTypeInput } from '@gauzy/models';
+import { IQuery } from '@nestjs/cqrs';
+
+export class EmployeeRecurringExpenseStartDateUpdateTypeQuery
+	implements IQuery {
+	static readonly type = '[EmployeeRecurringExpense] Start Date Update Type';
+
+	constructor(public readonly input: IFindStartDateUpdateTypeInput) {}
+}

--- a/apps/api/src/app/employee-recurring-expense/queries/handlers/employee-recurring-expense.start-date-update-type.handler.ts
+++ b/apps/api/src/app/employee-recurring-expense/queries/handlers/employee-recurring-expense.start-date-update-type.handler.ts
@@ -1,0 +1,25 @@
+import { IStartUpdateTypeInfo } from '@gauzy/models';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { FindRecurringExpenseStartDateUpdateTypeHandler } from '../../../shared/handlers/recurring-expense.find-update-type.handler';
+import { EmployeeRecurringExpense } from '../../employee-recurring-expense.entity';
+import { EmployeeRecurringExpenseService } from '../../employee-recurring-expense.service';
+import { EmployeeRecurringExpenseStartDateUpdateTypeQuery } from '../employee-recurring-expense.update-type.query';
+
+@QueryHandler(EmployeeRecurringExpenseStartDateUpdateTypeQuery)
+export class EmployeeRecurringExpenseUpdateTypeHandler
+	extends FindRecurringExpenseStartDateUpdateTypeHandler<
+		EmployeeRecurringExpense
+	>
+	implements IQueryHandler<EmployeeRecurringExpenseStartDateUpdateTypeQuery> {
+	constructor(
+		private readonly employeeRecurringExpenseService: EmployeeRecurringExpenseService
+	) {
+		super(employeeRecurringExpenseService);
+	}
+
+	public async execute(
+		command: EmployeeRecurringExpenseStartDateUpdateTypeQuery
+	): Promise<IStartUpdateTypeInfo> {
+		return await this.executeQuery(command.input);
+	}
+}

--- a/apps/api/src/app/employee-recurring-expense/queries/handlers/index.ts
+++ b/apps/api/src/app/employee-recurring-expense/queries/handlers/index.ts
@@ -1,3 +1,7 @@
 import { EmployeeRecurringExpenseByMonthHandler } from './employee-recurring-expense.by-month.handler';
+import { EmployeeRecurringExpenseUpdateTypeHandler } from './employee-recurring-expense.start-date-update-type.handler';
 
-export const QueryHandlers = [EmployeeRecurringExpenseByMonthHandler];
+export const QueryHandlers = [
+	EmployeeRecurringExpenseByMonthHandler,
+	EmployeeRecurringExpenseUpdateTypeHandler
+];

--- a/apps/api/src/app/organization-recurring-expense/commands/handlers/organization-recurring-expense.edit.handler.ts
+++ b/apps/api/src/app/organization-recurring-expense/commands/handlers/organization-recurring-expense.edit.handler.ts
@@ -1,11 +1,13 @@
-import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
-import { OrganizationRecurringExpenseService } from '../../organization-recurring-expense.service';
-import { OrganizationRecurringExpenseEditCommand } from '../organization-recurring-expense.edit.command';
+import { IStartUpdateTypeInfo } from '@gauzy/models';
+import { CommandHandler, ICommandHandler, QueryBus } from '@nestjs/cqrs';
 import { RecurringExpenseEditHandler } from '../../../shared';
 import { OrganizationRecurringExpense } from '../../organization-recurring-expense.entity';
+import { OrganizationRecurringExpenseService } from '../../organization-recurring-expense.service';
+import { OrganizationRecurringExpenseStartDateUpdateTypeQuery } from '../../queries/organization-recurring-expense.update-type.query';
+import { OrganizationRecurringExpenseEditCommand } from '../organization-recurring-expense.edit.command';
 
 /**
- * This edits the value of a recurring expense.
+ * This edits a recurring expense.
  * To edit a recurring expense
  * 1. Change the end date of the original expense so that old value is not modified for previous expense.
  * 2. Create a new expense to have new values for all future dates.
@@ -15,7 +17,8 @@ export class OrganizationRecurringExpenseEditHandler
 	extends RecurringExpenseEditHandler<OrganizationRecurringExpense>
 	implements ICommandHandler<OrganizationRecurringExpenseEditCommand> {
 	constructor(
-		private readonly organizationRecurringExpenseService: OrganizationRecurringExpenseService
+		private readonly organizationRecurringExpenseService: OrganizationRecurringExpenseService,
+		private readonly queryBus: QueryBus
 	) {
 		super(organizationRecurringExpenseService);
 	}
@@ -24,6 +27,21 @@ export class OrganizationRecurringExpenseEditHandler
 		command: OrganizationRecurringExpenseEditCommand
 	): Promise<any> {
 		const { id, input } = command;
-		return await this.executeCommand(id, input);
+
+		const updateType: IStartUpdateTypeInfo = await this.queryBus.execute(
+			new OrganizationRecurringExpenseStartDateUpdateTypeQuery({
+				newStartDate: new Date(
+					input.startYear,
+					input.startMonth,
+					input.startDay
+				),
+				recurringExpenseId: id
+			})
+		);
+
+		return await this.executeCommand(id, {
+			...input,
+			startDateUpdateType: updateType.value
+		});
 	}
 }

--- a/apps/api/src/app/organization-recurring-expense/organization-recurring-expense.controller.ts
+++ b/apps/api/src/app/organization-recurring-expense/organization-recurring-expense.controller.ts
@@ -1,4 +1,5 @@
 import {
+	IStartUpdateTypeInfo,
 	OrganizationRecurringExpenseForEmployeeOutput,
 	RecurringExpenseEditInput
 } from '@gauzy/models';
@@ -10,23 +11,24 @@ import {
 	HttpCode,
 	HttpStatus,
 	Param,
+	Post,
 	Put,
 	Query,
-	UseGuards,
-	Post
+	UseGuards
 } from '@nestjs/common';
 import { CommandBus, QueryBus } from '@nestjs/cqrs';
 import { AuthGuard } from '@nestjs/passport';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { IPagination } from '../core';
 import { CrudController } from '../core/crud/crud.controller';
+import { OrganizationRecurringExpenseCreateCommand } from './commands/organization-recurring-expense.create.command';
 import { OrganizationRecurringExpenseDeleteCommand } from './commands/organization-recurring-expense.delete.command';
 import { OrganizationRecurringExpenseEditCommand } from './commands/organization-recurring-expense.edit.command';
 import { OrganizationRecurringExpense } from './organization-recurring-expense.entity';
 import { OrganizationRecurringExpenseService } from './organization-recurring-expense.service';
 import { OrganizationRecurringExpenseByMonthQuery } from './queries/organization-recurring-expense.by-month.query';
 import { OrganizationRecurringExpenseFindSplitExpenseQuery } from './queries/organization-recurring-expense.find-split-expense.query';
-import { OrganizationRecurringExpenseCreateCommand } from './commands/organization-recurring-expense.create.command';
+import { OrganizationRecurringExpenseStartDateUpdateTypeQuery } from './queries/organization-recurring-expense.update-type.query';
 
 @ApiTags('OrganizationRecurringExpense')
 @Controller()
@@ -180,6 +182,29 @@ export class OrganizationRecurringExpenseController extends CrudController<
 
 		return this.queryBus.execute(
 			new OrganizationRecurringExpenseByMonthQuery(findInput)
+		);
+	}
+
+	@ApiOperation({
+		summary:
+			'Find start date update type & conflicting expenses for the update'
+	})
+	@ApiResponse({
+		status: HttpStatus.OK,
+		description: 'Found start date update type'
+	})
+	@ApiResponse({
+		status: HttpStatus.NOT_FOUND,
+		description: 'Record not found'
+	})
+	@Get('/date-update-type')
+	async findStartDateUpdateType(
+		@Query('data') data: string
+	): Promise<IStartUpdateTypeInfo> {
+		const { findInput } = JSON.parse(data);
+
+		return this.queryBus.execute(
+			new OrganizationRecurringExpenseStartDateUpdateTypeQuery(findInput)
 		);
 	}
 }

--- a/apps/api/src/app/organization-recurring-expense/queries/handlers/index.ts
+++ b/apps/api/src/app/organization-recurring-expense/queries/handlers/index.ts
@@ -1,7 +1,9 @@
 import { OrganizationRecurringExpenseByMonthHandler } from './organization-recurring-expense.by-month.handler';
 import { OrganizationRecurringExpenseFindSplitExpenseHandler } from './organization-recurring-expense.find-split-expense.handler';
+import { OrganizationRecurringExpenseUpdateTypeHandler } from './organization-recurring-expense.start-date-update-type.handler';
 
 export const QueryHandlers = [
 	OrganizationRecurringExpenseByMonthHandler,
-	OrganizationRecurringExpenseFindSplitExpenseHandler
+	OrganizationRecurringExpenseFindSplitExpenseHandler,
+	OrganizationRecurringExpenseUpdateTypeHandler
 ];

--- a/apps/api/src/app/organization-recurring-expense/queries/handlers/organization-recurring-expense.start-date-update-type.handler.ts
+++ b/apps/api/src/app/organization-recurring-expense/queries/handlers/organization-recurring-expense.start-date-update-type.handler.ts
@@ -1,0 +1,26 @@
+import { IStartUpdateTypeInfo } from '@gauzy/models';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { FindRecurringExpenseStartDateUpdateTypeHandler } from '../../../shared/handlers/recurring-expense.find-update-type.handler';
+import { OrganizationRecurringExpense } from '../../organization-recurring-expense.entity';
+import { OrganizationRecurringExpenseService } from '../../organization-recurring-expense.service';
+import { OrganizationRecurringExpenseStartDateUpdateTypeQuery } from '../organization-recurring-expense.update-type.query';
+
+@QueryHandler(OrganizationRecurringExpenseStartDateUpdateTypeQuery)
+export class OrganizationRecurringExpenseUpdateTypeHandler
+	extends FindRecurringExpenseStartDateUpdateTypeHandler<
+		OrganizationRecurringExpense
+	>
+	implements
+		IQueryHandler<OrganizationRecurringExpenseStartDateUpdateTypeQuery> {
+	constructor(
+		private readonly organizationRecurringExpenseService: OrganizationRecurringExpenseService
+	) {
+		super(organizationRecurringExpenseService);
+	}
+
+	public async execute(
+		command: OrganizationRecurringExpenseStartDateUpdateTypeQuery
+	): Promise<IStartUpdateTypeInfo> {
+		return await this.executeQuery(command.input);
+	}
+}

--- a/apps/api/src/app/organization-recurring-expense/queries/organization-recurring-expense.update-type.query.ts
+++ b/apps/api/src/app/organization-recurring-expense/queries/organization-recurring-expense.update-type.query.ts
@@ -1,0 +1,10 @@
+import { IFindStartDateUpdateTypeInput } from '@gauzy/models';
+import { IQuery } from '@nestjs/cqrs';
+
+export class OrganizationRecurringExpenseStartDateUpdateTypeQuery
+	implements IQuery {
+	static readonly type =
+		'[OrganizationRecurringExpense] Start Date Update Type';
+
+	constructor(public readonly input: IFindStartDateUpdateTypeInput) {}
+}

--- a/apps/api/src/app/shared/handlers/index.ts
+++ b/apps/api/src/app/shared/handlers/index.ts
@@ -1,4 +1,4 @@
-export * from './update-entity.by-member.handler';
-export * from './find-recurring-expense.by-month.handler';
 export * from './recurring-expense.delete.handler';
 export * from './recurring-expense.edit.handler';
+export * from './recurring-expense.find-by-month.handler';
+export * from './update-entity.by-member.handler';

--- a/apps/api/src/app/shared/handlers/recurring-expense.edit.handler.ts
+++ b/apps/api/src/app/shared/handlers/recurring-expense.edit.handler.ts
@@ -1,15 +1,23 @@
 import {
 	RecurringExpenseEditInput,
-	RecurringExpenseModel
+	RecurringExpenseModel,
+	StartDateUpdateTypeEnum
 } from '@gauzy/models';
-
-import { CrudService } from '../../core';
+import { BadRequestException } from '@nestjs/common';
+import {
+	Between,
+	In,
+	IsNull,
+	LessThanOrEqual,
+	MoreThanOrEqual,
+	Not
+} from 'typeorm';
+import { CrudService, getLastDayOfMonth } from '../../core';
 
 /**
- * This edits the value of a recurring expense.
- * To edit a recurring expense
- * 1. Change the end date of the original expense so that old value is not modified for previous expense.
- * 2. Create a new expense to have new values for all future dates.
+ * Edits a recurring expense.
+ * To edit a recurring expense there can be different cases depending on the new start date.
+ * For description of difference in each StartDateUpdateTypeEnum please refer to FindRecurringExpenseStartDateUpdateTypeHandler
  */
 export abstract class RecurringExpenseEditHandler<
 	T extends RecurringExpenseModel
@@ -22,29 +30,89 @@ export abstract class RecurringExpenseEditHandler<
 	): Promise<any> {
 		const originalExpense: any = await this.crudService.findOne(id);
 
-		const inputDate = new Date(
+		const { startDateUpdateType } = input;
+
+		switch (startDateUpdateType) {
+			case StartDateUpdateTypeEnum.NO_CHANGE:
+			case StartDateUpdateTypeEnum.WITHIN_MONTH:
+			case StartDateUpdateTypeEnum.REDUCE_SAFE:
+				return this.updateExpenseStartDateAndValue(id, input);
+			case StartDateUpdateTypeEnum.INCREASE_SAFE_OUTSIDE_LIMIT:
+			case StartDateUpdateTypeEnum.INCREASE_SAFE_WITHIN_LIMIT:
+				return this.increaseSafe(id, input, originalExpense);
+			case StartDateUpdateTypeEnum.REDUCE_CONFLICT:
+				return this.reduceConflict(id, input, originalExpense);
+			case StartDateUpdateTypeEnum.INCREASE_CONFLICT:
+				//TODO: Handle this case too
+				throw new BadRequestException(
+					'Cannot increase start date with conflicts'
+				);
+			default:
+				throw new BadRequestException(
+					'Start Date Update Type Not Defined'
+				);
+		}
+	}
+
+	/**
+	 * Update the original expense with the input values.
+	 * This is to be used when there is no other change required to update the expense.
+	 */
+	private updateExpenseStartDateAndValue = async (
+		id: string,
+		input: RecurringExpenseEditInput
+	) => {
+		//TODO: Fix typescript
+		const updateObject: any = {
+			startDay: input.startDay,
+			startMonth: input.startMonth,
+			startYear: input.startYear,
+			startDate: new Date(
+				input.startYear,
+				input.startMonth,
+				input.startDay
+			),
+			value: input.value
+		};
+		return await this.crudService.update(id, updateObject);
+	};
+
+	/**
+	 * This increases the date of the recurring expense when it is safe to do so
+	 * i.e. it is not conflicting with any other expense with the same parentExpenseId
+	 *
+	 * To do this we
+	 * 1. Change the end date of the original expense so that old value is not modified for previous expense.
+	 * 2. Create a new expense to have new values for all future dates.
+	 */
+	private increaseSafe = async (
+		id: string,
+		input: RecurringExpenseEditInput,
+		originalExpense: RecurringExpenseModel | any
+	) => {
+		const originalEndDate = new Date(
+			originalExpense.endYear,
+			originalExpense.endMonth,
+			originalExpense.endDay
+		);
+		const newStartDate = new Date(
 			input.startYear,
-			input.startMonth - 1,
+			input.startMonth,
 			input.startDay
 		);
 
-		if (originalExpense.startDate.getTime() === inputDate.getTime()) {
-			const inputObject: any = {
-				...input
-			};
-			return await this.crudService.update(id, inputObject);
-		}
-
-		const endMonth = input.startMonth > 1 ? input.startMonth - 1 : 12;
+		//1. Change the end date of the original expense so that old value is not modified for previous expense.
+		const endMonth = input.startMonth > 0 ? input.startMonth - 1 : 11;
 		const endYear =
-			input.startMonth > 1 ? input.startYear : input.startYear - 1;
+			input.startMonth > 0 ? input.startYear : input.startYear - 1;
+		const endDay = getLastDayOfMonth(endYear, endMonth);
 
 		//TODO: Fix typescript
 		const updateObject: any = {
-			endDay: input.startDay,
+			endDay,
 			endMonth, //Because from input.startMonth the new value will be considered
 			endYear,
-			endDate: new Date(endYear, endMonth - 1, input.startDay)
+			endDate: new Date(endYear, endMonth, endDay)
 		};
 
 		await this.crudService.update(id, updateObject);
@@ -55,13 +123,19 @@ export abstract class RecurringExpenseEditHandler<
 			startYear: input.startYear,
 			startDate: new Date(
 				input.startYear,
-				input.startMonth - 1,
+				input.startMonth,
 				input.startDay
 			),
-			endDay: originalExpense.endDay,
-			endMonth: originalExpense.endMonth,
-			endYear: originalExpense.endYear,
-			endDate: originalExpense.endDate,
+			endDay:
+				originalEndDate > newStartDate ? originalExpense.endDay : null,
+			endMonth:
+				originalEndDate > newStartDate
+					? originalExpense.endMonth
+					: null,
+			endYear:
+				originalEndDate > newStartDate ? originalExpense.endYear : null,
+			endDate:
+				originalEndDate > newStartDate ? originalExpense.endDate : null,
 			value: input.value,
 			categoryName: originalExpense.categoryName,
 			currency: originalExpense.currency,
@@ -77,5 +151,153 @@ export abstract class RecurringExpenseEditHandler<
 		const newExpense = await this.crudService.create(createObject);
 
 		return newExpense;
+	};
+
+	/**
+	 * Decrease the date of the recurring expense while modifying the date of the conflicting expense
+	 * 1. Find conflicting expense
+	 * 2. Update end date of conflicting expense to one month after the input month
+	 * 3. Remove any expense if is in between
+	 * 4. This resolves the conflict, now do a simple non conflicting update.
+	 */
+	private reduceConflict = async (
+		id: string,
+		input: RecurringExpenseEditInput,
+		originalExpense: RecurringExpenseModel
+	) => {
+		//1. Find conflicting expense
+		const conflictingExpense = await this.findConflictingExpense(
+			id,
+			originalExpense.parentRecurringExpenseId,
+			input.startYear,
+			input.startMonth
+		);
+
+		//2. Update end date of conflicting expense to one month before the input start month
+		if (conflictingExpense) {
+			await this.reduceEndDateToPreviousMonth(
+				conflictingExpense.id,
+				input.startYear,
+				input.startMonth
+			);
+		}
+
+		//3. Remove expenses in between, if any
+		const { items, total } = await this.findAllExpensesInBetween(
+			originalExpense.id,
+			originalExpense.parentRecurringExpenseId,
+			input.startYear,
+			input.startMonth,
+			originalExpense.startYear,
+			originalExpense.startMonth
+		);
+
+		if (total > 0) {
+			const itemsInBetween: any = {
+				id: In(items.map((i) => i.id))
+			};
+			await this.crudService.delete(itemsInBetween);
+		}
+
+		//4. This resolves the conflict, now do a simple non conflicting update.
+		this.updateExpenseStartDateAndValue(id, input);
+	};
+
+	/**
+	 * Decrease only the end date to the end of previous month without modifying any value
+	 */
+	private reduceEndDateToPreviousMonth(
+		id: string,
+		startYear: number,
+		startMonth: number
+	) {
+		const newEndYear = startMonth > 0 ? startYear : startYear - 1;
+		const newEndMonth = startMonth > 0 ? startMonth - 1 : 11;
+		const newEndDay = getLastDayOfMonth(newEndYear, newEndMonth);
+
+		const dateUpdate: any = {
+			endDay: newEndDay,
+			endMonth: newEndMonth,
+			endYear: newEndYear,
+			endDate: new Date(newEndYear, newEndMonth, newEndDay)
+		};
+		this.crudService.update(id, dateUpdate);
+	}
+
+	/**
+	 * Find all expenses (except the recurringExpenseId) between a given start and end months of the same parent recurring expense id.
+	 */
+	async findAllExpensesInBetween(
+		recurringExpenseId: string,
+		parentRecurringExpenseId: string,
+		updatedStartYear: number,
+		updatedStartMonth: number,
+		currentStartYear: number,
+		currentStartMonth: number
+	) {
+		const lastDayOfMonth = getLastDayOfMonth(
+			currentStartYear,
+			currentStartMonth
+		);
+		const currentStartDate = new Date(
+			currentStartYear,
+			currentStartMonth,
+			lastDayOfMonth
+		);
+		const updatedStartDate = new Date(
+			updatedStartYear,
+			updatedStartMonth,
+			1
+		);
+
+		return await this.crudService.findAll({
+			where: [
+				{
+					id: Not(recurringExpenseId),
+					parentRecurringExpenseId: parentRecurringExpenseId,
+					startDate: Between(updatedStartDate, currentStartDate)
+				},
+				{
+					id: Not(recurringExpenseId),
+					parentRecurringExpenseId: parentRecurringExpenseId,
+					endDate: Between(updatedStartDate, currentStartDate)
+				}
+			]
+		});
+	}
+
+	async findConflictingExpense(
+		recurringExpenseId: string,
+		parentRecurringExpenseId: string,
+		year: number,
+		month: number
+	) {
+		const lastDayOfMonth = getLastDayOfMonth(year, month);
+		const inputStartDate = new Date(year, month, lastDayOfMonth);
+		const inputEndDate = new Date(year, month, 1);
+
+		try {
+			const expense = await this.crudService.findOne({
+				where: [
+					{
+						parentRecurringExpenseId: parentRecurringExpenseId,
+						startDate: LessThanOrEqual(inputStartDate),
+						endDate: IsNull()
+					},
+					{
+						parentRecurringExpenseId: parentRecurringExpenseId,
+						startDate: LessThanOrEqual(inputStartDate),
+						endDate: MoreThanOrEqual(inputEndDate)
+					}
+				]
+			});
+
+			//If this is the same expense as the expense we want to update, then it is not a conflicting expense
+			return expense.id !== recurringExpenseId ? expense : undefined;
+		} catch (error) {
+			//Ignore, this means record not found.
+		}
+
+		return undefined;
 	}
 }

--- a/apps/api/src/app/shared/handlers/recurring-expense.edit.handler.ts
+++ b/apps/api/src/app/shared/handlers/recurring-expense.edit.handler.ts
@@ -206,7 +206,7 @@ export abstract class RecurringExpenseEditHandler<
 	/**
 	 * Decrease only the end date to the end of previous month without modifying any value
 	 */
-	private reduceEndDateToPreviousMonth(
+	private async reduceEndDateToPreviousMonth(
 		id: string,
 		startYear: number,
 		startMonth: number
@@ -221,7 +221,7 @@ export abstract class RecurringExpenseEditHandler<
 			endYear: newEndYear,
 			endDate: new Date(newEndYear, newEndMonth, newEndDay)
 		};
-		this.crudService.update(id, dateUpdate);
+		await this.crudService.update(id, dateUpdate);
 	}
 
 	/**

--- a/apps/api/src/app/shared/handlers/recurring-expense.find-by-month.handler.ts
+++ b/apps/api/src/app/shared/handlers/recurring-expense.find-by-month.handler.ts
@@ -3,7 +3,7 @@ import {
 	RecurringExpenseModel
 } from '@gauzy/models';
 import { IsNull, LessThanOrEqual, MoreThanOrEqual } from 'typeorm';
-import { CrudService, IPagination } from '../../core';
+import { CrudService, getLastDayOfMonth, IPagination } from '../../core';
 
 /**
  * Finds income, expense, profit and bonus for all organizations for the given month.
@@ -22,7 +22,13 @@ export abstract class FindRecurringExpenseByMonthHandler<
 	public async executeCommand(
 		input: RecurringExpenseByMonthFindInput | any
 	): Promise<IPagination<T>> {
-		const inputStartDate = new Date(input.year, input.month - 1, 1);
+		const lastDayOfMonth = getLastDayOfMonth(input.year, input.month);
+		const inputStartDate = new Date(
+			input.year,
+			input.month,
+			lastDayOfMonth
+		);
+		const inputEndDate = new Date(input.year, input.month, 1);
 
 		let whereId: Object = input.orgId
 			? {
@@ -49,7 +55,7 @@ export abstract class FindRecurringExpenseByMonthHandler<
 				{
 					...whereId,
 					startDate: LessThanOrEqual(inputStartDate),
-					endDate: MoreThanOrEqual(inputStartDate)
+					endDate: MoreThanOrEqual(inputEndDate)
 				}
 			]
 		});

--- a/apps/api/src/app/shared/handlers/recurring-expense.find-update-type.handler.ts
+++ b/apps/api/src/app/shared/handlers/recurring-expense.find-update-type.handler.ts
@@ -1,0 +1,159 @@
+import {
+	IFindStartDateUpdateTypeInput,
+	IStartUpdateTypeInfo,
+	RecurringExpenseModel,
+	StartDateUpdateTypeEnum
+} from '@gauzy/models';
+import { Between, Not } from 'typeorm';
+import { CrudService, getLastDayOfMonth } from '../../core';
+
+/**
+ * Finds the start date update type.
+ *
+ * When updating the start date, if
+ * NO_CHANGE: When there is no change in the date.
+ * WITHIN_MONTH: When the change is within a particular month.
+ * INCREASE_SAFE_WITHIN_LIMIT: When the change is 'safe*' and the new start date is BEFORE the end date
+ * INCREASE_SAFE_OUTSIDE_LIMIT: When the change is 'safe*' and the new start date is AFTER the end date
+ * INCREASE_CONFLICT: When there are one or more conflicting expenses between the original start date and new start date
+ * REDUCE_SAFE: When the new start date is before the old start date and it is 'safe*' to update the date
+ * REDUCE_CONFLICT: When the new start date is before the old start date and there is some expense already with the same parentRecurringExpenseId for the date
+ *
+ * *safe: An expense update is 'safe' when there is no other expense with the same parentRecurringExpenseId for the new start date.
+ */
+export abstract class FindRecurringExpenseStartDateUpdateTypeHandler<
+	T extends RecurringExpenseModel
+> {
+	constructor(private readonly crudService: CrudService<T>) {}
+
+	public async executeQuery(
+		input: IFindStartDateUpdateTypeInput
+	): Promise<IStartUpdateTypeInfo> {
+		const { newStartDate, recurringExpenseId } = input;
+
+		const originalExpense = await this.crudService.findOne(
+			recurringExpenseId
+		);
+
+		const oldStartDateObject = originalExpense.startDate;
+
+		const newStartDateObject = new Date(newStartDate);
+
+		if (oldStartDateObject.getTime() === newStartDateObject.getTime()) {
+			return { value: StartDateUpdateTypeEnum.NO_CHANGE, conflicts: [] };
+		} else if (
+			newStartDateObject.getMonth() === oldStartDateObject.getMonth() &&
+			newStartDateObject.getFullYear() ===
+				oldStartDateObject.getFullYear()
+		) {
+			return {
+				value: StartDateUpdateTypeEnum.WITHIN_MONTH,
+				conflicts: []
+			};
+		} else if (
+			newStartDateObject.getTime() > oldStartDateObject.getTime()
+		) {
+			return this.getIncreaseType(originalExpense, newStartDateObject);
+		} else if (
+			newStartDateObject.getTime() < oldStartDateObject.getTime()
+		) {
+			return this.getReduceType(originalExpense, newStartDate);
+		}
+	}
+
+	/**
+	 * Returns whether the increase is safe or has conflicts.
+	 * 1. If new start date is more than original end date then it is outside limit
+	 * 2. Find all expenses between original start date and new start date, if any expense found then conflict
+	 */
+	private async getIncreaseType(originalExpense, newStartDateObject) {
+		const safeUpdateType =
+			originalExpense.endDate &&
+			newStartDateObject.getTime() > originalExpense.endDate.getTime()
+				? StartDateUpdateTypeEnum.INCREASE_SAFE_OUTSIDE_LIMIT
+				: StartDateUpdateTypeEnum.INCREASE_SAFE_WITHIN_LIMIT;
+
+		const {
+			items: foundRecurringExpenses,
+			total
+		} = await this.findAllExpensesInBetween(
+			originalExpense.id,
+			originalExpense.parentRecurringExpenseId,
+			new Date(originalExpense.startYear, originalExpense.startMonth, 1),
+			new Date(
+				newStartDateObject.getFullYear(),
+				newStartDateObject.getMonth(),
+				getLastDayOfMonth(
+					newStartDateObject.getFullYear(),
+					newStartDateObject.getMonth()
+				)
+			)
+		);
+
+		return {
+			value:
+				total === 0
+					? safeUpdateType
+					: StartDateUpdateTypeEnum.INCREASE_CONFLICT,
+			conflicts: foundRecurringExpenses
+		};
+	}
+
+	/**
+	 * Returns whether reducing the start date is safe or has conflicts.
+	 * Find all expenses between new start date and original start date, if any expense found then conflict
+	 */
+	private async getReduceType(originalExpense, newStartDate) {
+		const currentStartDate = new Date(
+			originalExpense.startYear,
+			originalExpense.startMonth,
+			getLastDayOfMonth(
+				originalExpense.startYear,
+				originalExpense.startMonth
+			)
+		);
+
+		const {
+			items: foundRecurringExpenses,
+			total
+		} = await this.findAllExpensesInBetween(
+			originalExpense.id,
+			originalExpense.parentRecurringExpenseId,
+			newStartDate,
+			currentStartDate
+		);
+
+		return {
+			value:
+				total === 0
+					? StartDateUpdateTypeEnum.REDUCE_SAFE
+					: StartDateUpdateTypeEnum.REDUCE_CONFLICT,
+			conflicts: foundRecurringExpenses
+		};
+	}
+
+	/**
+	 * Find all expenses (except the recurringExpenseId) between a given from and to date of the same parent recurring expense id.
+	 */
+	private async findAllExpensesInBetween(
+		recurringExpenseId: string,
+		parentRecurringExpenseId: string,
+		fromStartDate: Date,
+		toStartDate: Date
+	) {
+		return await this.crudService.findAll({
+			where: [
+				{
+					id: Not(recurringExpenseId),
+					parentRecurringExpenseId: parentRecurringExpenseId,
+					startDate: Between(fromStartDate, toStartDate)
+				},
+				{
+					id: Not(recurringExpenseId),
+					parentRecurringExpenseId: parentRecurringExpenseId,
+					endDate: Between(fromStartDate, toStartDate)
+				}
+			]
+		});
+	}
+}

--- a/apps/gauzy/src/app/@core/services/employee-recurring-expense.service.ts
+++ b/apps/gauzy/src/app/@core/services/employee-recurring-expense.service.ts
@@ -4,6 +4,8 @@ import {
 	EmployeeRecurringExpense,
 	EmployeeRecurringExpenseByMonthFindInput,
 	EmployeeRecurringExpenseFindInput,
+	IFindStartDateUpdateTypeInput,
+	IStartUpdateTypeInfo,
 	RecurringExpenseDeleteInput,
 	RecurringExpenseOrderFields
 } from '@gauzy/models';
@@ -79,6 +81,19 @@ export class EmployeeRecurringExpenseService {
 	update(id: string, updateInput: EmployeeRecurringExpense): Promise<any> {
 		return this.http
 			.put(`${this.API_URL}/${id}`, updateInput)
+			.pipe(first())
+			.toPromise();
+	}
+
+	getStartDateUpdateType(
+		findInput?: IFindStartDateUpdateTypeInput
+	): Promise<IStartUpdateTypeInfo> {
+		const data = JSON.stringify({ findInput });
+
+		return this.http
+			.get<IStartUpdateTypeInfo>(`${this.API_URL}/date-update-type`, {
+				params: { data }
+			})
 			.pipe(first())
 			.toPromise();
 	}

--- a/apps/gauzy/src/app/@core/services/organization-recurring-expense.service.ts
+++ b/apps/gauzy/src/app/@core/services/organization-recurring-expense.service.ts
@@ -1,13 +1,15 @@
-import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { first } from 'rxjs/operators';
+import { Injectable } from '@angular/core';
 import {
+	IFindStartDateUpdateTypeInput,
+	IStartUpdateTypeInfo,
 	OrganizationRecurringExpense,
 	OrganizationRecurringExpenseFindInput,
-	RecurringExpenseDeleteInput,
 	OrganizationRecurringExpenseForEmployeeOutput,
+	RecurringExpenseDeleteInput,
 	RecurringExpenseOrderFields
 } from '@gauzy/models';
+import { first } from 'rxjs/operators';
 
 @Injectable({
 	providedIn: 'root'
@@ -99,6 +101,19 @@ export class OrganizationRecurringExpenseService {
 				items: OrganizationRecurringExpenseForEmployeeOutput[];
 				total: number;
 			}>(`${this.API_URL}/employee/${orgId}`, {
+				params: { data }
+			})
+			.pipe(first())
+			.toPromise();
+	}
+
+	getStartDateUpdateType(
+		findInput?: IFindStartDateUpdateTypeInput
+	): Promise<IStartUpdateTypeInfo> {
+		const data = JSON.stringify({ findInput });
+
+		return this.http
+			.get<IStartUpdateTypeInfo>(`${this.API_URL}/date-update-type`, {
 				params: { data }
 			})
 			.pipe(first())

--- a/apps/gauzy/src/app/@core/utils/date.ts
+++ b/apps/gauzy/src/app/@core/utils/date.ts
@@ -1,16 +1,18 @@
 const monthNames = [
-    'January',
-    'February',
-    'March',
-    'April',
-    'May',
-    'June',
-    'July',
-    'August',
-    'September',
-    'October',
-    'November',
-    'December'
+	'January',
+	'February',
+	'March',
+	'April',
+	'May',
+	'June',
+	'July',
+	'August',
+	'September',
+	'October',
+	'November',
+	'December'
 ];
 
-export { monthNames };
+const defaultDateFormat = 'll';
+
+export { monthNames, defaultDateFormat };

--- a/apps/gauzy/src/app/@shared/expenses/recurring-expense-block/recurring-expense-block.component.html
+++ b/apps/gauzy/src/app/@shared/expenses/recurring-expense-block/recurring-expense-block.component.html
@@ -7,8 +7,7 @@
 						{{ getCategoryName(recurringExpense?.categoryName) }}
 					</div>
 					<div class="col">
-						{{ getMonthString(recurringExpense?.startMonth) }}
-						{{ recurringExpense?.startYear }}
+						{{ getStartDate() }}
 					</div>
 					<div class="col">
 						<span class="block-amount" (click)="emitFetchHistory()"

--- a/apps/gauzy/src/app/@shared/expenses/recurring-expense-block/recurring-expense-block.component.ts
+++ b/apps/gauzy/src/app/@shared/expenses/recurring-expense-block/recurring-expense-block.component.ts
@@ -1,10 +1,12 @@
-import { Component, Input, OnInit, Output, EventEmitter } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import {
+	Organization,
 	RecurringExpenseDefaultCategoriesEnum,
 	RecurringExpenseModel
 } from '@gauzy/models';
 import { TranslateService } from '@ngx-translate/core';
-import { monthNames } from '../../../@core/utils/date';
+import * as moment from 'moment';
+import { defaultDateFormat } from '../../../@core/utils/date';
 import { TranslationBaseComponent } from '../../language-base/translation-base.component';
 
 @Component({
@@ -22,6 +24,9 @@ export class RecurringExpenseBlockComponent extends TranslationBaseComponent
 
 	@Input()
 	fetchedHistories: RecurringExpenseModel[];
+
+	@Input()
+	selectedOrganization: Organization;
 
 	@Output()
 	editRecurringExpense = new EventEmitter<void>();
@@ -60,8 +65,12 @@ export class RecurringExpenseBlockComponent extends TranslationBaseComponent
 		}
 	}
 
-	getMonthString(month: number) {
-		return monthNames[month - 1];
+	getStartDate() {
+		return this.recurringExpense && this.selectedOrganization
+			? moment(this.recurringExpense.startDate).format(
+					this.selectedOrganization.dateFormat || defaultDateFormat
+			  )
+			: '';
 	}
 
 	getCategoryName(categoryName: string) {

--- a/apps/gauzy/src/app/@shared/expenses/recurring-expense-mutation/recurring-expense-mutation.component.html
+++ b/apps/gauzy/src/app/@shared/expenses/recurring-expense-mutation/recurring-expense-mutation.component.html
@@ -66,7 +66,152 @@
 					</nb-select>
 				</div>
 			</div>
+			<!-- TODO: translate -->
+			<div class="row" *ngIf="recurringExpense">
+				<div class="col">
+					<div class="form-group">
+						<label>
+							Starts On
+						</label>
+						<input
+							[nbDatepicker]="datepicker"
+							nbInput
+							fullWidth
+							placeholder="{{ 'POP_UPS.PICK_DATE' | translate }}"
+							formControlName="startDate"
+							(ngModelChange)="datePickerChanged($event)"
+						/>
+						<nb-datepicker #datepicker></nb-datepicker>
 
+						<div
+							[ngSwitch]="startDateUpdateType"
+							style="margin-top:10px"
+							[nbSpinner]="startDateChangeLoading"
+							nbSpinnerStatus="danger"
+							nbSpinnerSize="large"
+							nbSpinnerMessage=""
+						>
+							<nb-alert
+								status="warning"
+								*ngSwitchCase="'REDUCE_CONFLICT'"
+							>
+								Warning: This period overlaps with an existing
+								previous record(s):
+								<span *ngFor="let conflict of conflicts">
+									{{
+										conflict.value
+											| currency: conflict.currency
+									}}: From
+									{{
+										formatToOrganizationDate(
+											conflict.startDate
+										)
+									}}
+									to
+									{{
+										formatToOrganizationDate(
+											conflict.endDate
+										)
+									}}</span
+								>The value will be overwritten from
+								{{ month(startDate) }}!
+							</nb-alert>
+							<nb-alert
+								status="danger"
+								*ngSwitchCase="'INCREASE_CONFLICT'"
+							>
+								Error: This period overlaps with existing future
+								record(s).
+								<span *ngFor="let conflict of conflicts">
+									{{
+										conflict.value
+											| currency: conflict.currency
+									}}: From
+									{{
+										formatToOrganizationDate(
+											conflict.startDate
+										)
+									}}
+									to
+									{{
+										formatToOrganizationDate(
+											conflict.endDate
+										)
+									}}</span
+								>
+								This is not supported, please edit the future
+								expenses instead.
+							</nb-alert>
+							<nb-alert
+								status="warning"
+								*ngSwitchCase="'INCREASE_SAFE_WITHIN_LIMIT'"
+							>
+								This will only edit the future value from
+								{{ formatToOrganizationDate(startDate) }},
+								existing value of
+								{{
+									recurringExpense.value
+										| currency: recurringExpense.currency
+								}}
+								started on
+								{{
+									formatToOrganizationDate(
+										recurringExpense.startDate
+									)
+								}}
+								will not be affected till
+								{{ previousMonth(startDate) }}.
+							</nb-alert>
+							<nb-alert
+								status="warning"
+								*ngSwitchCase="'INCREASE_SAFE_OUTSIDE_LIMIT'"
+							>
+								This will set the expense value
+								{{
+									value | currency: recurringExpense.currency
+								}}
+								from
+								{{ formatToOrganizationDate(startDate) }}
+								onwards and the existing value of
+								{{
+									recurringExpense.value
+										| currency: recurringExpense.currency
+								}}
+								(Started on
+								{{
+									formatToOrganizationDate(
+										recurringExpense.startDate
+									)
+								}}
+								and ending on
+								{{
+									formatToOrganizationDate(
+										recurringExpense.endDate
+									)
+								}}) will be now set till
+								{{ previousMonth(startDate) }}.
+							</nb-alert>
+							<nb-alert
+								status="warning"
+								*ngSwitchCase="'REDUCE_SAFE'"
+							>
+								This will reduce the start date and include all
+								the months from
+								{{ formatToOrganizationDate(startDate) }} for
+								expense value
+								{{ value | currency: currencyValue }}
+							</nb-alert>
+							<nb-alert
+								status="primary"
+								*ngSwitchCase="'WITHIN_MONTH'"
+							>
+								This will change the start date to
+								{{ formatToOrganizationDate(startDate) }}
+							</nb-alert>
+						</div>
+					</div>
+				</div>
+			</div>
 			<div class="actions">
 				<!-- TODO: FIX dialogRef.close() -->
 				<button
@@ -93,14 +238,14 @@
 				</button>
 				<button
 					(click)="submitForm()"
-					[disabled]="form.invalid"
+					[disabled]="
+						form.invalid ||
+						startDateUpdateType === 'INCREASE_CONFLICT'
+					"
 					type="submit"
 					nbButton
 					status="success"
 					*ngIf="recurringExpense"
-					nbTooltip="{{
-						'EMPLOYEES_PAGE.RECURRING_EXPENSE_EDIT' | translate
-					}}"
 				>
 					{{ 'BUTTONS.EDIT' | translate }}
 				</button>

--- a/apps/gauzy/src/app/@shared/expenses/recurring-expense-mutation/recurring-expense-mutation.component.ts
+++ b/apps/gauzy/src/app/@shared/expenses/recurring-expense-mutation/recurring-expense-mutation.component.ts
@@ -181,7 +181,11 @@ export class RecurringExpenseMutationComponent extends TranslationBaseComponent
 			startDate: [
 				recurringExpense && recurringExpense.startDate
 					? new Date(recurringExpense.startDate)
-					: this.selectedDate
+					: new Date(
+							this.selectedDate.getFullYear(),
+							this.selectedDate.getMonth(),
+							1
+					  )
 			]
 		});
 

--- a/apps/gauzy/src/app/@shared/expenses/recurring-expense-mutation/recurring-expense-mutation.module.ts
+++ b/apps/gauzy/src/app/@shared/expenses/recurring-expense-mutation/recurring-expense-mutation.module.ts
@@ -2,19 +2,20 @@ import { HttpClient } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import {
+	NbAlertModule,
 	NbButtonModule,
 	NbCardModule,
+	NbCheckboxModule,
 	NbDatepickerModule,
 	NbIconModule,
 	NbInputModule,
 	NbSelectModule,
-	NbTooltipModule,
-	NbCheckboxModule
+	NbSpinnerModule,
+	NbTooltipModule
 } from '@nebular/theme';
 import { NgSelectModule } from '@ng-select/ng-select';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
-
 import { OrganizationsService } from '../../../@core/services/organizations.service';
 import { ThemeModule } from '../../../@theme/theme.module';
 import { RecurringExpenseMutationComponent } from './recurring-expense-mutation.component';
@@ -37,6 +38,8 @@ export function HttpLoaderFactory(http: HttpClient) {
 		NbSelectModule,
 		NbTooltipModule,
 		NbCheckboxModule,
+		NbAlertModule,
+		NbSpinnerModule,
 		TranslateModule.forChild({
 			loader: {
 				provide: TranslateLoader,

--- a/apps/gauzy/src/app/@shared/expenses/reecurring-expense-history/recurring-expense-history.component.ts
+++ b/apps/gauzy/src/app/@shared/expenses/reecurring-expense-history/recurring-expense-history.component.ts
@@ -28,6 +28,6 @@ export class RecurringExpenseHistoryComponent extends TranslationBaseComponent
 	ngOnInit() {}
 
 	getMonthString(month: number) {
-		return monthNames[month - 1];
+		return monthNames[month];
 	}
 }

--- a/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee.component.html
+++ b/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee.component.html
@@ -126,6 +126,7 @@
 			(fetchRecurringExpenseHistory)="fetchHistory(i)"
 			[fetchedHistories]="fetchedHistories[i]"
 			[recurringExpense]="expense"
+			[selectedOrganization]="selectedOrganization"
 		>
 		</ga-recurring-expense-block>
 	</nb-card-body>

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization.component.html
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization.component.html
@@ -98,6 +98,7 @@
 			[fetchedHistories]="fetchedHistories[i]"
 			[recurringExpense]="expense"
 			[splitExpense]="expense.splitExpense"
+			[selectedOrganization]="selectedOrg"
 		>
 		</ga-recurring-expense-block>
 	</nb-card-body>

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization.component.ts
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization.component.ts
@@ -188,6 +188,7 @@ export class EditOrganizationComponent extends TranslationBaseComponent
 	}
 
 	async addOrganizationRecurringExpense() {
+		console.log(this.selectedDate);
 		const result = await this.dialogService
 			.open(RecurringExpenseMutationComponent, {
 				context: {

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization.component.ts
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization.component.ts
@@ -124,8 +124,7 @@ export class EditOrganizationComponent extends TranslationBaseComponent
 	}
 
 	getMonthString(month: number) {
-		const months = monthNames;
-		return months[month - 1];
+		return monthNames[month];
 	}
 
 	getCategoryName(categoryName: string) {
@@ -140,22 +139,6 @@ export class EditOrganizationComponent extends TranslationBaseComponent
 		this.selectedRowIndexToShow = index;
 	}
 
-	getDefaultDate() {
-		const month = ('0' + (this.selectedDate.getMonth() + 1)).slice(-2);
-		return `${this.selectedDate.getFullYear()}-${month}`;
-	}
-
-	getDateValue(value: string): { month: number; year: number } {
-		if (value) {
-			const res = value.split('-');
-
-			return {
-				year: +res[0],
-				month: +res[1]
-			};
-		}
-	}
-
 	async deleteOrgRecurringExpense(index: number) {
 		const selectedExpense = this.selectedOrgRecurringExpense[index];
 		const result: RecurringExpenseDeletionEnum = await this.dialogService
@@ -166,7 +149,7 @@ export class EditOrganizationComponent extends TranslationBaseComponent
 						selectedExpense.startMonth
 					)}, ${selectedExpense.startYear}`,
 					current: `${this.getMonthString(
-						this.selectedDate.getMonth() + 1
+						this.selectedDate.getMonth()
 					)}, ${this.selectedDate.getFullYear()}`,
 					end: selectedExpense.endMonth
 						? `${this.getMonthString(selectedExpense.endMonth)}, ${
@@ -183,7 +166,7 @@ export class EditOrganizationComponent extends TranslationBaseComponent
 				const id = selectedExpense.id;
 				await this.organizationRecurringExpenseService.delete(id, {
 					deletionType: result,
-					month: this.selectedDate.getMonth() + 1,
+					month: this.selectedDate.getMonth(),
 					year: this.selectedDate.getFullYear()
 				});
 				this.selectedRowIndexToShow = null;
@@ -208,7 +191,8 @@ export class EditOrganizationComponent extends TranslationBaseComponent
 		const result = await this.dialogService
 			.open(RecurringExpenseMutationComponent, {
 				context: {
-					componentType: COMPONENT_TYPE.ORGANIZATION
+					componentType: COMPONENT_TYPE.ORGANIZATION,
+					selectedDate: this.selectedDate
 				}
 			})
 			.onClose.pipe(first())
@@ -218,18 +202,7 @@ export class EditOrganizationComponent extends TranslationBaseComponent
 			try {
 				await this.organizationRecurringExpenseService.create({
 					orgId: this.selectedOrg.id,
-					categoryName: result.categoryName,
-					value: result.value,
-					startDay: 1,
-					startYear: this.selectedDate.getFullYear(),
-					startMonth: this.selectedDate.getMonth() + 1,
-					startDate: new Date(
-						this.selectedDate.getFullYear(),
-						this.selectedDate.getMonth(),
-						1
-					),
-					currency: result.currency,
-					splitExpense: result.splitExpense
+					...result
 				});
 
 				this.toastrService.primary(
@@ -251,7 +224,8 @@ export class EditOrganizationComponent extends TranslationBaseComponent
 			.open(RecurringExpenseMutationComponent, {
 				context: {
 					recurringExpense: this.selectedOrgRecurringExpense[index],
-					componentType: COMPONENT_TYPE.ORGANIZATION
+					componentType: COMPONENT_TYPE.ORGANIZATION,
+					selectedDate: this.selectedDate
 				}
 			})
 			.onClose.pipe(first())
@@ -260,12 +234,10 @@ export class EditOrganizationComponent extends TranslationBaseComponent
 		if (result) {
 			try {
 				const id = this.selectedOrgRecurringExpense[index].id;
-				await this.organizationRecurringExpenseService.update(id, {
-					...result,
-					startDay: 1,
-					startMonth: this.selectedDate.getMonth() + 1,
-					startYear: this.selectedDate.getFullYear()
-				});
+				await this.organizationRecurringExpenseService.update(
+					id,
+					result
+				);
 				this.selectedRowIndexToShow = null;
 				this._loadOrgRecurringExpense();
 
@@ -302,7 +274,7 @@ export class EditOrganizationComponent extends TranslationBaseComponent
 				await this.organizationRecurringExpenseService.getAllByMonth({
 					orgId: this.selectedOrg.id,
 					year: this.selectedDate.getFullYear(),
-					month: this.selectedDate.getMonth() + 1
+					month: this.selectedDate.getMonth()
 				})
 			).items;
 			this.loading = false;

--- a/libs/models/src/lib/recurring-expense.model.ts
+++ b/libs/models/src/lib/recurring-expense.model.ts
@@ -33,6 +33,7 @@ export interface RecurringExpenseEditInput extends IBaseEntityModel {
 	categoryName: string;
 	value: number;
 	currency: string;
+	startDateUpdateType?: string;
 }
 
 export interface RecurringExpenseDeleteInput {
@@ -43,6 +44,16 @@ export interface RecurringExpenseDeleteInput {
 
 export interface RecurringExpenseOrderFields {
 	startDate?: 'ASC' | 'DESC';
+}
+
+export interface IFindStartDateUpdateTypeInput {
+	newStartDate: Date;
+	recurringExpenseId: string;
+}
+
+export interface IStartUpdateTypeInfo {
+	value: StartDateUpdateTypeEnum;
+	conflicts: RecurringExpenseModel[];
 }
 
 export enum RecurringExpenseDeletionEnum {
@@ -56,4 +67,14 @@ export enum RecurringExpenseDefaultCategoriesEnum {
 	SALARY_TAXES = 'SALARY_TAXES',
 	RENT = 'RENT',
 	EXTRA_BONUS = 'EXTRA_BONUS'
+}
+
+export enum StartDateUpdateTypeEnum {
+	REDUCE_SAFE = 'REDUCE_SAFE',
+	REDUCE_CONFLICT = 'REDUCE_CONFLICT',
+	INCREASE_SAFE_WITHIN_LIMIT = 'INCREASE_SAFE_WITHIN_LIMIT',
+	INCREASE_SAFE_OUTSIDE_LIMIT = 'INCREASE_SAFE_OUTSIDE_LIMIT',
+	INCREASE_CONFLICT = 'INCREASE_CONFLICT',
+	WITHIN_MONTH = 'WITHIN_MONTH',
+	NO_CHANGE = 'NO_CHANGE'
 }


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

So finally I'm almost through with this feature. I just need to do some testing and refactoring, also I think I've successfully managed to change the base of 'month' to 0 so that it is the same with javascript date.getMonth()

For an employee expense, change start date within a month, increase start date without conflict, reduce start date without conflict
https://www.loom.com/share/5670a821a4754656bc94d1a9477e3cb3

Add organization expense, reduce start date without conflicts, increase start date without conflicts.
https://www.loom.com/share/bb2de54b6c4642e8b4808bc3fd0ccf96

Please note: The case where there are conflicts in increase date because the new start date is greater than the original end date is currently not supported and does not let the user do the change. We can support it if really required but the logic was extremely complicated so I've removed it for now.