### PR TITLE
feat: added new guard (OwnerGuard)

### DIFF
--- a/apps/api/src/app/employee/employee.controller.ts
+++ b/apps/api/src/app/employee/employee.controller.ts
@@ -24,6 +24,7 @@ import { Permissions } from '../shared/decorators/permissions';
 import { PermissionGuard } from '../shared/guards/auth/permission.guard';
 import { Employee } from './employee.entity';
 import { EmployeeService } from './employee.service';
+import OwnerGuard from '../shared/guards/auth/owner.guard';
 
 @ApiTags('Employee')
 @UseGuards(AuthGuard('jwt'))
@@ -52,6 +53,8 @@ export class EmployeeController extends CrudController<Employee> {
 	})
 	@HttpCode(HttpStatus.ACCEPTED)
 	@Put(':id')
+	@UseGuards(OwnerGuard, PermissionGuard)
+	@Permissions(PermissionsEnum.ORG_EMPLOYEES_EDIT)
 	async update(
 		@Param('id') id: string,
 		@Body() entity: Employee

--- a/apps/api/src/app/shared/guards/auth/organization-permission.guard.ts
+++ b/apps/api/src/app/shared/guards/auth/organization-permission.guard.ts
@@ -21,6 +21,7 @@ export class OrganizationPermissionGuard implements CanActivate {
 			'permissions',
 			context.getHandler()
 		);
+		const req = context.switchToHttp().getRequest();
 
 		let isAuthorized = false;
 
@@ -54,7 +55,6 @@ export class OrganizationPermissionGuard implements CanActivate {
 				);
 			}
 		}
-
-		return isAuthorized;
+		return isAuthorized || req.ownerGuardStatus;
 	}
 }

--- a/apps/api/src/app/shared/guards/auth/owner.guard.ts
+++ b/apps/api/src/app/shared/guards/auth/owner.guard.ts
@@ -1,0 +1,37 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { EmployeeService } from '../../../employee/employee.service';
+
+@Injectable()
+export default class OwnerGuard implements CanActivate {
+	constructor(
+		private readonly _reflector: Reflector,
+		private readonly employeeSrv: EmployeeService
+	) {}
+
+	async canActivate(context: ExecutionContext): Promise<boolean> {
+		let isAuthorized = false;
+		const req = context.switchToHttp().getRequest();
+		const paramsId = req.params.id;
+		const roles = this._reflector.get<string[]>(
+			'roles',
+			context.getHandler()
+		);
+		const permissions = this._reflector.get<string[]>(
+			'permissions',
+			context.getHandler()
+		);
+		if (paramsId) {
+			const currentService = context
+				.getClass()
+				.name.split('Controller')[0];
+			const currentData = await this[
+				`${currentService.toLowerCase()}Srv`
+			].findOne(paramsId);
+			isAuthorized =
+				currentData.userId && currentData.userId === req.user.id;
+		}
+		req.ownerGuardStatus = isAuthorized;
+		return permissions || roles ? true : isAuthorized;
+	}
+}

--- a/apps/api/src/app/shared/guards/auth/permission.guard.ts
+++ b/apps/api/src/app/shared/guards/auth/permission.guard.ts
@@ -17,7 +17,7 @@ export class PermissionGuard implements CanActivate {
 			'permissions',
 			context.getHandler()
 		);
-
+		const req = context.switchToHttp().getRequest();
 		let isAuthorized = false;
 
 		if (!permissions) {
@@ -48,6 +48,6 @@ export class PermissionGuard implements CanActivate {
 			}
 		}
 
-		return isAuthorized;
+		return isAuthorized || req.ownerGuardStatus;
 	}
 }

--- a/apps/api/src/app/shared/guards/auth/role.guard.ts
+++ b/apps/api/src/app/shared/guards/auth/role.guard.ts
@@ -15,6 +15,7 @@ export class RoleGuard implements CanActivate {
 			'roles',
 			context.getHandler()
 		);
+		const req = context.switchToHttp().getRequest();
 
 		let isAuthorized = false;
 
@@ -25,6 +26,6 @@ export class RoleGuard implements CanActivate {
 			isAuthorized = await this._authService.hasRole(token, roles);
 		}
 
-		return isAuthorized;
+		return isAuthorized || req.ownerGuardStatus;
 	}
 }


### PR DESCRIPTION
what's new

- added new guard **OwnerGuard**

what's guard functionality
- add permission for data owned (for this case using employee) field userId in employee for owned data employee
- if we use the owner guard then owner data can manage the data like update or delete

how to use this guard
- this guard must be on top of other guard ex: permissionGuard, rolesGuard

how this guard work
- this guard will get token userId and compare with field userId in data (ex: employee)
- if result of compare is true than user able to edit or delete this data

need review and advise @evereq 

 