### PR TITLE
feat: #850 reorganize main menu

### DIFF
--- a/apps/gauzy/src/app/@theme/components/header/header.component.ts
+++ b/apps/gauzy/src/app/@theme/components/header/header.component.ts
@@ -184,13 +184,13 @@ export class HeaderComponent implements OnInit, OnDestroy {
 			{
 				title: this.getTranslation('CONTEXT_MENU.ADD_INCOME'),
 				icon: 'plus-circle-outline',
-				link: 'pages/income',
+				link: 'pages/accounting/income',
 				hidden: !this.hasPermissionI || !this.hasPermissionIEdit
 			},
 			{
 				title: this.getTranslation('CONTEXT_MENU.ADD_EXPENSE'),
 				icon: 'minus-circle-outline',
-				link: 'pages/expenses',
+				link: 'pages/accounting/expenses',
 				hidden: !this.hasPermissionE || !this.hasPermissionEEdit
 			},
 			// TODO: divider
@@ -220,7 +220,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
 			{
 				title: this.getTranslation('CONTEXT_MENU.TASK'),
 				icon: 'calendar-outline',
-				link: '#'
+				link: 'pages/tasks/dashboard'
 			},
 			{
 				title: this.getTranslation('CONTEXT_MENU.CLIENT'),

--- a/apps/gauzy/src/app/pages/dashboard/data-entry-shortcuts/data-entry-shortcuts.component.ts
+++ b/apps/gauzy/src/app/pages/dashboard/data-entry-shortcuts/data-entry-shortcuts.component.ts
@@ -43,11 +43,13 @@ export class DataEntryShortcutsComponent implements OnInit, OnDestroy {
 	}
 
 	async addIncome() {
-		this.router.navigateByUrl('pages/income?openAddDialog=true');
+		this.router.navigateByUrl('pages/accounting/income?openAddDialog=true');
 	}
 
 	async addExpense() {
-		this.router.navigateByUrl('pages/expenses?openAddDialog=true');
+		this.router.navigateByUrl(
+			'pages/accounting/expenses?openAddDialog=true'
+		);
 	}
 
 	async addOrganizationRecurringExpense() {

--- a/apps/gauzy/src/app/pages/equipment/equipment.component.html
+++ b/apps/gauzy/src/app/pages/equipment/equipment.component.html
@@ -1,6 +1,15 @@
 <nb-card [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
 	<nb-card-header>
-		<h4>{{ 'EQUIPMENT_PAGE.HEADER' | translate }}</h4>
+		<div class="main-header">
+			<h4>{{ 'EQUIPMENT_PAGE.HEADER' | translate }}</h4>
+			<button
+				nbButton
+				status="primary"
+				(click)="manageEquipmentSharing()"
+			>
+				{{ 'MENU.EQUIPMENT_SHARING' | translate }}
+			</button>
+		</div>
 	</nb-card-header>
 
 	<nb-card-body>

--- a/apps/gauzy/src/app/pages/equipment/equipment.component.scss
+++ b/apps/gauzy/src/app/pages/equipment/equipment.component.scss
@@ -1,0 +1,5 @@
+.main-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+}

--- a/apps/gauzy/src/app/pages/equipment/equipment.component.ts
+++ b/apps/gauzy/src/app/pages/equipment/equipment.component.ts
@@ -10,6 +10,7 @@ import { EquipmentMutationComponent } from '../../@shared/equipment/equipment-mu
 import { first } from 'rxjs/operators';
 import { DeleteConfirmationComponent } from '../../@shared/user/forms/delete-confirmation/delete-confirmation.component';
 import { AutoApproveComponent } from './auto-approve/auto-approve.component';
+import { Router } from '@angular/router';
 
 export interface SelectedEquipment {
 	data: Equipment;
@@ -41,7 +42,8 @@ export class EquipmentComponent extends TranslationBaseComponent
 		readonly translateService: TranslateService,
 		private dialogService: NbDialogService,
 		private equipmentService: EquipmentService,
-		private toastrService: NbToastrService
+		private toastrService: NbToastrService,
+		private router: Router
 	) {
 		super(translateService);
 	}
@@ -100,6 +102,10 @@ export class EquipmentComponent extends TranslationBaseComponent
 				}
 			}
 		};
