### PR TITLE
feat(public-page): companies public page : part 1 #944

### DIFF
--- a/apps/api/src/app/organization/organization.controller.ts
+++ b/apps/api/src/app/organization/organization.controller.ts
@@ -71,6 +71,33 @@ export class OrganizationController extends CrudController<Organization> {
 		return this.organizationService.findOne(id, findObj);
 	}
 
+	@ApiOperation({ summary: 'Find Organization by profile link.' })
+	@ApiResponse({
+		status: HttpStatus.OK,
+		description: 'Found one record',
+		type: Organization
+	})
+	@ApiResponse({
+		status: HttpStatus.NOT_FOUND,
+		description: 'Record not found'
+	})
+	@Get('profile/:profile_link/:select')
+	async findOneByProfileLink(
+		@Param('profile_link') profile_link: string,
+		@Param('select') select: string
+	): Promise<Organization> {
+		const findObj = {};
+
+		if (select) {
+			findObj['select'] = JSON.parse(select);
+		}
+
+		return this.organizationService.findOne(
+			{ where: { profile_link: profile_link } },
+			findObj
+		);
+	}
+
 	@ApiOperation({ summary: 'Create new Organization' })
 	@ApiResponse({
 		status: HttpStatus.CREATED,

--- a/apps/api/src/app/organization/organization.entity.ts
+++ b/apps/api/src/app/organization/organization.entity.ts
@@ -55,6 +55,13 @@ export class Organization extends LocationBase implements IOrganization {
 	@Column()
 	name: string;
 
+	@ApiProperty({ type: String, minLength: 3, maxLength: 100 })
+	@IsString()
+	@Index({ unique: true })
+	@IsOptional()
+	@Column({ nullable: true })
+	profile_link: string;
+
 	@ApiPropertyOptional({ type: String, maxLength: 500 })
 	@IsOptional()
 	@Column({ length: 500, nullable: true })

--- a/apps/api/src/app/organization/organization.seed.ts
+++ b/apps/api/src/app/organization/organization.seed.ts
@@ -27,6 +27,7 @@ export const createOrganizations = async (
 	const currencies = Object.values(CurrenciesEnum);
 	const defaultDateTypes = Object.values(DefaultValueDateTypeEnum);
 	defaultOrganization.name = name;
+	defaultOrganization.profile_link = generateLink(name);
 	defaultOrganization.currency = currency;
 	defaultOrganization.defaultValueDateType = defaultValueDateType;
 	defaultOrganization.imageUrl = imageUrl;
@@ -47,6 +48,7 @@ export const createOrganizations = async (
 		const logoAbbreviation = _extractLogoAbbreviation(companyName);
 
 		organization.name = companyName;
+		organization.profile_link = generateLink(companyName);
 		organization.currency = currencies[index % currencies.length];
 		organization.defaultValueDateType =
 			defaultDateTypes[index % defaultDateTypes.length];
@@ -113,4 +115,8 @@ const randomBonus = () => {
 			: randomNumberBetween(5, 10);
 
 	return { bonusType, bonusPercentage };
+};
+
+const generateLink = (name) => {
+	return name.replace(/[^A-Z0-9]+/gi, '_').toLowerCase();
 };

--- a/apps/gauzy/src/app/@core/services/organizations.service.ts
+++ b/apps/gauzy/src/app/@core/services/organizations.service.ts
@@ -1,34 +1,62 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Organization, OrganizationSelectInput, OrganizationCreateInput } from '@gauzy/models';
+import {
+	Organization,
+	OrganizationSelectInput,
+	OrganizationCreateInput
+} from '@gauzy/models';
 import { Observable } from 'rxjs';
 import { first } from 'rxjs/operators';
 
 @Injectable()
 export class OrganizationsService {
+	constructor(private http: HttpClient) {}
 
-    constructor(
-        private http: HttpClient
-    ) { }
+	create(createInput: OrganizationCreateInput): Promise<Organization> {
+		return this.http
+			.post<Organization>('/api/organization', createInput)
+			.pipe(first())
+			.toPromise();
+	}
 
-    create(createInput: OrganizationCreateInput): Promise<Organization> {
-        return this.http.post<Organization>('/api/organization', createInput).pipe(first()).toPromise();
-    }
+	update(id: string, updateInput: OrganizationCreateInput): Promise<any> {
+		return this.http
+			.put(`/api/organization/${id}`, updateInput)
+			.pipe(first())
+			.toPromise();
+	}
 
-    update(id: string, updateInput: OrganizationCreateInput): Promise<any> {
-        return this.http.put(`/api/organization/${id}`, updateInput).pipe(first()).toPromise();
-    }
+	delete(id: string): Promise<any> {
+		return this.http
+			.delete(`/api/organization/${id}`)
+			.pipe(first())
+			.toPromise();
+	}
 
-    delete(id: string): Promise<any> {
-        return this.http.delete(`/api/organization/${id}`).pipe(first()).toPromise();
-    }
+	getAll(): Promise<{ items: Organization[]; total: number }> {
+		return this.http
+			.get<{ items: Organization[]; total: number }>(`/api/organization`)
+			.pipe(first())
+			.toPromise();
+	}
 
-    getAll(): Promise<{ items: Organization[], total: number }> {
-        return this.http.get<{ items: Organization[], total: number }>(`/api/organization`).pipe(first()).toPromise();
-        
-    }
-    
-    getById(id: string = '', select?: OrganizationSelectInput[]): Observable<Organization> {
-        return this.http.get<Organization>(`/api/organization/${id}/${JSON.stringify(select || '')}`);
-    }
+	getById(
+		id: string = '',
+		select?: OrganizationSelectInput[]
+	): Observable<Organization> {
+		return this.http.get<Organization>(
+			`/api/organization/${id}/${JSON.stringify(select || '')}`
+		);
+	}
+
+	getByProfileLink(
+		profile_link: string = '',
+		select?: OrganizationSelectInput[]
+	): Observable<Organization> {
+		return this.http.get<Organization>(
+			`/api/organization/profile/${profile_link}/${JSON.stringify(
+				select || ''
+			)}`
+		);
+	}
 }

--- a/apps/gauzy/src/app/@theme/layouts/one-column/one-column.layout.html
+++ b/apps/gauzy/src/app/@theme/layouts/one-column/one-column.layout.html
@@ -1,5 +1,5 @@
 <nb-layout windowMode>
-	<nb-layout-header fixed>
+	<nb-layout-header fixed *ngIf="user">
 		<ngx-header
 			[showEmployeesSelector]="showEmployeesSelector"
 			[showOrganizationsSelector]="showOrganizationsSelector"
@@ -10,6 +10,7 @@
 		class="menu-sidebar sidebar_class"
 		tag="menu-sidebar"
 		responsive
+		*ngIf="user"
 	>
 		<ng-content select="nb-menu"></ng-content>
 		<div class="user-container">

--- a/apps/gauzy/src/app/@theme/layouts/one-column/one-column.layout.ts
+++ b/apps/gauzy/src/app/@theme/layouts/one-column/one-column.layout.ts
@@ -71,6 +71,7 @@ export class OneColumnLayoutComponent implements OnInit, AfterViewInit {
 
 	private async loadUserData() {
 		const id = this.store.userId;
+		if (!id) return;
 		this.user = await this.usersService.getMe([
 			'employee',
 			'role',

--- a/apps/gauzy/src/app/app-routing.module.ts
+++ b/apps/gauzy/src/app/app-routing.module.ts
@@ -34,6 +34,12 @@ const routes: Routes = [
 		canActivate: [AuthGuard, AppModuleGuard]
 	},
 	{
+		path: 'share',
+		loadChildren: () =>
+			import('./share/share.module').then((m) => m.ShareModule),
+		canActivate: []
+	},
+	{
 		path: 'auth',
 		component: NbAuthComponent,
 		canActivate: [AppModuleGuard],

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-main/edit-organization-main.component.html
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-main/edit-organization-main.component.html
@@ -141,6 +141,25 @@
 			<div class="row">
 				<div class="col-6">
 					<div class="form-group">
+						<label class="label" for="profileLinkInput">{{
+							'FORM.LABELS.PROFILE_LINK' | translate
+						}}</label>
+						<input
+							fullWidth
+							id="profileLinkInput"
+							type="text"
+							nbInput
+							formControlName="profile_link"
+							placeholder="{{
+								'FORM.PLACEHOLDERS.PROFILE_LINK' | translate
+							}}"
+						/>
+					</div>
+				</div>
+			</div>
+			<div class="row">
+				<div class="col-6">
+					<div class="form-group">
 						<label class="label" for="registrationDate">{{
 							'FORM.LABELS.REGISTRATION_DATE' | translate
 						}}</label>

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-main/edit-organization-main.component.ts
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-main/edit-organization-main.component.ts
@@ -94,6 +94,7 @@ export class EditOrganizationMainComponent extends TranslationBaseComponent
 			currency: [this.organization.currency, Validators.required],
 			name: [this.organization.name, Validators.required],
 			officialName: [this.organization.officialName],
+			profile_link: [this.organization.profile_link],
 			taxId: [this.organization.taxId],
 			registrationDate: [
 				this.organization.registrationDate

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization.component.html
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization.component.html
@@ -17,6 +17,10 @@
 						{{ employeesCount }}
 						{{ 'ORGANIZATIONS_PAGE.EMPLOYEES' | translate }}
 					</div>
+					<span class="edit-public-page" (click)="editPublicPage()">
+						<nb-icon class="mr-1" icon="edit-outline"></nb-icon
+						>{{ 'ORGANIZATIONS_PAGE.EDIT_PUBLIC_PAGE' | translate }}
+					</span>
 				</div>
 			</div>
 

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization.component.scss
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization.component.scss
@@ -12,6 +12,14 @@
 	}
 }
 
+.org-details {
+	.edit-public-page {
+		cursor: pointer;
+		color: #027ad6;
+		padding-top: 3px;
+	}
+}
+
 .setting-name {
 	font-size: 24px;
 	font-weight: bold;

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization.component.ts
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization.component.ts
@@ -118,6 +118,12 @@ export class EditOrganizationComponent extends TranslationBaseComponent
 		]);
 	}
 
+	editPublicPage() {
+		this.router.navigate([
+			'/share/organization/' + this.selectedOrg.profile_link
+		]);
+	}
+
 	ngOnDestroy() {
 		this._ngDestroy$.next();
 		this._ngDestroy$.complete();

--- a/apps/gauzy/src/app/share/organization/organization-routing.module.ts
+++ b/apps/gauzy/src/app/share/organization/organization-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { OrganizationComponent } from './organization.component';
+
+const routes: Routes = [
+	{
+		path: '',
+		component: OrganizationComponent
+	}
+];
+
+@NgModule({
+	imports: [RouterModule.forChild(routes)],
+	exports: [RouterModule]
+})
+export class OrganizationRoutingModule {}

--- a/apps/gauzy/src/app/share/organization/organization.component.html
+++ b/apps/gauzy/src/app/share/organization/organization.component.html
@@ -1,0 +1,6 @@
+<nb-card>
+	<nb-card-header *ngIf="organization">
+		<h4 [textContent]="organization.name"></h4>
+	</nb-card-header>
+	<nb-card-body> </nb-card-body>
+</nb-card>

--- a/apps/gauzy/src/app/share/organization/organization.component.ts
+++ b/apps/gauzy/src/app/share/organization/organization.component.ts
@@ -1,0 +1,64 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Store } from '../../@core/services/store.service';
+import { TranslationBaseComponent } from '../../@shared/language-base/translation-base.component';
+import { ActivatedRoute, Router } from '@angular/router';
+import { OrganizationsService } from '../../@core/services/organizations.service';
+import { EmployeesService } from '../../@core/services';
+import { OrganizationRecurringExpenseService } from '../../@core/services/organization-recurring-expense.service';
+import { TranslateService } from '@ngx-translate/core';
+import { Organization, PermissionsEnum } from '@gauzy/models';
+import { Subject } from 'rxjs';
+import { first, takeUntil } from 'rxjs/operators';
+
+@Component({
+	selector: 'ngx-organization',
+	templateUrl: './organization.component.html',
+	styleUrls: ['./organization.component.scss']
+})
+export class OrganizationComponent extends TranslationBaseComponent
+	implements OnInit, OnDestroy {
+	organization: Organization;
+	hasEditPermission = false;
+	private _ngDestroy$ = new Subject<void>();
+
+	loading = true;
+
+	constructor(
+		private route: ActivatedRoute,
+		private router: Router,
+		private organizationsService: OrganizationsService,
+		private employeesService: EmployeesService,
+		private organizationRecurringExpenseService: OrganizationRecurringExpenseService,
+		private store: Store,
+		readonly translateService: TranslateService
+	) {
+		super(translateService);
+	}
+
+	ngOnInit() {
+		this.store.userRolePermissions$
+			.pipe(takeUntil(this._ngDestroy$))
+			.subscribe(() => {
+				this.hasEditPermission = this.store.hasPermission(
+					PermissionsEnum.ALL_ORG_EDIT
+				);
+			});
+
+		this.route.params
+			.pipe(takeUntil(this._ngDestroy$))
+			.subscribe(async (params) => {
+				const profileLink = params.link;
+
+				try {
+					this.organization = await this.organizationsService
+						.getByProfileLink(profileLink)
+						.pipe(first())
+						.toPromise();
+				} catch (error) {
+					await this.router.navigate(['/share/404']);
+				}
+			});
+	}
+
+	ngOnDestroy() {}
+}

--- a/apps/gauzy/src/app/share/organization/organization.module.ts
+++ b/apps/gauzy/src/app/share/organization/organization.module.ts
@@ -1,0 +1,34 @@
+import { NgModule } from '@angular/core';
+import { ThemeModule } from '../../@theme/theme.module';
+import { NbCardModule, NbButtonModule, NbInputModule } from '@nebular/theme';
+import { FormsModule } from '@angular/forms';
+import { OrganizationComponent } from './organization.component';
+import { OrganizationRoutingModule } from './organization-routing.module';
+
+import { TranslateModule, TranslateLoader } from '@ngx-translate/core';
+import { HttpClient } from '@angular/common/http';
+import { TranslateHttpLoader } from '@ngx-translate/http-loader';
+
+export function HttpLoaderFactory(http: HttpClient) {
+	return new TranslateHttpLoader(http, './assets/i18n/', '.json');
+}
+
+@NgModule({
+	imports: [
+		OrganizationRoutingModule,
+		ThemeModule,
+		NbCardModule,
+		FormsModule,
+		NbButtonModule,
+		NbInputModule,
+		TranslateModule.forChild({
+			loader: {
+				provide: TranslateLoader,
+				useFactory: HttpLoaderFactory,
+				deps: [HttpClient]
+			}
+		})
+	],
+	declarations: [OrganizationComponent]
+})
+export class OrganizationModule {}

--- a/apps/gauzy/src/app/share/share-routing.module.ts
+++ b/apps/gauzy/src/app/share/share-routing.module.ts
@@ -1,0 +1,36 @@
+import { RouterModule, Routes } from '@angular/router';
+import { NgModule } from '@angular/core';
+
+import { ShareComponent } from './share.component';
+import { NotFoundComponent } from '../pages/miscellaneous/not-found/not-found.component';
+
+const routes: Routes = [
+	{
+		path: '',
+		component: ShareComponent,
+		children: [
+			{
+				path: '',
+				redirectTo: 'organization',
+				pathMatch: 'full'
+			},
+			{
+				path: 'organization/:link',
+				loadChildren: () =>
+					import('./organization/organization.module').then(
+						(m) => m.OrganizationModule
+					)
+			},
+			{
+				path: '**',
+				component: NotFoundComponent
+			}
+		]
+	}
+];
+
+@NgModule({
+	imports: [RouterModule.forChild(routes)],
+	exports: [RouterModule]
+})
+export class ShareRoutingModule {}

--- a/apps/gauzy/src/app/share/share.component.ts
+++ b/apps/gauzy/src/app/share/share.component.ts
@@ -1,0 +1,42 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+
+@Component({
+	selector: 'ngx-share',
+	styleUrls: ['share.component.scss'],
+	template: `
+		<ngx-one-column-layout>
+			<router-outlet></router-outlet>
+		</ngx-one-column-layout>
+	`
+})
+export class ShareComponent implements OnInit, OnDestroy {
+	private _ngDestroy$ = new Subject<void>();
+
+	constructor(private translate: TranslateService) {}
+
+	async ngOnInit() {
+		this._applyTranslationOnSmartTable();
+	}
+
+	getTranslation(prefix: string) {
+		let result = prefix;
+		this.translate.get(prefix).subscribe((res) => {
+			result = res;
+		});
+		return result;
+	}
+
+	private _applyTranslationOnSmartTable() {
+		this.translate.onLangChange
+			.pipe(takeUntil(this._ngDestroy$))
+			.subscribe(() => {});
+	}
+
+	ngOnDestroy() {
+		this._ngDestroy$.next();
+		this._ngDestroy$.complete();
+	}
+}

--- a/apps/gauzy/src/app/share/share.module.ts
+++ b/apps/gauzy/src/app/share/share.module.ts
@@ -1,0 +1,37 @@
+import { NgModule } from '@angular/core';
+import { NbMenuModule, NbToastrModule, NbSpinnerModule } from '@nebular/theme';
+import { ThemeModule } from '../@theme/theme.module';
+import { ShareComponent } from './share.component';
+import { ShareRoutingModule } from './share-routing.module';
+import { MiscellaneousModule } from '../pages/miscellaneous/miscellaneous.module';
+import { AuthService } from '../@core/services/auth.service';
+import { RoleGuard } from '../@core/role/role.guard';
+import { TranslateModule, TranslateLoader } from '@ngx-translate/core';
+import { TranslateHttpLoader } from '@ngx-translate/http-loader';
+import { HttpClient } from '@angular/common/http';
+
+export function HttpLoaderFactory(http: HttpClient) {
+	return new TranslateHttpLoader(http, './assets/i18n/', '.json');
+}
+
+@NgModule({
+	imports: [
+		ShareRoutingModule,
+		ThemeModule,
+		NbMenuModule,
+		MiscellaneousModule,
+		NbToastrModule.forRoot(),
+		TranslateModule.forChild({
+			loader: {
+				provide: TranslateLoader,
+				useFactory: HttpLoaderFactory,
+				deps: [HttpClient]
+			}
+		}),
+		NbSpinnerModule
+	],
+	entryComponents: [],
+	declarations: [ShareComponent],
+	providers: [AuthService, RoleGuard]
+})
+export class ShareModule {}

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -111,6 +111,7 @@
 			"DATE_TYPE": "Default Date Type",
 			"ADD_TEAM": "Add New Team",
 			"OFFICIAL_NAME": "Official Name",
+			"PROFILE_LINK": "Profile Link",
 			"START_WEEK_ON": "Start Week On",
 			"TAX_ID": "Tax ID",
 			"COUNTRY": "Country",
@@ -187,6 +188,7 @@
 			"ADD_REMOVE_MEMBERS": "Add or Remove Team Members",
 			"MEMBERS_COUNT": "Members count",
 			"OFFICIAL_NAME": "Enter Official Name",
+			"PROFILE_LINK": "Enter Profile Link",
 			"START_WEEK_ON": "Start Week On",
 			"TAX_ID": "Tax ID",
 			"COUNTRY": "Country",
@@ -531,6 +533,7 @@
 	"ORGANIZATIONS_PAGE": {
 		"ORGANIZATIONS": "Organizations",
 		"EMPLOYEES": "Employees",
+		"EDIT_PUBLIC_PAGE": "Edit Public Page",
 		"SELECT_ORGANZIATION": "Please select organizations from the menu above.",
 		"MAIN": "Main",
 		"DEPARTMENTS": "Departments",

--- a/libs/models/src/lib/organization.model.ts
+++ b/libs/models/src/lib/organization.model.ts
@@ -6,6 +6,7 @@ import { ITenant } from '@gauzy/models';
 
 export interface Organization extends IBaseEntityModel, ILocation {
 	name: string;
+	profile_link: string;
 	valueDate?: Date;
 	totalEmployees?: number;
 	status?: string;
@@ -42,6 +43,7 @@ export interface Organization extends IBaseEntityModel, ILocation {
 
 export interface OrganizationFindInput extends IBaseEntityModel {
 	name?: string;
+	profile_link?: string;
 	valueDate?: Date;
 	imageUrl?: string;
 	currency?: CurrenciesEnum;
@@ -50,6 +52,7 @@ export interface OrganizationFindInput extends IBaseEntityModel {
 
 export interface OrganizationCreateInput extends ILocation {
 	name: string;
+	profile_link: string;
 	valueDate?: Date;
 	imageUrl: string;
 	currency: CurrenciesEnum;
@@ -69,6 +72,7 @@ export interface OrganizationCreateInput extends ILocation {
 export enum OrganizationSelectInput {
 	id = 'id',
 	name = 'name',
+	profile_link = 'profile_link',
 	valueDate = 'valueDate',
 	imageUrl = 'imageUrl',
 	currency = 'currency',


### PR DESCRIPTION
## Companies Public Page : Part 1 #944

### What I did recently:
 1. A new column name "profile_link", has been added to the organization table. As well as it's connected with seed as task requirement format.
<img width="345" alt="organization_table_data" src="https://user-images.githubusercontent.com/3712162/79118838-befa1d00-7db0-11ea-8bdb-207a2f396666.png">

2. Custom Profile Link Input added on the organization edit main tab section,
![profile_link_input](https://user-images.githubusercontent.com/3712162/79119336-f0271d00-7db1-11ea-8a04-969d7638c170.jpg)

3. A new link added name(edit public profile) on the organization edit page,
![edit_public_page](https://user-images.githubusercontent.com/3712162/79119398-13ea6300-7db2-11ea-8474-87cd88b06fa9.jpeg)

4. Added a new route with "share" prefix, so the organization profile link is like,
http://localhost:4200/#/share/organization/ever_technologies_ltd

5. When someone visit on the url they will see the blank page with the organization name.

  -  Profile preveiw without logged in user,
![organization_profile_without_login](https://user-images.githubusercontent.com/3712162/79119453-3b413000-7db2-11ea-8b05-6360d619390b.jpg)

  - Profile preview with logged in user,
![organization_profile_logged_in](https://user-images.githubusercontent.com/3712162/79119490-4d22d300-7db2-11ea-81cd-64347139a700.jpg)
