### PR TITLE
Feat/#887 income popup employee selector

### DIFF
--- a/apps/gauzy/src/app/@shared/income/income-mutation/income-mutation.component.html
+++ b/apps/gauzy/src/app/@shared/income/income-mutation/income-mutation.component.html
@@ -8,6 +8,9 @@
 		</h5>
 		<ga-employee-selector
 			#employeeSelector
+			placeholder="Organization"
+			[defaultSelected]="false"
+			[showAllEmployeesOption]="false"
 			[hidden]="income"
 			[skipGlobalChange]="true"
 			class="employees"

--- a/apps/gauzy/src/app/@shared/income/income-mutation/income-mutation.component.ts
+++ b/apps/gauzy/src/app/@shared/income/income-mutation/income-mutation.component.ts
@@ -1,5 +1,10 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
-import { Validators, FormBuilder, FormGroup } from '@angular/forms';
+import {
+	Validators,
+	FormBuilder,
+	FormGroup,
+	AbstractControl
+} from '@angular/forms';
 import { NbDialogRef } from '@nebular/theme';
 import { Income, OrganizationSelectInput } from '@gauzy/models';
 import { CurrenciesEnum } from '@gauzy/models';
@@ -22,6 +27,7 @@ export class IncomeMutationComponent implements OnInit {
 	currencies = Object.values(CurrenciesEnum);
 
 	form: FormGroup;
+	notes: AbstractControl;
 
 	clients: Object[] = [];
 
@@ -154,8 +160,10 @@ export class IncomeMutationComponent implements OnInit {
 				currency: '',
 				isBonus: false
 			});
+
 			this._loadDefaultCurrency();
 		}
+		this.notes = this.form.get('notes');
 	}
 
 	private async _loadDefaultCurrency() {

--- a/apps/gauzy/src/app/@theme/components/header/selectors/employee/employee.component.ts
+++ b/apps/gauzy/src/app/@theme/components/header/selectors/employee/employee.component.ts
@@ -58,7 +58,9 @@ export class EmployeeSelectorComponent implements OnInit, OnDestroy {
 	@Input()
 	disabled: boolean;
 	@Input()
-	defaultSelected;
+	defaultSelected: boolean;
+	@Input()
+	showAllEmployeesOption: boolean;
 	@Input()
 	placeholder: string;
 
@@ -78,6 +80,11 @@ export class EmployeeSelectorComponent implements OnInit, OnDestroy {
 	ngOnInit() {
 		this.defaultSelected =
 			this.defaultSelected === undefined ? true : this.defaultSelected;
+		this.showAllEmployeesOption =
+			this.showAllEmployeesOption === undefined
+				? true
+				: this.showAllEmployeesOption;
+
 		this._loadEmployees();
 		this._loadEmployeeId();
 	}
@@ -137,7 +144,6 @@ export class EmployeeSelectorComponent implements OnInit, OnDestroy {
 
 		const load = (loadItems) => {
 			this.people = [
-				ALL_EMPLOYEES_SELECTED,
 				...loadItems.map((e) => {
 					return {
 						id: e.id,
@@ -147,6 +153,8 @@ export class EmployeeSelectorComponent implements OnInit, OnDestroy {
 					};
 				})
 			];
+			if (this.showAllEmployeesOption)
+				this.people.unshift(ALL_EMPLOYEES_SELECTED);
 		};
 
 		this.store.selectedOrganization$.subscribe((org) => {


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
**What's got added?**
When Employee Selector in Header component has `All Employees` selected, opening add expense popup loads 'Organization' as default value within its Employee Selector.

When Employee Selector in Header component has a specific employee selected, opening add expense popup loads that employee within its Employee Selector.

**Feature Demo**
https://www.loom.com/share/693270b576e1484fb4069d1b3352b057