### PR TITLE
feat: #673 consider working employees only

### DIFF
--- a/apps/api/src/app/employee-statistics/employee-statistics.service.ts
+++ b/apps/api/src/app/employee-statistics/employee-statistics.service.ts
@@ -14,7 +14,6 @@ import { Between, In, LessThanOrEqual, MoreThanOrEqual, IsNull } from 'typeorm';
 import { subMonths, startOfMonth, endOfMonth } from 'date-fns';
 import { EmployeeRecurringExpenseService } from '../employee-recurring-expense/employee-recurring-expense.service';
 import { OrganizationRecurringExpenseService } from '../organization-recurring-expense/organization-recurring-expense.service';
-import * as moment from 'moment';
 
 @Injectable()
 export class EmployeeStatisticsService {

--- a/apps/api/src/app/employee-statistics/queries/handlers/aggregate-employee-statistic.handler.ts
+++ b/apps/api/src/app/employee-statistics/queries/handlers/aggregate-employee-statistic.handler.ts
@@ -1,14 +1,16 @@
 import {
 	AggregatedEmployeeStatistic,
 	EmployeeStatisticSum,
-	StatisticSum
+	StatisticSum,
+	MonthAggregatedSplitExpense
 } from '@gauzy/models';
 import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 import { startOfMonth, subMonths } from 'date-fns';
 import { EmployeeService } from '../../../employee/employee.service';
 import { AggregatedEmployeeStatisticQuery } from '../aggregate-employee-statistic.query';
 import { EmployeeStatisticsService } from './../../employee-statistics.service';
-
+import { LessThanOrEqual, Not, IsNull } from 'typeorm';
+import * as moment from 'moment';
 /**
  * Finds income, expense, profit and bonus for all employees for the given month.
  * If month is not specified, finds from the start of time till now.
@@ -28,22 +30,36 @@ export class AggregateOrganizationQueryHandler
 			input: { filterDate, organizationId }
 		} = command;
 
-		// Calculate transactions for 1 month if filterDate is available, last 20 years otherwise.
+		// Calculate transactions for 1 month if filterDate is available,
+		// TODO: last 20 years otherwise. More than one month can be very complex, since in any given month, any number of employees can be working
 		const searchInput = {
-			months: filterDate ? 1 : 12 * 20,
+			months: 1,
 			valueDate: filterDate ? filterDate : new Date()
 		};
 
 		// Get employees of input organization
-		const { items: employees } = await this.employeeService.findAll({
-			select: ['id'],
-			where: {
-				organization: {
-					id: organizationId
-				}
-			},
-			relations: ['user']
-		});
+		// const { items: employees } = await this.employeeService.findAll({
+		// 	select: ['id'],
+		// 	where: {
+		// 		organization: {
+		// 			id: organizationId
+		// 		},
+		// 		startedWorkOn: filterDate ? LessThanOrEqual(
+		// 			moment(filterDate)
+		// 				.endOf('month')
+		// 				.toDate()
+		// 		) : Not(IsNull()) //Only employees that started work on before the filter date
+		// 	},
+		// 	relations: ['user']
+		// });
+
+		const {
+			items: employees
+		} = await this.employeeService.findWorkingEmployees(
+			organizationId,
+			filterDate,
+			true
+		);
 
 		const employeeMap: Map<string, EmployeeStatisticSum> = new Map();
 
@@ -55,7 +71,10 @@ export class AggregateOrganizationQueryHandler
 				expense: 0,
 				bonus: 0,
 				profit: 0,
-				employee
+				employee: {
+					id: employee.id,
+					user: employee.user
+				}
 			});
 		});
 
@@ -190,25 +209,27 @@ export class AggregateOrganizationQueryHandler
 	) {
 		const employeeIds = [...employeeMap.keys()];
 
-		// Fetch split expenses and the number of employees the expense need to be split among
-		const {
-			items: expenses,
-			splitAmong
-		} = await this.employeeStatisticsService.employeeSplitExpenseInNMonths(
+		// Fetch split expenses and the number of employees the expense need to be split among for each month
+		// TODO: Handle case when searchInput.months > 1
+		const expenses = await this.employeeStatisticsService.employeeSplitExpenseInNMonths(
 			employeeIds[0], // split expenses are fetched at organization level, 1st Employee
 			searchInput.valueDate,
-			searchInput.months
+			searchInput.months //this is always 1
 		);
 
-		// sum all split expenses amounts
-		const commonSplitAmount = expenses.reduce((a, b) => a + b.amount, 0);
+		//Since we are only calculating for one month, we only expect one value here.
+		const monthSplitExpense: MonthAggregatedSplitExpense = expenses
+			.values()
+			.next().value;
 
-		// Add split expense share to each employee's expenses
-		employeeMap.forEach((emp) => {
-			emp.expense = Number(
-				(emp.expense + commonSplitAmount / splitAmong).toFixed(2)
-			);
-		});
+		if (monthSplitExpense) {
+			// Add split expense share to each employee's expenses
+			employeeMap.forEach((emp) => {
+				emp.expense = Number(
+					(emp.expense + monthSplitExpense.splitExpense).toFixed(2)
+				);
+			});
+		}
 	}
 
 	private async _loadOrganizationRecurringSplitExpenses(
@@ -218,63 +239,27 @@ export class AggregateOrganizationQueryHandler
 		const employeeIds = [...employeeMap.keys()];
 
 		// Fetch split expenses and the number of employees the expense need to be split among
-		const {
-			items: organizationRecurringSplitExpenses,
-			splitAmong
-		} = await this.employeeStatisticsService.organizationRecurringSplitExpenses(
-			employeeIds[0]
+		const organizationRecurringSplitExpenses = await this.employeeStatisticsService.organizationRecurringSplitExpenses(
+			employeeIds[0],
+			searchInput.valueDate,
+			searchInput.months //this is always 1
 		);
 
-		/**
-		 * Add Organization split recurring expense from the
-		 * expense start date
-		 * OR
-		 * past N months to each month's expense, whichever is lesser
-		 * Stop adding recurring expenses at the month where it was stopped
-		 * OR
-		 * till the input date
-		 */
-		const splitExpenses = organizationRecurringSplitExpenses.map(
-			(expense) => {
-				// Find start date based on input date and X months.
-				const inputStartDate = subMonths(
-					startOfMonth(searchInput.valueDate),
-					searchInput.months - 1
-				);
+		//Since we are only calculating for one month, we only expect one value here.
+		const monthSplitExpense: MonthAggregatedSplitExpense = organizationRecurringSplitExpenses
+			.values()
+			.next().value;
 
-				/**
-				 * Add Organization split recurring expense from the
-				 * expense start date
-				 * OR
-				 * past N months to each month's expense, whichever is more recent
-				 */
-				const requiredStartDate =
-					expense.startDate > inputStartDate
-						? expense.startDate
-						: inputStartDate;
-
-				let amount = 0;
-				for (
-					const date = requiredStartDate;
-					date <= searchInput.valueDate;
-					date.setMonth(date.getMonth() + 1)
-				) {
-					// Stop loading expense if the split recurring expense has ended before input date
-					if (expense.endDate && date > expense.endDate) break;
-
-					// accumulate employee's recurring expense share for each month
-					amount += Number(expense.value) / splitAmong;
-				}
-				return amount;
-			}
-		);
-
-		// sum accumulate employee's recurring expense shares
-		const employeeShare = splitExpenses.reduce((a, b) => a + b, 0);
-		employeeMap.forEach(
-			(emp) =>
-				(emp.expense = Number((emp.expense + employeeShare).toFixed(2)))
-		);
+		if (monthSplitExpense) {
+			employeeMap.forEach(
+				(emp) =>
+					(emp.expense = Number(
+						(emp.expense + monthSplitExpense.splitExpense).toFixed(
+							2
+						)
+					))
+			);
+		}
 	}
 
 	private _calculateProfit(employeeMap: Map<string, EmployeeStatisticSum>) {

--- a/apps/api/src/app/employee-statistics/queries/handlers/aggregate-employee-statistic.handler.ts
+++ b/apps/api/src/app/employee-statistics/queries/handlers/aggregate-employee-statistic.handler.ts
@@ -1,16 +1,14 @@
 import {
 	AggregatedEmployeeStatistic,
 	EmployeeStatisticSum,
-	StatisticSum,
-	MonthAggregatedSplitExpense
+	MonthAggregatedSplitExpense,
+	StatisticSum
 } from '@gauzy/models';
 import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 import { startOfMonth, subMonths } from 'date-fns';
 import { EmployeeService } from '../../../employee/employee.service';
 import { AggregatedEmployeeStatisticQuery } from '../aggregate-employee-statistic.query';
 import { EmployeeStatisticsService } from './../../employee-statistics.service';
-import { LessThanOrEqual, Not, IsNull } from 'typeorm';
-import * as moment from 'moment';
 /**
  * Finds income, expense, profit and bonus for all employees for the given month.
  * If month is not specified, finds from the start of time till now.

--- a/apps/api/src/app/employee-statistics/queries/handlers/month-aggregated-employee-statistics.handler.ts
+++ b/apps/api/src/app/employee-statistics/queries/handlers/month-aggregated-employee-statistics.handler.ts
@@ -239,29 +239,27 @@ export class MonthAggregatedEmployeeStatisticsQueryHandler
 		statisticsMap: Map<string, MonthAggregatedEmployeeStatistics>
 	) {
 		// Fetch split expenses and the number of employees the expense need to be split among
-		const {
-			items: expenses,
-			splitAmong
-		} = await this.employeeStatisticsService.employeeSplitExpenseInNMonths(
+		// the split among will be different for every month, depending upon the number of active employees in the month
+		const splitExpensesMap = await this.employeeStatisticsService.employeeSplitExpenseInNMonths(
 			input.employeeId,
 			input.valueDate,
 			input.months
 		);
 
-		expenses.map((expense) => {
-			const key = `${expense.valueDate.getMonth()}-${expense.valueDate.getFullYear()}`;
-			const amount = Number(expense.amount) / splitAmong;
+		splitExpensesMap.forEach((value, key) => {
 			if (statisticsMap.has(key)) {
 				// Update expense statistics values in map if key pre-exists
 				const stat = statisticsMap.get(key);
-				stat.expense = Number((amount + stat.expense).toFixed(2));
+				stat.expense = Number(
+					(value.splitExpense + stat.expense).toFixed(2)
+				);
 			} else {
 				// Add a new map entry if the key(month-year) does not already exist
 				const newStat: MonthAggregatedEmployeeStatistics = {
-					month: expense.valueDate.getMonth(),
-					year: expense.valueDate.getFullYear(),
+					month: value.month,
+					year: value.year,
 					income: 0,
-					expense: Number(amount.toFixed(2)),
+					expense: Number(value.splitExpense.toFixed(2)),
 					profit: 0,
 					bonus: 0
 				};
@@ -271,9 +269,9 @@ export class MonthAggregatedEmployeeStatisticsQueryHandler
 	}
 
 	/**
-	 * 
-	 * @param input 
-	 * @param statisticsMap 
+	 *
+	 * @param input
+	 * @param statisticsMap
 	 * Fetches employee's organization recurring expenses that were marked to be split among
 	 * its employees for past N months from given date
 	 * Updates expense statistics values in map if key pre-exists
@@ -284,66 +282,30 @@ export class MonthAggregatedEmployeeStatisticsQueryHandler
 		input: MonthAggregatedEmployeeStatisticsFindInput,
 		statisticsMap: Map<string, MonthAggregatedEmployeeStatistics>
 	) {
-		const {
-			items: organizationRecurringSplitExpenses,
-			splitAmong
-		} = await this.employeeStatisticsService.organizationRecurringSplitExpenses(
-			input.employeeId
+		const splitExpensesMap = await this.employeeStatisticsService.organizationRecurringSplitExpenses(
+			input.employeeId,
+			input.valueDate,
+			input.months
 		);
 
-		/**
-		 * Add Organization split recurring expense from the
-		 * expense start date
-		 * OR
-		 * past N months to each month's expense, whichever is lesser
-		 * Stop adding recurring expenses at the month where it was stopped
-		 * OR
-		 * till the input date
-		 */
-		organizationRecurringSplitExpenses.map((expense) => {
-			// Find start date based on input date and X months.
-			const inputStartDate = subMonths(
-				startOfMonth(input.valueDate),
-				input.months - 1
-			);
-
-			/**
-			 * Add Organization split recurring expense from the
-			 * expense start date
-			 * OR
-			 * past N months to each month's expense, whichever is more recent
-			 */
-			const requiredStartDate =
-				expense.startDate > inputStartDate
-					? expense.startDate
-					: inputStartDate;
-
-			for (
-				const date = requiredStartDate;
-				date <= input.valueDate;
-				date.setMonth(date.getMonth() + 1)
-			) {
-				// Stop loading expense if the split recurring expense has ended before input date
-				if (expense.endDate && date > expense.endDate) break;
-
-				const key = `${date.getMonth()}-${date.getFullYear()}`;
-				const amount = Number(expense.value) / splitAmong;
-				if (statisticsMap.has(key)) {
-					// Update expense statistics values in map if key pre-exists
-					const stat = statisticsMap.get(key);
-					stat.expense = Number((amount + stat.expense).toFixed(2));
-				} else {
-					// Add a new map entry if the key(month-year) does not already exist
-					const newStat: MonthAggregatedEmployeeStatistics = {
-						month: date.getMonth(),
-						year: date.getFullYear(),
-						income: 0,
-						expense: Number(amount.toFixed(2)),
-						profit: 0,
-						bonus: 0
-					};
-					statisticsMap.set(key, newStat);
-				}
+		splitExpensesMap.forEach((value, key) => {
+			if (statisticsMap.has(key)) {
+				// Update expense statistics values in map if key pre-exists
+				const stat = statisticsMap.get(key);
+				stat.expense = Number(
+					(value.splitExpense + stat.expense).toFixed(2)
+				);
+			} else {
+				// Add a new map entry if the key(month-year) does not already exist
+				const newStat: MonthAggregatedEmployeeStatistics = {
+					month: value.month,
+					year: value.year,
+					income: 0,
+					expense: Number(value.splitExpense.toFixed(2)),
+					profit: 0,
+					bonus: 0
+				};
+				statisticsMap.set(key, newStat);
 			}
 		});
 	}

--- a/apps/api/src/app/employee/employee.controller.ts
+++ b/apps/api/src/app/employee/employee.controller.ts
@@ -87,6 +87,28 @@ export class EmployeeController extends CrudController<Employee> {
 		return this.employeeService.findAll({ where: findInput, relations });
 	}
 
+	@ApiOperation({ summary: 'Find all working employees.' })
+	@ApiResponse({
+		status: HttpStatus.OK,
+		description: 'Found working employees',
+		type: Employee
+	})
+	@ApiResponse({
+		status: HttpStatus.NOT_FOUND,
+		description: 'Record not found'
+	})
+	@Get('/working')
+	async findAllWorkingEmployees(
+		@Query('data') data: string
+	): Promise<IPagination<Employee>> {
+		const { organizationId, forMonth, withUser } = JSON.parse(data);
+		return this.employeeService.findWorkingEmployees(
+			organizationId,
+			new Date(forMonth),
+			withUser
+		);
+	}
+
 	@ApiOperation({ summary: 'Find User by id.' })
 	@ApiResponse({
 		status: HttpStatus.OK,

--- a/apps/api/src/app/employee/employee.service.ts
+++ b/apps/api/src/app/employee/employee.service.ts
@@ -1,9 +1,10 @@
 import { EmployeeCreateInput } from '@gauzy/models';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, LessThanOrEqual, Brackets } from 'typeorm';
 import { Employee } from './employee.entity';
 import { CrudService } from '../core/crud/crud.service';
+import * as moment from 'moment';
 
 @Injectable()
 export class EmployeeService extends CrudService<Employee> {
@@ -16,5 +17,54 @@ export class EmployeeService extends CrudService<Employee> {
 
 	async createBulk(input: EmployeeCreateInput[]) {
 		return await this.repository.save(input);
+	}
+
+	/**
+	 * Find the employees working in the organization for a particular month.
+	 * An employee is considered to be 'working' if:
+	 * 1. The startedWorkOn date is (not null and) less than the last day forMonth
+	 * 2. The endWork date is either null or greater than the first day forMonth
+	 * @param organizationId  The organization id of the employees to find
+	 * @param forMonth  Only the month & year is considered
+	 */
+	async findWorkingEmployees(
+		organizationId: string,
+		forMonth: Date,
+		withUser: boolean
+	): Promise<{ total: number; items: Employee[] }> {
+		let query = await this.repository
+			.createQueryBuilder('employee')
+			.where('"employee"."organizationId" = :organizationId', {
+				organizationId
+			})
+			.andWhere('"employee"."startedWorkOn" <= :startedWorkOnCondition', {
+				startedWorkOnCondition: moment(forMonth)
+					.endOf('month')
+					.toDate()
+			})
+			.andWhere(
+				new Brackets((notEndedCondition) => {
+					notEndedCondition
+						.where('"employee"."endWork" IS NULL')
+						.orWhere(
+							'"employee"."endWork" >= :endWorkOnCondition',
+							{
+								endWorkOnCondition: moment(forMonth)
+									.startOf('month')
+									.toDate()
+							}
+						);
+				})
+			);
+
+		if (withUser) {
+			query = query.leftJoinAndSelect('employee.user', 'user');
+		}
+
+		const [items, total] = await query.getManyAndCount();
+		return {
+			total,
+			items
+		};
 	}
 }

--- a/apps/api/src/app/employee/employee.service.ts
+++ b/apps/api/src/app/employee/employee.service.ts
@@ -1,7 +1,7 @@
 import { EmployeeCreateInput } from '@gauzy/models';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, LessThanOrEqual, Brackets } from 'typeorm';
+import { Repository, Brackets } from 'typeorm';
 import { Employee } from './employee.entity';
 import { CrudService } from '../core/crud/crud.service';
 import * as moment from 'moment';

--- a/apps/gauzy/src/app/@core/services/employees.service.ts
+++ b/apps/gauzy/src/app/@core/services/employees.service.ts
@@ -26,6 +26,23 @@ export class EmployeesService {
 		);
 	}
 
+	getWorking(
+		organizationId: string,
+		forMonth: Date,
+		withUser: boolean
+	): Promise<{ items: Employee[]; total: number }> {
+		const data = JSON.stringify({ organizationId, forMonth, withUser });
+		return this.http
+			.get<{ items: Employee[]; total: number }>(
+				`/api/employee/working`,
+				{
+					params: { data }
+				}
+			)
+			.pipe(first())
+			.toPromise();
+	}
+
 	getEmployeeById(id: string) {
 		return this.http
 			.get<Employee>(`/api/employee/${id}`)

--- a/apps/gauzy/src/app/@shared/expenses/expenses-mutation/expenses-mutation.component.html
+++ b/apps/gauzy/src/app/@shared/expenses/expenses-mutation/expenses-mutation.component.html
@@ -18,6 +18,7 @@
 			placeholder="Organization"
 			[defaultSelected]="false"
 			(selectionChanged)="onEmployeeChange($event)"
+			[selectedDate]="valueDate.value"
 		></ga-employee-selector>
 		<span
 			*ngIf="showTooltip"

--- a/apps/gauzy/src/app/@shared/income/income-mutation/income-mutation.component.html
+++ b/apps/gauzy/src/app/@shared/income/income-mutation/income-mutation.component.html
@@ -14,6 +14,7 @@
 			[hidden]="income"
 			[skipGlobalChange]="true"
 			class="employees"
+			[selectedDate]="valueDate"
 		>
 		</ga-employee-selector>
 

--- a/apps/gauzy/src/app/@theme/components/header/selectors/employee/employee.component.ts
+++ b/apps/gauzy/src/app/@theme/components/header/selectors/employee/employee.component.ts
@@ -7,7 +7,7 @@ import {
 	EventEmitter
 } from '@angular/core';
 import { EmployeesService } from 'apps/gauzy/src/app/@core/services/employees.service';
-import { first, takeUntil } from 'rxjs/operators';
+import { takeUntil } from 'rxjs/operators';
 import { Store } from 'apps/gauzy/src/app/@core/services/store.service';
 import { Subject } from 'rxjs';
 import { Tag } from '@gauzy/models';

--- a/apps/gauzy/src/app/@theme/components/header/selectors/employee/employee.component.ts
+++ b/apps/gauzy/src/app/@theme/components/header/selectors/employee/employee.component.ts
@@ -64,6 +64,18 @@ export class EmployeeSelectorComponent implements OnInit, OnDestroy {
 	@Input()
 	placeholder: string;
 
+	@Input()
+	set selectedDate(value: Date) {
+		this._selectedDate = value;
+		this.loadWorkingEmployees(this.store.selectedOrganization.id, value);
+	}
+
+	get selectedDate() {
+		return this._selectedDate;
+	}
+
+	private _selectedDate?: Date;
+
 	@Output()
 	selectionChanged: EventEmitter<SelectedEmployee> = new EventEmitter();
 
@@ -132,48 +144,20 @@ export class EmployeeSelectorComponent implements OnInit, OnDestroy {
 	}
 
 	private async _loadEmployees() {
-		/**
-		 * TODO: fetch only employees of selected organization,
-		 * currently all employees are fetched and filtered at the frontend
-		 */
-
-		const { items } = await this.employeesService
-			.getAll(['user'])
-			.pipe(first())
-			.toPromise();
-
-		const load = (loadItems) => {
-			this.people = [
-				...loadItems.map((e) => {
-					return {
-						id: e.id,
-						firstName: e.user.firstName,
-						lastName: e.user.lastName,
-						imageUrl: e.user.imageUrl
-					};
-				})
-			];
-			if (this.showAllEmployeesOption)
-				this.people.unshift(ALL_EMPLOYEES_SELECTED);
-		};
-
-		this.store.selectedOrganization$.subscribe((org) => {
-			if (org) {
-				load(items.filter((e) => e.orgId === org.id));
+		this.store.selectedOrganization$.subscribe(async (org) => {
+			if (org && this.store.selectedDate) {
+				this.loadWorkingEmployees(org.id, this.store.selectedDate);
 			}
 		});
 
-		const selectedOrg = this.store.selectedOrganization;
-		load(
-			selectedOrg
-				? items.filter((e) => e.orgId === selectedOrg.id)
-				: items
-		);
-
-		if (items.length > 0 && !this.store.selectedEmployee) {
-			this.store.selectedEmployee =
-				this.people[0] || ALL_EMPLOYEES_SELECTED;
-		}
+		this.store.selectedDate$.subscribe(async (date) => {
+			if (date && this.store.selectedOrganization) {
+				this.loadWorkingEmployees(
+					this.store.selectedOrganization.id,
+					date
+				);
+			}
+		});
 
 		if (!this.selectedEmployee) {
 			// This is so selected employee doesn't get reset when it's already set from somewhere else
@@ -188,6 +172,36 @@ export class EmployeeSelectorComponent implements OnInit, OnDestroy {
 		)
 			this.selectedEmployee = null;
 	}
+
+	loadWorkingEmployees = async (orgId: string, selectedDate: Date) => {
+		const { items } = await this.employeesService.getWorking(
+			orgId,
+			selectedDate,
+			true
+		);
+
+		this.people = [
+			...items.map((e) => {
+				return {
+					id: e.id,
+					firstName: e.user.firstName,
+					lastName: e.user.lastName,
+					imageUrl: e.user.imageUrl
+				};
+			})
+		];
+
+		//Insert All Employees Option
+		if (this.showAllEmployeesOption) {
+			this.people.unshift(ALL_EMPLOYEES_SELECTED);
+		}
+
+		//Set selected employee if no employee selected
+		if (items.length > 0 && !this.store.selectedEmployee) {
+			this.store.selectedEmployee =
+				this.people[0] || ALL_EMPLOYEES_SELECTED;
+		}
+	};
 
 	ngOnDestroy() {
 		this._ngDestroy$.next();

--- a/apps/gauzy/src/app/pages/employees/employees.component.ts
+++ b/apps/gauzy/src/app/pages/employees/employees.component.ts
@@ -365,7 +365,8 @@ export class EmployeesComponent extends TranslationBaseComponent
 				averageIncome: Math.floor(this.averageIncome),
 				averageExpenses: Math.floor(this.averageExpense),
 				averageBonus: Math.floor(this.averageBonus),
-				bonusDate: Date.now()
+				bonusDate: Date.now(),
+				startedWorkOn: emp.startedWorkOn
 			});
 		}
 

--- a/apps/gauzy/src/app/pages/employees/table-components/employee-work-status/employee-work-status.component.html
+++ b/apps/gauzy/src/app/pages/employees/table-components/employee-work-status/employee-work-status.component.html
@@ -6,13 +6,25 @@
 </div>
 <div
 	class="text-center d-block"
-	*ngIf="rowData.isActive && !rowData.workStatus"
+	*ngIf="!rowData.startedWorkOn"
+	nbTooltip="{{ 'EMPLOYEES_PAGE.NOT_STARTED_HELP' | translate }}"
+>
+	<div class="badge-disabled">
+		{{ 'EMPLOYEES_PAGE.NOT_STARTED' | translate }}
+	</div>
+</div>
+<div
+	class="text-center d-block"
+	*ngIf="rowData.startedWorkOn && rowData.isActive && !rowData.workStatus"
 >
 	<div class="badge-success">
 		{{ 'EMPLOYEES_PAGE.ACTIVE' | translate }}
 	</div>
 </div>
-<div class="text-center d-block" *ngIf="!rowData.isActive">
+<div
+	class="text-center d-block"
+	*ngIf="rowData.startedWorkOn && !rowData.isActive"
+>
 	<div class="badge-danger">
 		{{ 'EMPLOYEES_PAGE.DELETED' | translate }}
 	</div>

--- a/apps/gauzy/src/app/pages/employees/table-components/employee-work-status/employee-work-status.component.scss
+++ b/apps/gauzy/src/app/pages/employees/table-components/employee-work-status/employee-work-status.component.scss
@@ -10,3 +10,9 @@
 	padding: 5px;
 	background-color: #00d68f;
 }
+
+.badge-disabled {
+	text-align: center;
+	padding: 5px;
+	background-color: #ccc;
+}

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -481,7 +481,9 @@
 			"FINISHED_ADDING": "I’ve Added All Current Employees",
 			"NEXT": "Next",
 			"PREVIOUS": "Previous"
-		}
+		},
+		"NOT_STARTED": "Not Started",
+		"NOT_STARTED_HELP": "Started work on date is not set for this employee. The employee will not be considered in accounts, split expenses etc."
 	},
 	"CANDIDATES_PAGE": {
 		"HEADER": "Manage Candidates for ",

--- a/libs/models/src/lib/employee-statistics.model.ts
+++ b/libs/models/src/lib/employee-statistics.model.ts
@@ -1,4 +1,5 @@
 import { Employee } from './employee.model';
+import { User } from './user.model';
 
 export interface EmployeeStatisticsFindInput {
 	valueDate: Date;
@@ -25,6 +26,13 @@ export interface MonthAggregatedEmployeeStatistics {
 	bonus: number;
 }
 
+export interface MonthAggregatedSplitExpense {
+	month: number;
+	year: number;
+	splitExpense: number;
+	splitAmong: number;
+}
+
 export interface AggregatedEmployeeStatisticFindInput {
 	organizationId: string;
 	filterDate: Date;
@@ -38,7 +46,10 @@ export interface StatisticSum {
 }
 
 export interface EmployeeStatisticSum extends StatisticSum {
-	employee: Employee;
+	employee: {
+		id: string;
+		user: User;
+	};
 }
 
 export interface AggregatedEmployeeStatistic {

--- a/libs/models/src/lib/employee-statistics.model.ts
+++ b/libs/models/src/lib/employee-statistics.model.ts
@@ -1,4 +1,3 @@
-import { Employee } from './employee.model';
 import { User } from './user.model';
 
 export interface EmployeeStatisticsFindInput {


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

**Not Working Employees**
1. An employee is 'not working' If the _startWorksOn_ date is not set
2. Such an employee will not be shown in the dashboard as well as the employee selector 
3. Also in windows like Add Income, Add Expense. The employees shown will depend on the date selected (Because it does not make sense to add an Employee's expense if he/she is not working)
Video No 1: https://www.loom.com/share/d6ed6596f43b4c5cada10f36c350da43

**Split Expenses & Recurring Split Expenses**
1. Split expenses are divided among working employees only.
2. Currently, the data in the Accounting page and HR charts are correct, We will move the calculation to the backend hence the data on the left side of the HR component might not be correct right now, it will be fixed soon but to save time & not do double work we'll fix that in #912 (probably by Monday/Tuesday itself)
3. When the date is not selected in the charts component, then it shows correctly split data up to one year.

In the video below:
Jan has 1 employee
Feb has 2 employees
March has 3 employees
April has 4 employees
Video No. 2: https://www.loom.com/share/fcfe80db704f41ac8418c288590264dd
Video No. 3 (please only see the charts component here): https://www.loom.com/share/1b55e74ad11a4c2ba5bcc543a0ee91a9

**What's left**
1. Edge cases & extensive testing (when no expense, no employee working etc.)
2. Left side report in HR - #912 
3. In Accounting, the case when date is not selected. @evereq  in this case, should we display data since start of time or last one year?