### PR TITLE
fix: #981 fixed slow user data seeding

### DIFF
--- a/apps/api/src/app/organization/organization.seed.ts
+++ b/apps/api/src/app/organization/organization.seed.ts
@@ -40,18 +40,18 @@ export const createOrganizations = async (
 
 	const randomOrganizations: Organization[] = [];
 
-	for (let index = 1; index <= 5; index++) {
+	for (let index = 0; index < 5; index++) {
 		const organization = new Organization();
 		const companyName = faker.company.companyName();
 
 		const logoAbbreviation = _extractLogoAbbreviation(companyName);
 
 		organization.name = companyName;
-		organization.currency = currencies[(index % currencies.length) + 1 - 1];
+		organization.currency = currencies[index % currencies.length];
 		organization.defaultValueDateType =
-			defaultDateTypes[(index % defaultDateTypes.length) + 1 - 1];
+			defaultDateTypes[index % defaultDateTypes.length];
 		organization.imageUrl = getDummyImage(330, 300, logoAbbreviation);
-		organization.tenant = tenant[index];
+		organization.tenant = tenant[index % tenant.length];
 		organization.invitesAllowed = true;
 
 		const { bonusType, bonusPercentage } = randomBonus();

--- a/apps/api/src/app/role/role.seed.ts
+++ b/apps/api/src/app/role/role.seed.ts
@@ -1,4 +1,4 @@
-// Modified code from https://github.com/alexitaylor/angular-graphql-nestjs-postgres-starter-kit. 
+// Modified code from https://github.com/alexitaylor/angular-graphql-nestjs-postgres-starter-kit.
 // MIT License, see https://github.com/alexitaylor/angular-graphql-nestjs-postgres-starter-kit/blob/master/LICENSE
 // Copyright (c) 2019 Alexi Taylor
 
@@ -7,22 +7,21 @@ import { Role } from './role.entity';
 import { RolesEnum } from '@gauzy/models';
 
 export const createRoles = async (connection: Connection): Promise<Role[]> => {
-    const roles: Role[] = [];
-    const rolesNames = Object.values(RolesEnum);
+	const roles: Role[] = [];
+	const rolesNames = Object.values(RolesEnum);
 
-    for (const name of rolesNames) {
-        const role = new Role();
-        role.name = name;
+	for (const name of rolesNames) {
+		const role = new Role();
+		role.name = name;
+		roles.push(role);
+	}
 
-        await connection
-            .createQueryBuilder()
-            .insert()
-            .into(Role)
-            .values(role)
-            .execute();
+	await connection
+		.createQueryBuilder()
+		.insert()
+		.into(Role)
+		.values(roles)
+		.execute();
 
-        roles.push(role);
-    }
-
-    return roles;
+	return roles;
 };

--- a/apps/api/src/app/tenant/tenant.seed.ts
+++ b/apps/api/src/app/tenant/tenant.seed.ts
@@ -19,21 +19,19 @@ export const createTenants = async (
 		}
 	];
 
-	for (let i = 0; i < tenants.length; i++) {
-		await insertTenant(connection, tenants[i]);
-	}
+	await insertTenants(connection, tenants);
 
 	return tenants;
 };
 
-const insertTenant = async (
+const insertTenants = async (
 	connection: Connection,
-	tenant: Tenant
+	tenants: Tenant[]
 ): Promise<void> => {
 	await connection
 		.createQueryBuilder()
 		.insert()
 		.into(Tenant)
-		.values(tenant)
+		.values(tenants)
 		.execute();
 };


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

**What is new?**
1. Make single insert call to DB to save all user types.
2. There are multiple user types, Admin, Super Admin, Employee, Candidate, Random Candidate and Random users that need to be created as part of User seeding. Awaiting for fake data generation several users in user type slowed down the seeding process. This now is made to run in parallel using promise.all().  
3. Organization ->Tenant mapping in Organization seed
**Time to seed Users before this PR: 66898 ms**
![Annotation 2020-04-12 104301](https://user-images.githubusercontent.com/32574315/79063467-83335a80-7cbf-11ea-9050-a1197ee26c17.jpg)

**Time to seed Users after this PR: 17246 ms**
![After](https://user-images.githubusercontent.com/32574315/79063482-9e05cf00-7cbf-11ea-8fd2-9995224d7001.jpg)

`const oldSeedTime = 66898;`
`const newSeedTime = 17246;` 
`const percentageIncrease = (((oldSeedTime-newSeedTime)/oldSeedTime)*100).toFixed(2)  //74.22`

User data seed is now 74.22% faster than before 😀 

All seeded organizations have a tenantId
![image](https://user-images.githubusercontent.com/32574315/79064258-0b682e80-7cc5-11ea-813c-7e09318b9abe.png)
