### PR TITLE
feat: add calendar for interview and  icons[ref:#1156]

### DIFF
--- a/apps/gauzy/src/app/pages/candidates/candidates-routing.module.ts
+++ b/apps/gauzy/src/app/pages/candidates/candidates-routing.module.ts
@@ -16,6 +16,7 @@ import { EditCandidateTasksComponent } from './edit-candidate/edit-candidate-pro
 import { EditCandidateExperienceComponent } from './edit-candidate/edit-candidate-profile/edit-candidate-experience/edit-candidate-experience.component';
 import { EditCandidateRatesComponent } from './edit-candidate/edit-candidate-profile/edit-candidate-rates/edit-candidate-rates.component';
 import { EditCandidateFeedbacksComponent } from './edit-candidate/edit-candidate-profile/edit-candidate-feedbacks/edit-candidate-feedbacks.component';
+import { ManageCandidateInterviewsComponent } from './manage-candidate-interviews/manage-candidate-interviews.component';
 
 const routes: Routes = [
 	{
@@ -87,6 +88,10 @@ const routes: Routes = [
 				PermissionsEnum.ORG_INVITE_VIEW
 			]
 		}
+	},
+	{
+		path: 'interviews',
+		component: ManageCandidateInterviewsComponent
 	}
 ];
 

--- a/apps/gauzy/src/app/pages/candidates/candidates.component.html
+++ b/apps/gauzy/src/app/pages/candidates/candidates.component.html
@@ -6,6 +6,19 @@
 				{{ organizationName }}
 			</h4>
 			<button
+				class="interview-button"
+				*ngIf="
+					organizationInvitesAllowed &&
+					hasInviteViewOrEditPermission &&
+					hasEditPermission
+				"
+				nbButton
+				status="primary"
+				(click)="manageInterviews()"
+			>
+				{{ 'BUTTONS.MANAGE_INTERVIEWS' | translate }}
+			</button>
+			<button
 				*ngIf="
 					organizationInvitesAllowed &&
 					hasInviteViewOrEditPermission &&

--- a/apps/gauzy/src/app/pages/candidates/candidates.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/candidates.component.scss
@@ -3,3 +3,6 @@
 	align-items: center;
 	justify-content: space-between;
 }
+.interview-button {
+	margin-right: 10px;
+}

--- a/apps/gauzy/src/app/pages/candidates/candidates.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/candidates.component.scss
@@ -3,6 +3,7 @@
 	align-items: center;
 	justify-content: space-between;
 }
+
 .interview-button {
 	margin-right: 10px;
 }

--- a/apps/gauzy/src/app/pages/candidates/candidates.component.ts
+++ b/apps/gauzy/src/app/pages/candidates/candidates.component.ts
@@ -192,6 +192,9 @@ export class CandidatesComponent extends TranslationBaseComponent
 	manageInvites() {
 		this.router.navigate(['/pages/employees/candidates/invites']);
 	}
