### PR TITLE
feat: #987 tenant for new users and user delete API

### DIFF
--- a/apps/api/src/app/auth/auth.service.ts
+++ b/apps/api/src/app/auth/auth.service.ts
@@ -109,10 +109,27 @@ export class AuthService {
 		const hash = await this.getPasswordHash(findObject.password);
 		return this.userService.changePassword(findObject.user.id, hash);
 	}
-
+	/**
+	 * Shared method involved in
+	 * 1. Sign up
+	 * 2. Addition of new user to organization
+	 * 3. User invite accept scenario
+	 */
 	async register(input: IUserRegistrationInput): Promise<User> {
+		let tenant = input.user.tenant;
+		if (input.createdById) {
+			const creatingUser = await this.userService.findOne(
+				input.createdById,
+				{
+					relations: ['tenant']
+				}
+			);
+			tenant = creatingUser.tenant;
+		}
+
 		const user = this.userService.create({
 			...input.user,
+			tenant,
 			...(input.password
 				? {
 						hash: await this.getPasswordHash(input.password)

--- a/apps/api/src/app/invite/commands/handlers/invite.accept-user.handler.ts
+++ b/apps/api/src/app/invite/commands/handlers/invite.accept-user.handler.ts
@@ -27,7 +27,8 @@ export class InviteAcceptUserHandler
 		const { input } = command;
 
 		const organization = await this.organizationService.findOne(
-			input.organization.id
+			input.organization.id,
+			{ relations: ['tenant'] }
 		);
 
 		if (!input.user.imageUrl) {
@@ -38,10 +39,9 @@ export class InviteAcceptUserHandler
 			...input,
 			user: {
 				...input.user,
-				tenant: {
-					id: organization.tenantId
-				}
-			}
+				tenant: organization.tenant
+			},
+			organizationId: organization.id
 		});
 
 		return await this.inviteService.update(input.inviteId, {

--- a/apps/api/src/app/user-organization/commands/handlers/user-organization.delete.handler.ts
+++ b/apps/api/src/app/user-organization/commands/handlers/user-organization.delete.handler.ts
@@ -1,0 +1,99 @@
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { UserOrganizationDeleteCommand } from '../user-organization.delete.command';
+import { UserOrganization } from '../../user-organization.entity';
+import { UserService } from '../../../user/user.service';
+import { UserOrganizationService } from '../../user-organization.services';
+import { DeleteResult } from 'typeorm';
+import { RoleService } from '../../../role/role.service';
+import { RolesEnum } from '@gauzy/models';
+import { User } from '../../../user/user.entity';
+import { UnauthorizedException, BadRequestException } from '@nestjs/common';
+
+/**
+ * 1. Remove user from given organization if user belongs to multiple organizations
+ * 2. Remove user record if the user belongs only to the given organization
+ * 3. Allow the deletion of Admin and Super Admin Users only if there are more than 1 users of that Role.
+ * 4. When a Super Admins are deleted, they must be removed from all existing organizations.
+ * 5. Super Admin user can be deleted only by a Super Admin user.
+ */
+@CommandHandler(UserOrganizationDeleteCommand)
+export class UserOrganizationDeleteHandler
+	implements ICommandHandler<UserOrganizationDeleteCommand> {
+	constructor(
+		private readonly userOrganizationService: UserOrganizationService,
+		private readonly userService: UserService,
+		private readonly roleService: RoleService
+	) {}
+
+	public async execute(
+		command: UserOrganizationDeleteCommand
+	): Promise<UserOrganization | DeleteResult> {
+		const { input } = command;
+
+		// 1. find user to delete
+		const {
+			user: {
+				role: { name: roleName }
+			},
+			userId
+		} = await this.userOrganizationService.findOne(
+			input.userOrganizationId,
+			{ relations: ['user', 'user.role'] }
+		);
+
+		// 2. Handle Super Admin Deletion if applicable
+		if (roleName === RolesEnum.SUPER_ADMIN)
+			return this._removeSuperAdmin(input.requestingUser, userId);
+
+		return this._removeUserFromOrganization(
+			userId,
+			input.userOrganizationId
+		);
+	}
+
+	private async _removeUserFromOrganization(
+		userId: string,
+		userOrganizationId: string
+	): Promise<UserOrganization | DeleteResult> {
+		// 1. get count of organizations the user belongs to
+		const { total } = await this.userOrganizationService.findAll({
+			where: { userId }
+		});
+
+		return total === 1
+			? this.userService.delete(userId)
+			: this.userOrganizationService.delete(userOrganizationId);
+	}
+
+	private async _removeSuperAdmin(
+		requestingUser: User,
+		userId: string
+	): Promise<UserOrganization | DeleteResult> {
+		// 1. Check if the requesting user has permission to delete Super Admin
+		const { name: requestingUserRoleName } = await this.roleService.findOne(
+			requestingUser.roleId
+		);
+
+		if (requestingUserRoleName !== RolesEnum.SUPER_ADMIN)
+			throw new UnauthorizedException(
+				'Only Super Admin user can delete Super Admin users'
+			);
+
+		// 2. Check if there are at least 2 Super Admins before deleting Super Admin user
+		const { total } = await this.userService.findAll({
+			where: {
+				role: { id: requestingUser.roleId },
+				tenant: { id: requestingUser.tenantId }
+			},
+			relations: ['role', 'tenant']
+		});
+
+		if (total === 1)
+			throw new BadRequestException(
+				'There must be at least 1 Super Admin per Tenant'
+			);
+
+		// 3. Delete Super Admin user from all organizations
+		return this.userService.delete(userId);
+	}
+}

--- a/apps/api/src/app/user-organization/commands/index.ts
+++ b/apps/api/src/app/user-organization/commands/index.ts
@@ -1,0 +1,3 @@
+import { UserOrganizationDeleteHandler } from './handlers/user-organization.delete.handler';
+
+export const CommandHandlers = [UserOrganizationDeleteHandler];

--- a/apps/api/src/app/user-organization/commands/user-organization.delete.command.ts
+++ b/apps/api/src/app/user-organization/commands/user-organization.delete.command.ts
@@ -1,0 +1,8 @@
+import { ICommand } from '@nestjs/cqrs';
+import { UserOrganizationDeleteInput } from '@gauzy/models';
+
+export class UserOrganizationDeleteCommand implements ICommand {
+	static readonly type = '[UserOrganization] Delete';
+
+	constructor(public readonly input: UserOrganizationDeleteInput) {}
+}

--- a/apps/api/src/app/user-organization/user-organization.controller.ts
+++ b/apps/api/src/app/user-organization/user-organization.controller.ts
@@ -1,11 +1,27 @@
-import { Controller, HttpStatus, Get, Query, UseGuards } from '@nestjs/common';
+import {
+	Controller,
+	HttpStatus,
+	Get,
+	Query,
+	UseGuards,
+	HttpCode,
+	Delete,
+	Param,
+	Req
+} from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { CrudController } from '../core/crud/crud.controller';
-import { UserOrganization as IUserOrganization } from '@gauzy/models';
+import {
+	UserOrganization as IUserOrganization,
+	RolesEnum
+} from '@gauzy/models';
 import { UserOrganizationService } from './user-organization.services';
 import { IPagination } from '../core';
 import { UserOrganization } from './user-organization.entity';
 import { AuthGuard } from '@nestjs/passport';
+import { Not } from 'typeorm';
+import { CommandBus } from '@nestjs/cqrs';
+import { UserOrganizationDeleteCommand } from './commands/user-organization.delete.command';
 
 @ApiTags('UserOrganization')
 @UseGuards(AuthGuard('jwt'))
@@ -14,7 +30,8 @@ export class UserOrganizationController extends CrudController<
 	IUserOrganization
 > {
 	constructor(
-		private readonly userOrganizationService: UserOrganizationService
+		private readonly userOrganizationService: UserOrganizationService,
+		private readonly commandBus: CommandBus
 	) {
 		super(userOrganizationService);
 	}
@@ -38,6 +55,53 @@ export class UserOrganizationController extends CrudController<
 			where: findInput,
 			relations
 		});
+	}
+
+	@ApiOperation({ summary: 'Delete user from organization' })
+	@ApiResponse({
+		status: HttpStatus.NO_CONTENT,
+		description: 'The user has been successfully deleted'
+	})
+	@ApiResponse({
+		status: HttpStatus.NOT_FOUND,
+		description: 'Record not found'
+	})
+	@HttpCode(HttpStatus.ACCEPTED)
+	@Delete(':id')
+	async delete(
+		@Param('id') id: string,
+		@Req() request
+	): Promise<UserOrganization> {
+		return this.commandBus.execute(
+			new UserOrganizationDeleteCommand({
+				userOrganizationId: id,
+				requestingUser: request.user
+			})
+		);
+	}
+
+	@ApiOperation({ summary: 'Find number of Organizations user belongs to' })
+	@ApiResponse({
+		status: HttpStatus.OK,
+		description: 'Count of Organizations given user belongs to',
+		type: Number
+	})
+	@ApiResponse({
+		status: HttpStatus.NOT_FOUND,
+		description: 'Record not found'
+	})
+	@Get(':id')
+	async findOrganizationCount(@Param('id') id: string): Promise<number> {
+		const { userId } = await this.findById(id);
+		const { total } = await this.userOrganizationService.findAll({
+			where: {
+				userId,
+				isActive: true,
+				'user.role': { name: Not(RolesEnum.EMPLOYEE) }
+			},
+			relations: ['user', 'user.role']
+		});
+		return total;
 	}
 
 	// This was not being used and it overrides the default unnecessarily, so removed until required.

--- a/apps/api/src/app/user-organization/user-organization.module.ts
+++ b/apps/api/src/app/user-organization/user-organization.module.ts
@@ -6,14 +6,31 @@ import { UserOrganization } from './user-organization.entity';
 import { Organization } from '../organization/organization.entity';
 import { User } from '../user/user.entity';
 import { UserService } from '../user/user.service';
+import { CommandHandlers } from './commands';
+import { CqrsModule } from '@nestjs/cqrs';
+import { SharedModule } from '../shared';
+import { Role } from '../role/role.entity';
+import { RoleService } from '../role/role.service';
 @Module({
 	imports: [
 		forwardRef(() =>
-			TypeOrmModule.forFeature([UserOrganization, Organization, User])
-		)
+			TypeOrmModule.forFeature([
+				UserOrganization,
+				Organization,
+				User,
+				Role
+			])
+		),
+		SharedModule,
+		CqrsModule
 	],
 	controllers: [UserOrganizationController],
-	providers: [UserOrganizationService, UserService],
+	providers: [
+		UserOrganizationService,
+		UserService,
+		RoleService,
+		...CommandHandlers
+	],
 	exports: [UserOrganizationService]
 })
 export class UserOrganizationModule {}

--- a/apps/gauzy/src/app/@core/services/users-organizations.service.ts
+++ b/apps/gauzy/src/app/@core/services/users-organizations.service.ts
@@ -38,6 +38,13 @@ export class UsersOrganizationsService {
 			.toPromise();
 	}
 
+	getUserOrganizationCount(id: string): Promise<number> {
+		return this.http
+			.get<number>(`/api/user-organization/${id}`)
+			.pipe(first())
+			.toPromise();
+	}
+
 	removeUserFromOrg(id: string): Promise<UserOrganization> {
 		return this.http
 			.delete<UserOrganization>(`/api/user-organization/${id}`)

--- a/apps/gauzy/src/app/pages/users/users.component.html
+++ b/apps/gauzy/src/app/pages/users/users.component.html
@@ -57,7 +57,7 @@
 			<button
 				nbButton
 				[disabled]="!selectedUser"
-				(click)="remove()"
+				(click)="remove(selectedUser)"
 				status="danger"
 				class="mr-2"
 			>

--- a/apps/gauzy/src/app/pages/users/users.component.ts
+++ b/apps/gauzy/src/app/pages/users/users.component.ts
@@ -280,101 +280,56 @@ export class UsersComponent extends TranslationBaseComponent
 		this.users = items.map((user) => user.user);
 	}
 
-	async remove() {
-		const user = await this.usersService.getUserByEmail(
-			this.selectedUser.email
+	async remove(selectedOrganization: UserViewModel) {
+		const { id: userOrganizationId } = selectedOrganization;
+		const fullName =
+			selectedOrganization.fullName.trim() || selectedOrganization.email;
+
+		/**
+		 *  User belongs to only 1 organization -> delete user
+		 *	User belongs multiple organizations -> remove user from Organization
+		 *
+		 */
+		const count = await this.userOrganizationsService.getUserOrganizationCount(
+			userOrganizationId
 		);
+		const confirmationMessage =
+			count === 1
+				? 'FORM.DELETE_CONFIRMATION.DELETE_USER'
+				: 'FORM.DELETE_CONFIRMATION.REMOVE_USER';
 
-		const { items } = await this.userOrganizationsService.getAll([
-			'user',
-			'user.role'
-		]);
+		this.dialogService
+			.open(DeleteConfirmationComponent, {
+				context: {
+					recordType: `${fullName} ${this.getTranslation(
+						confirmationMessage
+					)}`
+				}
+			})
+			.onClose.pipe(takeUntil(this._ngDestroy$))
+			.subscribe(async (result) => {
+				if (result) {
+					try {
+						await this.userOrganizationsService.removeUserFromOrg(
+							userOrganizationId
+						);
 
-		let counter = -1;
+						this.toastrService.primary(
+							this.getTranslation('USERS_PAGE.REMOVE_USER', {
+								name: fullName
+							}),
+							this.getTranslation('TOASTR.TITLE.SUCCESS')
+						);
 
-		for (const orgUser of items) {
-			if (
-				orgUser.isActive &&
-				(!orgUser.user.role ||
-					orgUser.user.role.name !== RolesEnum.EMPLOYEE)
-			) {
-				if (orgUser.id === this.userToRemoveId)
-					this.userToRemove = orgUser;
-				if (orgUser.user.id === user.id) counter++;
-			}
-		}
-
-		if (counter < 1) {
-			this.dialogService
-				.open(DeleteConfirmationComponent, {
-					context: {
-						recordType:
-							this.selectedUser.fullName +
-							' ' +
-							this.getTranslation(
-								'FORM.DELETE_CONFIRMATION.DELETE_USER'
-							)
+						this.loadPage();
+					} catch (error) {
+						this.toastrService.danger(
+							error.error.message || error.message,
+							'Error'
+						);
 					}
-				})
-				.onClose.pipe(takeUntil(this._ngDestroy$))
-				.subscribe(async (result) => {
-					if (result) {
-						try {
-							this.usersService.delete(
-								this.userToRemove.user.id,
-								this.userToRemove
-							);
-
-							this.toastrService.primary(
-								this.userName + ' was successfuly deleted.',
-								'Success'
-							);
-
-							this.loadPage();
-						} catch (error) {
-							this.toastrService.danger(
-								error.error.message || error.message,
-								'Error'
-							);
-						}
-					}
-				});
-		} else {
-			this.dialogService
-				.open(DeleteConfirmationComponent, {
-					context: {
-						recordType:
-							this.selectedUser.fullName +
-							' ' +
-							this.getTranslation(
-								'FORM.DELETE_CONFIRMATION.USER_RECORD'
-							)
-					}
-				})
-				.onClose.pipe(takeUntil(this._ngDestroy$))
-				.subscribe(async (result) => {
-					if (result) {
-						try {
-							await this.userOrganizationsService.removeUserFromOrg(
-								this.selectedUser.id
-							);
-
-							this.toastrService.primary(
-								this.userName +
-									' was successfuly removed from organization.',
-								'Success'
-							);
-
-							this.loadPage();
-						} catch (error) {
-							this.toastrService.danger(
-								error.error.message || error.message,
-								'Error'
-							);
-						}
-					}
-				});
-		}
+				}
+			});
 	}
 
 	private async loadPage() {

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -261,7 +261,7 @@
 		"DELETE_CONFIRMATION": {
 			"REMOVE_ALL_DATA": "REMOVE ALL DATA",
 			"DELETE_ACCOUNT": "Are you sure you want to delete your account?",
-			"REMOVE_USER": " from you organization",
+			"REMOVE_USER": " from your organization",
 			"SURE": "Are you sure you want to delete",
 			"RECORD": "record",
 			"USER_RECORD": "from your organization",
@@ -270,7 +270,7 @@
 			"EXPENSE": "Expense",
 			"USER": "user",
 			"INVITATION": "invitation",
-			"DELETE_USER": " from database as it's data in no longer part of any organization "
+			"DELETE_USER": " from database as it is associated only to current organization"
 		}
 	},
 	"POP_UPS": {
@@ -843,7 +843,8 @@
 			"EDIT_EXISTING_USER": "Edit Existing User",
 			"MAIN": "Main",
 			"USER_ORGANIZATIONS": "Organizations"
-		}
+		},
+		"REMOVE_USER": "{{ name }} successfully removed"
 	},
 	"CONTEXT_MENU": {
 		"TIMER": "Start Timer",

--- a/libs/models/src/lib/user-organization.model.ts
+++ b/libs/models/src/lib/user-organization.model.ts
@@ -22,3 +22,8 @@ export interface UserOrganizationCreateInput {
 	isDefault?: boolean;
 	isActive?: boolean;
 }
+
+export interface UserOrganizationDeleteInput {
+	userOrganizationId: string;
+	requestingUser: User;
+}


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
**What got added?**
1. Super admins deletion is allowed only for super admins
2. Prevent Super admins from deleting all Super admins (there must be at least one Super admin in a Tenant) 
3. Deleting Super admin user will also remove this user from all the organizations in the Tenant.
4. For normal users, 
- If the user belonged to multiple organizations,  user delete action must remove the user only from the specified organization. 
- If the user belonged to only one organization,  user delete action must delete the user from the database. ( Notify this in the delete confirmation prompt)
5.  The logic for 4 existed in the front end and is now moved to the backend.

Also, User addition and invite flows did not set the tenantId in the User table which leads to created users not show up in the UI. The code to set tenantId is also included in the same ticket. Users will now get the tenantId of the inviting User(in case of user addition) or creating User ( in case of user addition)

**Demo**
https://www.loom.com/share/49650823a2484a53b056e4c4a09c8f6c