### PR TITLE
fix: #921 fixed role selector load condition

### DIFF
--- a/apps/gauzy/src/app/@shared/user/forms/basic-info/basic-info-form.component.html
+++ b/apps/gauzy/src/app/@shared/user/forms/basic-info/basic-info-form.component.html
@@ -126,12 +126,14 @@
 				</div>
 			</div>
 		</div>
-		<div class="col-sm-6" *ngIf="!(!isEmployee || !isCandidate)">
+
+		<div class="col-sm-6" *ngIf="!(isEmployee || isCandidate)">
 			<div class="form-group">
-				<label for="startedWork" class="label">{{
+				<label for="role" class="label">{{
 					'FORM.LABELS.ROLE' | translate
 				}}</label>
 				<nb-select
+					id="role"
 					class="d-block"
 					placeholder="{{ 'FORM.PLACEHOLDERS.ROLE' | translate }}"
 					formControlName="role"
@@ -197,11 +199,11 @@
 					id="offerDateInput"
 					formControlName="offerDate"
 					nbInput
-					[nbDatepicker]="offertDatePicker"
+					[nbDatepicker]="offerDatePicker"
 					placeholder="{{ 'POP_UPS.PICK_DATE' | translate }}"
 					[autocomplete]="off"
 				/>
-				<nb-datepicker #offertDatePicker></nb-datepicker>
+				<nb-datepicker #offerDatePicker></nb-datepicker>
 			</div>
 		</div>
 		<div class="col-sm-6">


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
**What got fixed?**
This condition did not match up in the markup `*ngIf="!(!isEmployee || !isCandidate)"` 
Updating the condition to `*ngIf="!(isEmployee || isCandidate)"` with an assumption that role needs to be role needs to be enabled when the component inputs `isCandidate` or `isEmployee` is **not** set to `true`.

**Demo after fix**
https://www.loom.com/share/00238f092491465eab2960f767b6e5b0