+	manageInterviews() {
+		this.router.navigate(['/pages/employees/candidates/interviews']);
+	}
 	async getCandidateSource(id: string) {
 		this.candidateSource = null;
 		const res = await this.candidateSourceService.getAll({

--- a/apps/gauzy/src/app/pages/candidates/candidates.module.ts
+++ b/apps/gauzy/src/app/pages/candidates/candidates.module.ts
@@ -59,6 +59,8 @@ import { EditCandidateFeedbacksComponent } from './edit-candidate/edit-candidate
 import { StarRatingInputModule } from '../../@shared/star-rating/star-rating-input/star-rating-input.module';
 import { StarRatingOutputModule } from '../../@shared/star-rating/star-rating-output/star-rating-output.module';
 import { CandidateSourceComponent } from './table-components/candidate-source/candidate-source.component';
+import { ManageCandidateInterviewsComponent } from './manage-candidate-interviews/manage-candidate-interviews.component';
+import { FullCalendarModule } from '@fullcalendar/angular';
 
 export function HttpLoaderFactory(http: HttpClient) {
 	return new TranslateHttpLoader(http, './assets/i18n/', '.json');
@@ -88,6 +90,7 @@ const COMPONENTS = [
 
 @NgModule({
 	imports: [
+		FullCalendarModule,
 		TableComponentsModule,
 		SharedModule,
 		CandidatesRoutingModule,
@@ -128,7 +131,7 @@ const COMPONENTS = [
 		StarRatingInputModule,
 		StarRatingOutputModule
 	],
-	declarations: [...COMPONENTS],
+	declarations: [...COMPONENTS, ManageCandidateInterviewsComponent],
 	entryComponents: [
 		CandidateStatusComponent,
 		CandidateSourceComponent,

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-documents/edit-candidate-documents.component.html
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-documents/edit-candidate-documents.component.html
@@ -86,11 +86,18 @@
 
 		<nb-card *ngFor="let document of documentList; let i = index">
 			<nb-card-body class="documents-card">
-				<div>
-					<div class="documents-line">
+				<div class="documents-line">
+					<div>
+						<nb-icon
+							class="doc-icon"
+							icon="file-text-outline"
+						></nb-icon>
 						<a href="{{ document.documentUrl }}">
 							{{ document.name }}
 						</a>
+					</div>
+					<div class="document-data">
+						{{ document.updatedAt | date: 'medium' }}
 					</div>
 				</div>
 

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-documents/edit-candidate-documents.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-documents/edit-candidate-documents.component.scss
@@ -42,10 +42,12 @@ input {
 .label {
 	margin: 0 0 8px;
 }
+
 .document-data {
 	font-size: 12px;
 	color: grey;
 }
+
 .doc-icon {
 	color: #3365ff !important;
 }

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-documents/edit-candidate-documents.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-documents/edit-candidate-documents.component.scss
@@ -42,3 +42,10 @@ input {
 .label {
 	margin: 0 0 8px;
 }
+.document-data {
+	font-size: 12px;
+	color: grey;
+}
+.doc-icon {
+	color: #3365ff !important;
+}

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate.component.html
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate.component.html
@@ -30,6 +30,10 @@
 						<strong>{{ selectedCandidate?.user.email }}</strong>
 					</div>
 				</div>
+				<div class="notification">
+					<nb-icon class="bell" icon="bell"></nb-icon>
+					<div *ngIf="selectedInterview" class="exist"></div>
+				</div>
 				<div
 					*ngIf="hasEditPermission"
 					class="employee-details edit-icon"

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate.component.scss
@@ -1,0 +1,28 @@
+.notification {
+	margin-top: 18px;
+	margin-right: -20px;
+	margin-left: 20px;
+	position: relative;
+	display: inline-block;
+	width: 36px;
+	height: 36px;
+	border-radius: 50%;
+	background-color: #0091ff;
+}
+.exist {
+	position: absolute;
+	font-size: 8px;
+	top: 9px;
+	right: 8px;
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+	background-color: #ff1100;
+}
+.bell {
+	color: white !important;
+	font-size: 18px;
+	position: absolute;
+	margin-top: 9px;
+	margin-left: 9px;
+}

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate.component.scss
@@ -7,8 +7,9 @@
 	width: 36px;
 	height: 36px;
 	border-radius: 50%;
-	background-color: #0091ff;
+	background-color: #091f;
 }
+
 .exist {
 	position: absolute;
 	font-size: 8px;
@@ -17,8 +18,9 @@
 	width: 8px;
 	height: 8px;
 	border-radius: 50%;
-	background-color: #ff1100;
+	background-color: #f10;
 }
+
 .bell {
 	color: white !important;
 	font-size: 18px;

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate.component.ts
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate.component.ts
@@ -13,13 +13,15 @@ import { CandidatesService } from '../../../@core/services/candidates.service';
 	templateUrl: './edit-candidate.component.html',
 	styleUrls: [
 		'../../organizations/edit-organization/edit-organization.component.scss',
-		'../../dashboard/dashboard.component.scss'
+		'../../dashboard/dashboard.component.scss',
+		'./edit-candidate.component.scss'
 	]
 })
 export class EditCandidateComponent extends TranslationBaseComponent
 	implements OnInit, OnDestroy {
 	private _ngDestroy$ = new Subject<void>();
 	selectedCandidate: Candidate;
+	selectedInterview = true;
 	candidateName = 'Candidate';
 	hasEditPermission = false;
 	constructor(

--- a/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/manage-candidate-interviews.component.html
+++ b/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/manage-candidate-interviews.component.html
@@ -1,0 +1,10 @@
+<nb-card>
+	<nb-card-header>
+		<div class="main-header">
+			<a>Calendar</a>
+		</div>
+	</nb-card-header>
+	<nb-card-body>
+		<full-calendar #calendar [options]="calendarOptions"></full-calendar>
+	</nb-card-body>
+</nb-card>

--- a/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/manage-candidate-interviews.component.ts
+++ b/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/manage-candidate-interviews.component.ts
@@ -1,0 +1,66 @@
+import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
+import { TranslationBaseComponent } from '../../../@shared/language-base/translation-base.component';
+import { Subject } from 'rxjs';
+import { FullCalendarComponent } from '@fullcalendar/angular';
+import { OptionsInput, EventInput } from '@fullcalendar/core';
+import { Router } from '@angular/router';
+import { TranslateService } from '@ngx-translate/core';
+import bootstrapPlugin from '@fullcalendar/bootstrap';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import timeGrigPlugin from '@fullcalendar/timegrid';
+import interactionPlugin from '@fullcalendar/interaction';
+
+@Component({
+	selector: 'ngx-manage-candidate-interviews',
+	templateUrl: './manage-candidate-interviews.component.html'
+})
+export class ManageCandidateInterviewsComponent extends TranslationBaseComponent
+	implements OnInit, OnDestroy {
+	private _ngDestroy$ = new Subject<void>();
+
+	@ViewChild('calendar', { static: true })
+	calendarComponent: FullCalendarComponent;
+	calendarOptions: OptionsInput;
+
+	calendarEvents: EventInput[] = [];
+
+	constructor(
+		private router: Router,
+		readonly translateService: TranslateService
+	) {
+		super(translateService);
+		this.calendarOptions = {
+			initialView: 'timeGridWeek',
+			header: {
+				left: 'prev,next today',
+				center: 'title',
+				right: 'timeGridWeek'
+			},
+			themeSystem: 'bootstrap',
+			plugins: [
+				dayGridPlugin,
+				timeGrigPlugin,
+				interactionPlugin,
+				bootstrapPlugin
+			],
+			weekends: true,
+			height: 'auto',
+			events: this.calendarEvents
+		};
+	}
+
+	ngOnInit(): void {}
+
+	getRoute(name: string) {
+		return `/pages/employees/appointments/${name}`;
+	}
+
+	manageAppointments() {
+		this.router.navigate([this.getRoute('add')]);
+	}
+
+	ngOnDestroy() {
+		this._ngDestroy$.next();
+		this._ngDestroy$.complete();
+	}
+}

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -23,6 +23,7 @@
 		"INVITE": "Invite",
 		"SELECT_ALL": "Select All",
 		"COPY_LINK": "Copy Link",
+		"MANAGE_INTERVIEWS": "Manage Interviews",
 		"MANAGE_INVITES": "Manage Invites",
 		"RESEND": "Resend",
 		"NEXT": "Next",


### PR DESCRIPTION
Added manage interviews button & new page with a calendar(in the feature will display interviews with candidates)
Added notification icon(in the feature will display if the candidate has planed interview)
Added info about document(updated time&date) and icon for document
![Screen Shot 2020-05-06 at 6 34 52 PM](https://user-images.githubusercontent.com/20084357/81197049-807b0b00-8fc8-11ea-9fe8-a54052285be2.png)
![Screen Shot 2020-05-06 at 6 33 17 PM](https://user-images.githubusercontent.com/20084357/81197059-840e9200-8fc8-11ea-991f-849b5528a698.png)
![Screen Shot 2020-05-06 at 6 32 51 PM](https://user-images.githubusercontent.com/20084357/81197064-84a72880-8fc8-11ea-9186-69736f316d13.png)
![Screen Shot 2020-05-06 at 6 32 44 PM](https://user-images.githubusercontent.com/20084357/81197066-853fbf00-8fc8-11ea-9c54-4f4fd2d2aa6a.png)





-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