+	}
+
+	manageEquipmentSharing() {
+		this.router.navigate(['/pages/organization/equipment-sharing']);
 	}
 
 	async save() {

--- a/apps/gauzy/src/app/pages/pages-routing.module.ts
+++ b/apps/gauzy/src/app/pages/pages-routing.module.ts
@@ -15,6 +15,12 @@ const routes: Routes = [
 				path: '',
 				redirectTo: 'dashboard',
 				pathMatch: 'full'
+				// canActivate: [RoleGuard],
+				// data: {
+				// 	expectedRole: [
+				// 		RolesEnum.ADMIN
+				// 	]
+				// }
 			},
 			{
 				path: 'dashboard',
@@ -22,53 +28,96 @@ const routes: Routes = [
 					import('./dashboard/dashboard.module').then(
 						(m) => m.DashboardModule
 					)
-				//   ,
-				// canActivate: [RoleGuard],
-				// data: { expectedRole: [] }
-				// data: { expectedRole: [RolesEnum.ADMIN] }
 			},
 			{
-				path: 'income',
-				loadChildren: () =>
-					import('./income/income.module').then((m) => m.IncomeModule)
-				// canActivate: [RoleGuard],
-				// data: {
-				// 	expectedRole: [
-				// 		// RolesEnum.DATA_ENTRY,
-				// 		// RolesEnum.EMPLOYEE,
-				// 		RolesEnum.ADMIN
-				// 	]
-				// }
+				path: 'accounting',
+				children: [
+					{
+						path: '',
+						redirectTo: 'invoices',
+						pathMatch: 'full'
+					},
+					{
+						path: 'income',
+						loadChildren: () =>
+							import('./income/income.module').then(
+								(m) => m.IncomeModule
+							)
+					},
+					{
+						path: 'expenses',
+						loadChildren: () =>
+							import('./expenses/expenses.module').then(
+								(m) => m.ExpensesModule
+							)
+					},
+					{
+						path: 'invoices',
+						loadChildren: () =>
+							import('./invoices/invoices.module').then(
+								(m) => m.InvoicesModule
+							)
+					},
+					{
+						path: 'recurring-invoices',
+						loadChildren: () =>
+							import(
+								'./work-in-progress/work-in-progress.module'
+							).then((m) => m.WorkInProgressModule)
+					},
+					{
+						path: 'estimates',
+						loadChildren: () =>
+							import(
+								'./work-in-progress/work-in-progress.module'
+							).then((m) => m.WorkInProgressModule)
+					}
+				]
 			},
 			{
-				path: 'expenses',
+				path: 'clients',
 				loadChildren: () =>
-					import('./expenses/expenses.module').then(
-						(m) => m.ExpensesModule
+					import('./work-in-progress/work-in-progress.module').then(
+						(m) => m.WorkInProgressModule
 					)
-				// canActivate: [RoleGuard],
-				// data: {
-				// 	expectedRole: [
-				// 		// RolesEnum.DATA_ENTRY,
-				// 		// RolesEnum.EMPLOYEE,
-				// 		RolesEnum.ADMIN
-				// 	]
-				// }
 			},
 			{
-				path: 'integrations',
+				path: 'projects',
 				loadChildren: () =>
-					import('./integrations/integrations.module').then(
-						(m) => m.IntegrationsModule
+					import('./work-in-progress/work-in-progress.module').then(
+						(m) => m.WorkInProgressModule
 					)
-				// canActivate: [RoleGuard],
-				// data: {
-				// 	expectedRole: [
-				// 		// RolesEnum.DATA_ENTRY,
-				// 		// RolesEnum.EMPLOYEE,
-				// 		RolesEnum.ADMIN
-				// 	]
-				// }
+			},
+			{
+				path: 'tasks',
+				children: [
+					{
+						path: '',
+						redirectTo: 'dashboard',
+						pathMatch: 'full'
+					},
+					{
+						path: 'dashboard',
+						loadChildren: () =>
+							import('./tasks/tasks.module').then(
+								(m) => m.TasksModule
+							)
+					},
+					{
+						path: 'me',
+						loadChildren: () =>
+							import(
+								'./work-in-progress/work-in-progress.module'
+							).then((m) => m.WorkInProgressModule)
+					},
+					{
+						path: 'team',
+						loadChildren: () =>
+							import(
+								'./work-in-progress/work-in-progress.module'
+							).then((m) => m.WorkInProgressModule)
+					}
+				]
 			},
 			{
 				path: 'proposals',
@@ -76,89 +125,133 @@ const routes: Routes = [
 					import('./proposals/proposals.module').then(
 						(m) => m.ProposalsModule
 					)
-				// canActivate: [RoleGuard],
-				// data: {
-				// 	expectedRole: [
-				// 		// RolesEnum.DATA_ENTRY,
-				// 		// RolesEnum.EMPLOYEE,
-				// 		RolesEnum.ADMIN
-				// 	]
-				// }
 			},
 			{
-				path: 'time-off',
-				loadChildren: () =>
-					import('./time-off/time-off.module').then(
-						(m) => m.TimeOffModule
-					)
-				// canActivate: [RoleGuard],
-				// data: {
-				// 	expectedRole: [
-				// 		// RolesEnum.EMPLOYEE,
-				// 		RolesEnum.ADMIN
-				// 	]
-				// }
+				path: 'employees',
+				children: [
+					{
+						path: '',
+						loadChildren: () =>
+							import('./employees/employees.module').then(
+								(m) => m.EmployeesModule
+							)
+					},
+					{
+						path: 'activity',
+						loadChildren: () =>
+							import(
+								'./work-in-progress/work-in-progress.module'
+							).then((m) => m.WorkInProgressModule)
+					},
+					{
+						path: 'timesheets',
+						loadChildren: () =>
+							import(
+								'./work-in-progress/work-in-progress.module'
+							).then((m) => m.WorkInProgressModule)
+					},
+					{
+						path: 'schedules',
+						loadChildren: () =>
+							import(
+								'./work-in-progress/work-in-progress.module'
+							).then((m) => m.WorkInProgressModule)
+					},
+					{
+						path: 'time-off',
+						loadChildren: () =>
+							import('./time-off/time-off.module').then(
+								(m) => m.TimeOffModule
+							)
+					}
+				]
+			},
+
+			{
+				path: 'organization',
+				children: [
+					{
+						path: 'equipment',
+						loadChildren: () =>
+							import('./equipment/equipment.module').then(
+								(m) => m.EquipmentModule
+							)
+					},
+					{
+						path: 'tags',
+						loadChildren: () =>
+							import('./tags/tags.module').then(
+								(m) => m.TagsModule
+							)
+					},
+					{
+						path: 'candidates',
+						loadChildren: () =>
+							import('./candidates/candidates.module').then(
+								(m) => m.CandidatesModule
+							)
+					},
+					{
+						path: 'email-templates',
+						loadChildren: () =>
+							import(
+								'./work-in-progress/work-in-progress.module'
+							).then((m) => m.WorkInProgressModule)
+					},
+					{
+						path: 'equipment-sharing',
+						loadChildren: () =>
+							import(
+								'./equipment-sharing/equipment-sharing.module'
+							).then((m) => m.EquipmentSharingModule)
+					}
+				]
 			},
 			{
-				path: 'tags',
-				loadChildren: () =>
-					import('./tags/tags.module').then((m) => m.TagsModule)
-			},
-			{
-				path: 'tasks',
-				loadChildren: () =>
-					import('./tasks/tasks.module').then((m) => m.TasksModule)
+				path: 'reports',
+				children: [
+					{
+						path: '',
+						redirectTo: 'time',
+						pathMatch: 'full'
+					},
+					{
+						path: 'time',
+						loadChildren: () =>
+							import(
+								'./work-in-progress/work-in-progress.module'
+							).then((m) => m.WorkInProgressModule)
+					},
+					{
+						path: 'accounting',
+						loadChildren: () =>
+							import(
+								'./work-in-progress/work-in-progress.module'
+							).then((m) => m.WorkInProgressModule)
+					}
+				]
 			},
 			{
 				path: 'help',
 				loadChildren: () =>
 					import('./help/help.module').then((m) => m.HelpModule)
-				// canActivate: [RoleGuard],
-				// data: {
-				// 	expectedRole: [
-				// 		// RolesEnum.DATA_ENTRY,
-				// 		// RolesEnum.EMPLOYEE,
-				// 		RolesEnum.ADMIN
-				// 	]
-				// }
 			},
 			{
 				path: 'about',
 				loadChildren: () =>
 					import('./about/about.module').then((m) => m.AboutModule)
-				// canActivate: [RoleGuard],
-				// data: {
-				// 	expectedRole: [
-				// 		// RolesEnum.DATA_ENTRY,
-				// 		// RolesEnum.EMPLOYEE,
-				// 		RolesEnum.ADMIN
-				// 	]
-				// }
 			},
 			{
-				path: 'employees',
+				path: 'integrations',
 				loadChildren: () =>
-					import('./employees/employees.module').then(
-						(m) => m.EmployeesModule
+					import('./integrations/integrations.module').then(
+						(m) => m.IntegrationsModule
 					)
-				// canActivate: [RoleGuard],
-				// data: { expectedRole: [RolesEnum.ADMIN] }
-			},
-			{
-				path: 'candidates',
-				loadChildren: () =>
-					import('./candidates/candidates.module').then(
-						(m) => m.CandidatesModule
-					)
-				// canActivate: [RoleGuard],
-				// data: { expectedRole: [RolesEnum.ADMIN] }
 			},
 			{
 				path: 'users',
 				loadChildren: () =>
 					import('./users/users.module').then((m) => m.UsersModule)
-				// canActivate: [RoleGuard],
-				// data: { expectedRole: [RolesEnum.ADMIN] }
 			},
 			{
 				path: 'organizations',
@@ -166,8 +259,6 @@ const routes: Routes = [
 					import('./organizations/organizations.module').then(
 						(m) => m.OrganizationsModule
 					)
-				// canActivate: [RoleGuard],
-				// data: { expectedRole: [RolesEnum.ADMIN] }
 			},
 			{
 				path: 'import-export',
@@ -186,27 +277,6 @@ const routes: Routes = [
 				loadChildren: () =>
 					import('./settings/settings.module').then(
 						(m) => m.SettingsModule
-					)
-			},
-			{
-				path: 'equipment',
-				loadChildren: () =>
-					import('./equipment/equipment.module').then(
-						(m) => m.EquipmentModule
-					)
-			},
-			{
-				path: 'equipment-sharing',
-				loadChildren: () =>
-					import('./equipment-sharing/equipment-sharing.module').then(
-						(m) => m.EquipmentSharingModule
-					)
-			},
-			{
-				path: 'invoices',
-				loadChildren: () =>
-					import('./invoices/invoices.module').then(
-						(m) => m.InvoicesModule
 					)
 			},
 			{

--- a/apps/gauzy/src/app/pages/pages.component.ts
+++ b/apps/gauzy/src/app/pages/pages.component.ts
@@ -39,40 +39,115 @@ export class PagesComponent implements OnInit, OnDestroy {
 			}
 		},
 		{
-			title: 'Income',
-			icon: 'plus-circle-outline',
-			link: '/pages/income',
+			title: 'Accounting',
+			icon: 'credit-card-outline',
 			data: {
 				translated: false,
-				translationKey: 'MENU.INCOME',
-				permissionKeys: [PermissionsEnum.ORG_INCOMES_VIEW]
-			}
-		},
-		{
-			title: 'Expenses',
-			icon: 'minus-circle-outline',
-			link: '/pages/expenses',
-			data: {
-				translated: false,
-				translationKey: 'MENU.EXPENSES',
-				permissionKeys: [PermissionsEnum.ORG_EXPENSES_VIEW]
-			}
-		},
-		{
-			title: 'Integrations',
-			icon: 'settings-outline',
-			link: '/pages/integrations',
-			data: {
-				translated: false,
-				translationKey: 'MENU.INTEGRATIONS'
+				translationKey: 'MENU.ACCOUNTING'
 			},
 			children: [
 				{
-					title: 'Upwork',
-					link: '/pages/integrations/upwork',
+					title: 'Invoices',
+					icon: 'file-text-outline',
+					link: '/pages/accounting/invoices',
 					data: {
 						translated: false,
-						translationKey: 'MENU.UPWORK'
+						permissionKeys: [PermissionsEnum.ALL_ORG_VIEW],
+						translationKey: 'MENU.INVOICES'
+					}
+				},
+				{
+					title: 'Recurring Invoices',
+					icon: 'flip-outline',
+					link: '/pages/accounting/recurring-invoices',
+					data: {
+						translated: false,
+						translationKey: 'MENU.RECURRING_INVOICES'
+					}
+				},
+				{
+					title: 'Estimates',
+					icon: 'file-outline',
+					link: '/pages/accounting/estimates',
+					data: {
+						translated: false,
+						translationKey: 'MENU.ESTIMATES'
+					}
+				},
+				{
+					title: 'Income',
+					icon: 'plus-circle-outline',
+					link: '/pages/accounting/income',
+					data: {
+						translated: false,
+						translationKey: 'MENU.INCOME',
+						permissionKeys: [PermissionsEnum.ORG_INCOMES_VIEW]
+					}
+				},
+				{
+					title: 'Expenses',
+					icon: 'minus-circle-outline',
+					link: '/pages/accounting/expenses',
+					data: {
+						translated: false,
+						translationKey: 'MENU.EXPENSES',
+						permissionKeys: [PermissionsEnum.ORG_EXPENSES_VIEW]
+					}
+				}
+			]
+		},
+		{
+			title: 'Clients',
+			icon: 'book-open-outline',
+			link: '/pages/clients',
+			data: {
+				translated: false,
+				translationKey: 'ORGANIZATIONS_PAGE.CLIENTS'
+			}
+		},
+		{
+			title: 'Projects',
+			icon: 'book-outline',
+			link: '/pages/projects',
+			data: {
+				translated: false,
+				translationKey: 'ORGANIZATIONS_PAGE.PROJECTS'
+			}
+		},
+		{
+			title: 'Tasks',
+			icon: 'browser-outline',
+			link: '/pages/tasks',
+			data: {
+				translated: false,
+				translationKey: 'MENU.TASKS'
+			},
+			children: [
+				{
+					title: 'Dashboard',
+					icon: 'list-outline',
+					link: '/pages/tasks/dashboard',
+					data: {
+						translated: false,
+						translationKey: 'MENU.DASHBOARD'
+					}
+				},
+				{
+					title: 'My Tasks',
+					icon: 'person-outline',
+					link: '/pages/tasks/me',
+					data: {
+						translated: false,
+						translationKey: 'MENU.MY_TASKS'
+					}
+				},
+				{
+					title: "Team's Tasks",
+					icon: 'people-outline',
+					link: '/pages/tasks/team',
+					data: {
+						translated: false,
+						translationKey: 'MENU.TEAM_TASKS'
 					}
 				}
 			]
@@ -89,34 +164,232 @@ export class PagesComponent implements OnInit, OnDestroy {
 			}
 		},
 		{
-			title: 'Time Off',
-			icon: 'calendar-outline',
-			link: '/pages/time-off',
+			title: 'Employees',
+			icon: 'people-outline',
 			data: {
 				translated: false,
-				translationKey: 'MENU.TIME_OFF',
-				permissionKeys: [PermissionsEnum.POLICY_VIEW]
-			}
+				translationKey: 'MENU.EMPLOYEES',
+				permissionKeys: [
+					PermissionsEnum.ORG_EMPLOYEES_VIEW,
+					PermissionsEnum.ORG_EXPENSES_EDIT
+				]
+			},
+			children: [
+				{
+					title: 'Manage',
+					icon: 'list-outline',
+					link: '/pages/employees',
+					data: {
+						translated: false,
+						translationKey: 'MENU.MANAGE'
+					}
+				},
+				{
+					title: 'Activity',
+					icon: 'trending-up-outline',
+					link: '/pages/employees/activity',
+					data: {
+						translated: false,
+						translationKey: 'MENU.ACTIVITY'
+					}
+				},
+				{
+					title: 'Timesheets',
+					icon: 'clock-outline',
+					link: '/pages/employees/timesheets',
+					data: {
+						translated: false,
+						translationKey: 'MENU.TIMESHEETS'
+					}
+				},
+				{
+					title: 'Schedules',
+					icon: 'calendar-outline',
+					link: '/pages/employees/schedules',
+					data: {
+						translated: false,
+						translationKey: 'MENU.SCHEDULES'
+					}
+				},
+				{
+					title: 'Time Off',
+					icon: 'eye-off-2-outline',
+					link: '/pages/employees/time-off',
+					data: {
+						translated: false,
+						translationKey: 'MENU.TIME_OFF',
+						permissionKeys: [PermissionsEnum.POLICY_VIEW]
+					}
+				}
+			]
 		},
 		{
-			title: 'Tags',
-			icon: 'pricetags-outline',
-			link: '/pages/tags',
+			title: 'Organization',
+			icon: 'globe-2-outline',
 			data: {
 				translated: false,
-				translationKey: 'MENU.TAGS'
-				//   permissionKeys: [],
-			}
+				translationKey: 'MENU.ORGANIZATION',
+				withOrganizationShortcuts: true
+			},
+			children: [
+				{
+					title: 'Manage',
+					icon: 'globe-2-outline',
+					data: {
+						translated: false,
+						organizationShortcut: true,
+						permissionKeys: [PermissionsEnum.ALL_ORG_EDIT],
+						urlPrefix: `/pages/organizations/edit/`,
+						urlPostfix: '',
+						translationKey: 'MENU.MANAGE'
+					}
+				},
+				{
+					title: 'Equipment',
+					icon: 'shopping-bag-outline',
+					link: '/pages/organization/equipment',
+					data: {
+						translated: false,
+						permissionKeys: [PermissionsEnum.ALL_ORG_VIEW],
+						translationKey: 'MENU.EQUIPMENT'
+					}
+				},
+				{
+					title: 'Tags',
+					icon: 'pricetags-outline',
+					link: '/pages/organization/tags',
+					data: {
+						translated: false,
+						translationKey: 'MENU.TAGS'
+						//   permissionKeys: [],
+					}
+				},
+				{
+					title: 'Clients',
+					icon: 'book-open-outline',
+					link: `/pages/organizations/`,
+					data: {
+						translated: false,
+						organizationShortcut: true,
+						permissionKeys: [PermissionsEnum.ALL_ORG_EDIT],
+						urlPrefix: `/pages/organizations/edit/`,
+						urlPostfix: '/settings/clients',
+						translationKey: 'ORGANIZATIONS_PAGE.CLIENTS'
+					}
+				},
+				{
+					title: 'Vendors',
+					icon: 'car-outline',
+					link: `/pages/organizations/`,
+					data: {
+						translated: false,
+						organizationShortcut: true,
+						permissionKeys: [PermissionsEnum.ALL_ORG_EDIT],
+						urlPrefix: `/pages/organizations/edit/`,
+						urlPostfix: '/settings/vendors',
+						translationKey: 'ORGANIZATIONS_PAGE.VENDORS'
+					}
+				},
+				{
+					title: 'Projects',
+					icon: 'book-outline',
+					link: `/pages/organizations/`,
+					data: {
+						translated: false,
+						organizationShortcut: true,
+						permissionKeys: [PermissionsEnum.ALL_ORG_EDIT],
+						urlPrefix: `/pages/organizations/edit/`,
+						urlPostfix: '/settings/projects',
+						translationKey: 'ORGANIZATIONS_PAGE.PROJECTS'
+					}
+				},
+				{
+					title: 'Positions',
+					icon: 'award-outline',
+					link: `/pages/organizations/`,
+					data: {
+						translated: false,
+						organizationShortcut: true,
+						permissionKeys: [PermissionsEnum.ALL_ORG_EDIT],
+						urlPrefix: `/pages/organizations/edit/`,
+						urlPostfix: '/settings/positions',
+						translationKey: 'ORGANIZATIONS_PAGE.POSITIONS'
+					}
+				},
+				{
+					title: 'Departments',
+					icon: 'briefcase-outline',
+					link: `/pages/organizations/`,
+					data: {
+						translated: false,
+						organizationShortcut: true,
+						permissionKeys: [PermissionsEnum.ALL_ORG_EDIT],
+						urlPrefix: `/pages/organizations/edit/`,
+						urlPostfix: '/settings/departments',
+						translationKey: 'ORGANIZATIONS_PAGE.DEPARTMENTS'
+					}
+				},
+				{
+					title: 'Teams',
+					icon: 'people-outline',
+					link: `/pages/organizations/`,
+					data: {
+						translated: false,
+						organizationShortcut: true,
+						permissionKeys: [PermissionsEnum.ALL_ORG_EDIT],
+						urlPrefix: `/pages/organizations/edit/`,
+						urlPostfix: '/settings/teams',
+						translationKey: 'ORGANIZATIONS_PAGE.EDIT.TEAMS'
+					}
+				},
+				{
+					title: 'Candidates',
+					icon: 'person-done-outline',
+					link: '/pages/organization/candidates',
+					data: {
+						translated: false,
+						translationKey: 'MENU.CANDIDATES'
+					}
+				},
+				{
+					title: 'Email Templates',
+					icon: 'email-outline',
+					link: '/pages/organization/email-templates',
+					data: {
+						translated: false,
+						translationKey: 'MENU.EMAIL_TEMPLATES'
+					}
+				}
+			]
 		},
 		{
-			title: 'Tasks',
-			icon: 'browser-outline',
-			link: '/pages/tasks',
+			title: 'Reports',
+			icon: 'file-text-outline',
+			link: '/pages/reports',
 			data: {
 				translated: false,
-				translationKey: 'MENU.TASKS'
-				//   permissionKeys: [],
-			}
+				translationKey: 'MENU.REPORTS'
+			},
+			children: [
+				{
+					title: 'Time Reports',
+					link: '/pages/reports/time',
+					icon: 'clock-outline',
+					data: {
+						translated: false,
+						translationKey: 'MENU.TIME_REPORTS'
+					}
+				},
+				{
+					title: 'Accounting Reports',
+					link: '/pages/reports/accounting',
+					icon: 'credit-card-outline',
+					data: {
+						translated: false,
+						translationKey: 'MENU.ACCOUNTING_REPORTS'
+					}
+				}
+			]
 		},
 		{
 			title: 'Help',
@@ -151,32 +424,6 @@ export class PagesComponent implements OnInit, OnDestroy {
 			}
 		},
 		{
-			title: 'Employees',
-			icon: 'people-outline',
-			link: '/pages/employees',
-			data: {
-				translated: false,
-				permissionKeys: [
-					PermissionsEnum.ORG_EMPLOYEES_VIEW,
-					PermissionsEnum.ORG_EXPENSES_EDIT
-				],
-				translationKey: 'MENU.EMPLOYEES'
-			}
-		},
-		{
-			title: 'Candidates',
-			icon: 'people-outline',
-			link: '/pages/candidates',
-			data: {
-				translated: false,
-				// permissionKeys: [
-				// 	PermissionsEnum.ORG_EMPLOYEES_VIEW,
-				// 	PermissionsEnum.ORG_EXPENSES_EDIT
-				// ],
-				translationKey: 'MENU.CANDIDATES'
-			}
-		},
-		{
 			title: 'Users',
 			icon: 'people-outline',
 			link: '/pages/users',
@@ -186,72 +433,6 @@ export class PagesComponent implements OnInit, OnDestroy {
 				translationKey: 'MENU.USERS'
 			}
 		},
-		{
-			title: 'Projects',
-			icon: 'book-outline',
-			link: `/pages/organizations/`,
-			data: {
-				translated: false,
-				organizationShortcut: true,
-				permissionKeys: [PermissionsEnum.ALL_ORG_EDIT],
-				urlPrefix: `/pages/organizations/edit/`,
-				urlPostfix: '/settings/projects',
-				translationKey: 'ORGANIZATIONS_PAGE.PROJECTS'
-			}
-		},
-		{
-			title: 'Departments',
-			icon: 'briefcase-outline',
-			link: `/pages/organizations/`,
-			data: {
-				translated: false,
-				organizationShortcut: true,
-				permissionKeys: [PermissionsEnum.ALL_ORG_EDIT],
-				urlPrefix: `/pages/organizations/edit/`,
-				urlPostfix: '/settings/departments',
-				translationKey: 'ORGANIZATIONS_PAGE.DEPARTMENTS'
-			}
-		},
-		{
-			title: 'Clients',
-			icon: 'book-open-outline',
-			link: `/pages/organizations/`,
-			data: {
-				translated: false,
-				organizationShortcut: true,
-				permissionKeys: [PermissionsEnum.ALL_ORG_EDIT],
-				urlPrefix: `/pages/organizations/edit/`,
-				urlPostfix: '/settings/clients',
-				translationKey: 'ORGANIZATIONS_PAGE.CLIENTS'
-			}
-		},
-		{
-			title: 'Positions',
-			icon: 'award-outline',
-			link: `/pages/organizations/`,
-			data: {
-				translated: false,
-				organizationShortcut: true,
-				permissionKeys: [PermissionsEnum.ALL_ORG_EDIT],
-				urlPrefix: `/pages/organizations/edit/`,
-				urlPostfix: '/settings/positions',
-				translationKey: 'ORGANIZATIONS_PAGE.POSITIONS'
-			}
-		},
-		{
-			title: 'Vendors',
-			icon: 'car-outline',
-			link: `/pages/organizations/`,
-			data: {
-				translated: false,
-				organizationShortcut: true,
-				permissionKeys: [PermissionsEnum.ALL_ORG_EDIT],
-				urlPrefix: `/pages/organizations/edit/`,
-				urlPostfix: '/settings/vendors',
-				translationKey: 'ORGANIZATIONS_PAGE.VENDORS'
-			}
-		},
-
 		{
 			title: 'Organizations',
 			icon: 'globe-outline',
@@ -266,49 +447,33 @@ export class PagesComponent implements OnInit, OnDestroy {
 			}
 		},
 		{
-			title: 'Expense Categories',
-			icon: 'list-outline',
-			link: `/pages/organizations/`,
+			title: 'Import/Export',
+			icon: 'arrow-circle-down-outline',
+			link: '/pages/import-export',
 			data: {
 				translated: false,
-				organizationShortcut: true,
-				permissionKeys: [PermissionsEnum.ALL_ORG_EDIT],
-				urlPrefix: `/pages/organizations/edit/`,
-				urlPostfix: '/settings/expense-categories',
-				translationKey: 'ORGANIZATIONS_PAGE.EXPENSE_CATEGORIES'
+				translationKey: 'MENU.IMPORT_EXPORT.IMPORT_EXPORT'
 			}
 		},
 		{
-			title: 'Equipment',
-			icon: 'shopping-bag-outline',
-			link: '/pages/equipment',
+			title: 'Integrations',
+			icon: 'pantone-outline',
+			link: '/pages/integrations',
 			data: {
 				translated: false,
-				permissionKeys: [PermissionsEnum.ALL_ORG_VIEW],
-				translationKey: 'MENU.EQUIPMENT'
-			}
+				translationKey: 'MENU.INTEGRATIONS'
+			},
+			children: [
+				{
+					title: 'Upwork',
+					link: '/pages/integrations/upwork',
+					data: {
+						translated: false,
+						translationKey: 'MENU.UPWORK'
+					}
+				}
+			]
 		},
-		{
-			title: 'Equipment Sharing',
-			icon: 'shopping-cart-outline',
-			link: '/pages/equipment-sharing',
-			data: {
-				translated: false,
-				permissionKeys: [PermissionsEnum.ALL_ORG_VIEW],
-				translationKey: 'MENU.EQUIPMENT_SHARING'
-			}
-		},
-		{
-			title: 'Invoices',
-			icon: 'file-text-outline',
-			link: '/pages/invoices',
-			data: {
-				translated: false,
-				permissionKeys: [PermissionsEnum.ALL_ORG_VIEW],
-				translationKey: 'MENU.INVOICES'
-			}
-		},
-
 		{
 			title: 'Settings',
 			icon: 'settings-outline',
@@ -323,6 +488,20 @@ export class PagesComponent implements OnInit, OnDestroy {
 					data: {
 						translated: false,
 						translationKey: 'MENU.GENERAL'
+					}
+				},
+				{
+					title: 'Payment Gateways',
+					data: {
+						translated: false,
+						translationKey: 'MENU.PAYMENT_GATEWAYS'
+					}
+				},
+				{
+					title: 'Custom SMTP',
+					data: {
+						translated: false,
+						translationKey: 'MENU.CUSTOM_SMTP'
 					}
 				},
 				{
@@ -343,20 +522,10 @@ export class PagesComponent implements OnInit, OnDestroy {
 						translated: false,
 						translationKey: 'MENU.DANGER_ZONE'
 					}
-				},
-				{
-					title: 'Import/Export',
-					icon: 'arrow-circle-down-outline',
-					link: '/pages/import-export',
-					data: {
-						translated: false,
-						translationKey: 'MENU.IMPORT_EXPORT.IMPORT_EXPORT'
-					}
 				}
 			]
 		}
 	];
-
 	menu: NbMenuItem[] = this.MENU_ITEMS;
 
 	constructor(

--- a/apps/gauzy/src/app/pages/time-off/time-off.component.ts
+++ b/apps/gauzy/src/app/pages/time-off/time-off.component.ts
@@ -91,7 +91,7 @@ export class TimeOffComponent implements OnInit, OnDestroy {
 	) {}
 
 	openTimeOffSettings() {
-		this.router.navigate(['/pages/time-off/settings']);
+		this.router.navigate(['/pages/employees/time-off/settings']);
 	}
 
 	async requestDaysOff() {

--- a/apps/gauzy/src/app/pages/work-in-progress/work-in-progress-routing.module.ts
+++ b/apps/gauzy/src/app/pages/work-in-progress/work-in-progress-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { WorkInProgressComponent } from './work-in-progress.component';
+
+const routes: Routes = [
+	{
+		path: '',
+		component: WorkInProgressComponent
+	}
+];
+
+@NgModule({
+	imports: [RouterModule.forChild(routes)],
+	exports: [RouterModule]
+})
+export class WorkInProgressRoutingModule {}

--- a/apps/gauzy/src/app/pages/work-in-progress/work-in-progress.component.ts
+++ b/apps/gauzy/src/app/pages/work-in-progress/work-in-progress.component.ts
@@ -1,0 +1,26 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Store } from '../../@core/services/store.service';
+
+@Component({
+	selector: 'ga-wip',
+	template: `
+		<div>
+			<div
+				style="display: flex; flex-direction: column; align-items: center; margin: 100px; 0px"
+			>
+				<nb-icon
+					icon="flash-outline"
+					style="font-size:50px; color: #cacaca"
+				></nb-icon>
+				<div>This page is coming soon!</div>
+			</div>
+		</div>
+	`
+})
+export class WorkInProgressComponent implements OnInit, OnDestroy {
+	constructor(private store: Store) {}
+
+	ngOnInit() {}
+
+	ngOnDestroy() {}
+}

--- a/apps/gauzy/src/app/pages/work-in-progress/work-in-progress.module.ts
+++ b/apps/gauzy/src/app/pages/work-in-progress/work-in-progress.module.ts
@@ -1,12 +1,6 @@
 import { NgModule } from '@angular/core';
 import { ThemeModule } from '../../@theme/theme.module';
-import {
-	NbCardModule,
-	NbButtonModule,
-	NbInputModule,
-	NbIconModule
-} from '@nebular/theme';
-import { FormsModule } from '@angular/forms';
+import { NbCardModule, NbIconModule } from '@nebular/theme';
 import { WorkInProgressComponent } from './work-in-progress.component';
 import { WorkInProgressRoutingModule } from './work-in-progress-routing.module';
 

--- a/apps/gauzy/src/app/pages/work-in-progress/work-in-progress.module.ts
+++ b/apps/gauzy/src/app/pages/work-in-progress/work-in-progress.module.ts
@@ -1,0 +1,37 @@
+import { NgModule } from '@angular/core';
+import { ThemeModule } from '../../@theme/theme.module';
+import {
+	NbCardModule,
+	NbButtonModule,
+	NbInputModule,
+	NbIconModule
+} from '@nebular/theme';
+import { FormsModule } from '@angular/forms';
+import { WorkInProgressComponent } from './work-in-progress.component';
+import { WorkInProgressRoutingModule } from './work-in-progress-routing.module';
+
+import { TranslateModule, TranslateLoader } from '@ngx-translate/core';
+import { HttpClient } from '@angular/common/http';
+import { TranslateHttpLoader } from '@ngx-translate/http-loader';
+
+export function HttpLoaderFactory(http: HttpClient) {
+	return new TranslateHttpLoader(http, './assets/i18n/', '.json');
+}
+
+@NgModule({
+	imports: [
+		WorkInProgressRoutingModule,
+		ThemeModule,
+		NbCardModule,
+		NbIconModule,
+		TranslateModule.forChild({
+			loader: {
+				provide: TranslateLoader,
+				useFactory: HttpLoaderFactory,
+				deps: [HttpClient]
+			}
+		})
+	],
+	declarations: [WorkInProgressComponent]
+})
+export class WorkInProgressModule {}

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -279,6 +279,7 @@
 	},
 	"MENU": {
 		"DASHBOARD": "Dashboard",
+		"ACCOUNTING": "Accounting",
 		"INCOME": "Income",
 		"EXPENSES": "Expenses",
 		"INTEGRATIONS": "Integrations",
@@ -289,6 +290,7 @@
 		"ABOUT": "About",
 		"ADMIN": "Admin",
 		"EMPLOYEES": "Employees",
+		"MANAGE": "Manage",
 		"CANDIDATES": "Candidates",
 		"ORGANIZATIONS": "Organizations",
 		"SETTINGS": "Settings",
@@ -305,7 +307,21 @@
 		"EQUIPMENT": "Equipment",
 		"EQUIPMENT_SHARING": "Equipment Sharing",
 		"TASKS": "Tasks",
-		"INVOICES": "Invoices"
+		"INVOICES": "Invoices",
+		"ORGANIZATION": "Organization",
+		"RECURRING_INVOICES": "Recurring Invoices",
+		"ESTIMATES": "Estimates",
+		"MY_TASKS": "My Tasks",
+		"TEAM_TASKS": "Team's Tasks",
+		"ACTIVITY": "Activity",
+		"TIMESHEETS": "Timesheets",
+		"SCHEDULES": "Schedules",
+		"EMAIL_TEMPLATES": "Email Templates",
+		"REPORTS": "Reports",
+		"TIME_REPORTS": "Time Reports",
+		"ACCOUNTING_REPORTS": "Accounting Reports",
+		"PAYMENT_GATEWAYS": "Payment Gateways",
+		"CUSTOM_SMTP": "Custom SMTP"
 	},
 	"SETTINGS_MENU": {
 		"THEMES": "Themes",


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
Please check the video for the new organization menu items. 
1. I have added **all items** given in #850 and the ones which have not implemented route to a dummy component. I have done this so that future implementations are easy, now we will just need to change the route and do nothing with the sidebar code.
2. If required we can also comment out the dummy sidebar items and then uncomment them when implemented.
3. There was a 'Candidates' route which was not in the ticket, I have added in the Organization section.
4. The organization edit page has too many tabs now and they are flowing off the screen, we'll need to fix this.
5. I think the 'Clients' & 'Projects' menu items under the Accounting item might be a little confusing with 'Organization > Clients' and 'Organization > Projects' ?

Video:
https://www.loom.com/share/8e7431bab1654e15abafc86285e3f418

Images of the sidebar:
<img width="238" alt="Screen Shot 2020-04-01 at 9 40 56 PM" src="https://user-images.githubusercontent.com/6750734/78160465-9e9d9a80-7461-11ea-91e1-864264e37abe.png">
 <img width="243" alt="Screen Shot 2020-04-01 at 9 41 15 PM" src="https://user-images.githubusercontent.com/6750734/78160441-92194200-7461-11ea-9d86-74cc1e28930d.png">
