### PR TITLE
fix: #1178 fixed browser warnings, refactored tags-color-input component

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,16 @@
 {
-  "singleQuote": true,
-  "semi": true,
-  "useTabs": true,
-  "tabWidth": 4,
-  "arrowParens": "always"
+	"singleQuote": true,
+	"semi": true,
+	"useTabs": true,
+	"tabWidth": 4,
+	"arrowParens": "always",
+	"overrides": [
+		{
+			"files": "*.scss",
+			"options": {
+				"useTabs": false,
+				"tabWidth": 2
+			}
+		}
+	]
 }

--- a/apps/gauzy/src/app/@shared/equipment/equipment-mutation.component.html
+++ b/apps/gauzy/src/app/@shared/equipment/equipment-mutation.component.html
@@ -185,12 +185,11 @@
 					/>
 				</div>
 				<div class="col-sm-6">
-					<ngx-tags-color-input
-						[form]="form"
+					<ga-tags-color-input
 						[selectedTags]="tags"
 						(selectedTagsEvent)="selectedTagsEvent($event)"
 					>
-					</ngx-tags-color-input>
+					</ga-tags-color-input>
 				</div>
 			</div>
 

--- a/apps/gauzy/src/app/@shared/equipment/equipment-mutation.component.ts
+++ b/apps/gauzy/src/app/@shared/equipment/equipment-mutation.component.ts
@@ -66,6 +66,7 @@ export class EquipmentMutationComponent extends TranslationBaseComponent
 			],
 			id: [this.equipment ? this.equipment.id : null]
 		});
+		this.tags = this.form.get('tags').value || [];
 	}
 
 	async saveEquipment() {
@@ -83,7 +84,7 @@ export class EquipmentMutationComponent extends TranslationBaseComponent
 	async closeDialog(equipment?: Equipment) {
 		this.dialogRef.close(equipment);
 	}
-	selectedTagsEvent(ev) {
-		this.tags = ev;
+	selectedTagsEvent(currentTagSelection: Tag[]) {
+		this.tags = currentTagSelection;
 	}
 }

--- a/apps/gauzy/src/app/@shared/expenses/expenses-mutation/expenses-mutation.component.html
+++ b/apps/gauzy/src/app/@shared/expenses/expenses-mutation/expenses-mutation.component.html
@@ -201,12 +201,11 @@
 			<div class="row">
 				<div class="col-sm-12">
 					<div class="form-group">
-						<ngx-tags-color-input
-							[form]="form"
+						<ga-tags-color-input
 							[selectedTags]="tags"
 							(selectedTagsEvent)="selectedTagsHandler($event)"
 						>
-						</ngx-tags-color-input>
+						</ga-tags-color-input>
 					</div>
 				</div>
 			</div>

--- a/apps/gauzy/src/app/@shared/expenses/expenses-mutation/expenses-mutation.component.ts
+++ b/apps/gauzy/src/app/@shared/expenses/expenses-mutation/expenses-mutation.component.ts
@@ -239,7 +239,6 @@ export class ExpensesMutationComponent extends TranslationBaseComponent
 
 	private _initializeForm() {
 		if (this.expense) {
-			this.tags = this.expense.tags;
 			this.form = this.fb.group({
 				id: [this.expense.id],
 				amount: [this.expense.amount, Validators.required],
@@ -290,6 +289,7 @@ export class ExpensesMutationComponent extends TranslationBaseComponent
 		this.valueDate = this.form.get('valueDate');
 		this.amount = this.form.get('amount');
 		this.notes = this.form.get('notes');
+		this.tags = this.form.get('tags').value || [];
 	}
 
 	private calculateTaxes() {
@@ -377,8 +377,8 @@ export class ExpensesMutationComponent extends TranslationBaseComponent
 			});
 	}
 
-	selectedTagsHandler(ev: any) {
-		this.form.get('tags').setValue(ev);
+	selectedTagsHandler(currentSelection: Tag) {
+		this.form.get('tags').setValue(currentSelection);
 	}
 
 	onEmployeeChange(selectedEmployee: SelectedEmployee) {

--- a/apps/gauzy/src/app/@shared/income/income-mutation/income-mutation.component.html
+++ b/apps/gauzy/src/app/@shared/income/income-mutation/income-mutation.component.html
@@ -97,12 +97,11 @@
 			<div class="row">
 				<div class="col-sm-12">
 					<div class="form-group">
-						<ngx-tags-color-input
-							[form]="form"
+						<ga-tags-color-input
 							[selectedTags]="tags"
 							(selectedTagsEvent)="selectedTagsHandler($event)"
 						>
-						</ngx-tags-color-input>
+						</ga-tags-color-input>
 					</div>
 				</div>
 			</div>

--- a/apps/gauzy/src/app/@shared/income/income-mutation/income-mutation.component.ts
+++ b/apps/gauzy/src/app/@shared/income/income-mutation/income-mutation.component.ts
@@ -171,7 +171,6 @@ export class IncomeMutationComponent extends TranslationBaseComponent
 
 	private _initializeForm() {
 		if (this.income) {
-			this.tags = this.income.tags;
 			this.form = this.fb.group({
 				valueDate: [
 					new Date(this.income.valueDate),
@@ -188,7 +187,7 @@ export class IncomeMutationComponent extends TranslationBaseComponent
 				notes: this.income.notes,
 				currency: this.income.currency,
 				isBonus: this.income.isBonus,
-				tags: this.income.tags
+				tags: [this.income.tags]
 			});
 		} else {
 			this.form = this.fb.group({
@@ -207,6 +206,7 @@ export class IncomeMutationComponent extends TranslationBaseComponent
 			this._loadDefaultCurrency();
 		}
 		this.notes = this.form.get('notes');
+		this.tags = this.form.get('tags').value || [];
 	}
 
 	private async _loadDefaultCurrency() {
@@ -221,7 +221,7 @@ export class IncomeMutationComponent extends TranslationBaseComponent
 			this.currency.setValue(orgData.currency);
 		}
 	}
-	selectedTagsHandler(ev: any) {
-		this.form.get('tags').setValue(ev);
+	selectedTagsHandler(currentSelection: Tag[]) {
+		this.form.get('tags').setValue(currentSelection);
 	}
 }

--- a/apps/gauzy/src/app/@shared/organizations/organizations-step-form/organizations-step-form.component.html
+++ b/apps/gauzy/src/app/@shared/organizations/organizations-step-form/organizations-step-form.component.html
@@ -194,14 +194,13 @@
 						</div>
 						<div class="row">
 							<div class="col-6">
-								<ngx-tags-color-input
-									[form]="orgMainForm"
+								<ga-tags-color-input
 									[selectedTags]="tags"
 									(selectedTagsEvent)="
 										selectedTagsEvent($event)
 									"
 								>
-								</ngx-tags-color-input>
+								</ga-tags-color-input>
 							</div>
 						</div>
 

--- a/apps/gauzy/src/app/@shared/organizations/organizations-step-form/organizations-step-form.component.ts
+++ b/apps/gauzy/src/app/@shared/organizations/organizations-step-form/organizations-step-form.component.ts
@@ -50,7 +50,7 @@ export class OrganizationsStepFormComponent implements OnInit, OnDestroy {
 	orgLocationForm: FormGroup;
 	orgBonusForm: FormGroup;
 	orgSettingsForm: FormGroup;
-	tags: Tag[];
+	tags: Tag[] = [];
 
 	@Output()
 	createOrganization = new EventEmitter();
@@ -207,8 +207,9 @@ export class OrganizationsStepFormComponent implements OnInit, OnDestroy {
 		};
 		this.createOrganization.emit(consolidatedFormValues);
 	}
-	selectedTagsEvent(ev) {
-		this.tags = ev;
+
+	selectedTagsEvent(currentSelection: Tag[]) {
+		this.orgMainForm.get('tags').setValue(currentSelection);
 	}
 
 	ngOnDestroy() {

--- a/apps/gauzy/src/app/@shared/product-mutation/product-form/product-form.component.html
+++ b/apps/gauzy/src/app/@shared/product-mutation/product-form/product-form.component.html
@@ -89,12 +89,11 @@
 				</div>
 				<div class="row">
 					<div class="col-sm-12">
-						<ngx-tags-color-input
-							[form]="form"
+						<ga-tags-color-input
 							[selectedTags]="tags"
 							(selectedTagsEvent)="selectedTagsEvent($event)"
 						>
-						</ngx-tags-color-input>
+						</ga-tags-color-input>
 					</div>
 				</div>
 				<div class="mb-4">

--- a/apps/gauzy/src/app/@shared/product-mutation/product-form/product-form.component.ts
+++ b/apps/gauzy/src/app/@shared/product-mutation/product-form/product-form.component.ts
@@ -31,7 +31,7 @@ export class ProductFormComponent extends TranslationBaseComponent
 	productCategories: ProductCategory[];
 	options: Array<ProductOption> = [];
 	variants: Array<ProductVariant> = [];
-	tags: Tag[];
+	tags: Tag[] = [];
 
 	@Output() save = new EventEmitter<Product>();
 	@Output() cancel = new EventEmitter<string>();
@@ -57,11 +57,8 @@ export class ProductFormComponent extends TranslationBaseComponent
 	}
 
 	private _initializeForm() {
-		if (this.product) {
-			this.tags = this.product.tags;
-		}
 		this.form = this.fb.group({
-			tags: [],
+			tags: [this.product ? this.product.tags : ''],
 			name: [this.product ? this.product.name : '', Validators.required],
 			code: [this.product ? this.product.code : '', Validators.required],
 			productTypeId: [
@@ -75,6 +72,7 @@ export class ProductFormComponent extends TranslationBaseComponent
 			enabled: [this.product ? this.product.enabled : true],
 			description: [this.product ? this.product.description : '']
 		});
+		this.tags = this.form.get('tags').value || [];
 	}
 
 	async loadProductTypes() {
@@ -132,7 +130,7 @@ export class ProductFormComponent extends TranslationBaseComponent
 	onCancel() {
 		this.cancel.emit('PRODUCT_EDIT');
 	}
-	selectedTagsEvent(ev) {
-		this.tags = ev;
+	selectedTagsEvent(currentSelection: Tag[]) {
+		this.form.get('tags').setValue(currentSelection);
 	}
 }

--- a/apps/gauzy/src/app/@shared/tags/tags-color-input/tags-color-input.component.html
+++ b/apps/gauzy/src/app/@shared/tags/tags-color-input/tags-color-input.component.html
@@ -1,82 +1,51 @@
-<form [formGroup]="form" *ngIf="form">
+<div>
 	<label class="label" for="addTags">
 		{{ 'TAGS_PAGE.HEADER' | translate }}
 	</label>
-	<ng-select
-		bindLabel="name"
-		[addTag]="true"
-		formControlName="tags"
-		[items]="tags"
-		[(ngModel)]="selectedTags"
-		multiple="true"
-		(change)="onChange()"
+	<!-- <nb-select
+		class="d-block"
+		multiple
+		id="addTags"
+		(selectedChange)="onChange($event)"
+		[(selected)]="selectedTagIds"
 	>
-		<ng-template ng-label-tmp let-item="item" let-clear="clear">
-			<span class="ng-value-label"
-				><nb-badge
-					style="position: static !important;"
-					width="20px"
-					height="20px"
-					[style.background]="item.color"
-					text="{{ item.name }}"
-				></nb-badge
-			></span>
-			<span
-				class="ng-value-icon right"
-				(click)="clear(item)"
-				aria-hidden="true"
-				>×</span
-			>
-		</ng-template>
-		<ng-template ng-option-tmp let-item="item">
+		<nb-option *ngFor="let tag of tags" value="{{ tag.id }}">
 			<nb-badge
-				style="position: static !important;"
-				width="20px"
-				height="20px"
-				[style.background]="item.color"
-				text="{{ item.name }}"
+				class="tag-color"
+				[style.background]="tag.color"
+				text=""
 			></nb-badge>
-		</ng-template>
-	</ng-select>
-</form>
+			{{ tag.name }}
+		</nb-option>
+	</nb-select> -->
 
-<form *ngIf="!form">
-	<label class="label" for="addTags">
-		{{ 'TAGS_PAGE.HEADER' | translate }}
-	</label>
 	<ng-select
 		[items]="tags"
-		[(ngModel)]="selectedTags"
-		bindLabel="id"
 		multiple="true"
-		(change)="onChange()"
-		[ngModelOptions]="{ standalone: true }"
+		bindLabel="name"
+		(change)="selectedTagsEvent.emit($event)"
+		[ngModel]="selectedTags"
+		[closeOnSelect]="false"
+		id="addTags"
 	>
-		<ng-template ng-label-tmp let-item="item" let-clear="clear">
-			<span class="ng-value-label"
-				><nb-badge
-					style="position: static !important;"
-					width="20px"
-					height="20px"
-					[style.background]="item.color"
-					text="{{ item.name }}"
-				></nb-badge
-			></span>
-			<span
-				class="ng-value-icon right"
-				(click)="clear(item)"
-				aria-hidden="true"
-				>×</span
-			>
-		</ng-template>
-		<ng-template ng-option-tmp let-item="item">
+		<ng-template ng-option-tmp let-tag="item" let-tag$="item$">
+			<input type="checkbox" [ngModel]="tag$.selected" />
+
 			<nb-badge
-				style="position: static !important;"
-				width="20px"
-				height="20px"
-				[style.background]="item.color"
-				text="{{ item.name }}"
+				[style.background]="tag.color"
+				class="tag-color"
 			></nb-badge>
+			<span>{{ tag.name }}</span>
+		</ng-template>
+
+		<ng-template ng-label-tmp let-tag="item" let-clear="clear">
+			<nb-badge
+				class="tag-color tag-label"
+				[style.background]="tag.color"
+				text="X"
+				(click)="clear(tag)"
+			></nb-badge>
+			<span>{{ tag.name }}</span>
 		</ng-template>
 	</ng-select>
-</form>
+</div>

--- a/apps/gauzy/src/app/@shared/tags/tags-color-input/tags-color-input.component.scss
+++ b/apps/gauzy/src/app/@shared/tags/tags-color-input/tags-color-input.component.scss
@@ -1,0 +1,14 @@
+.tag-color {
+	position: unset;
+	display: inline-flex;
+	align-self: center;
+	width: 1rem;
+	height: 1rem;
+	margin-right: 1em;
+	margin-left: 1em;
+}
+
+.tag-label {
+	display: unset;
+	margin-right: 0.7em;
+}

--- a/apps/gauzy/src/app/@shared/tags/tags-color-input/tags-color-input.component.scss
+++ b/apps/gauzy/src/app/@shared/tags/tags-color-input/tags-color-input.component.scss
@@ -1,14 +1,14 @@
 .tag-color {
-	position: unset;
-	display: inline-flex;
-	align-self: center;
-	width: 1rem;
-	height: 1rem;
-	margin-right: 1em;
-	margin-left: 1em;
+  position: unset;
+  display: inline-flex;
+  align-self: center;
+  width: 1rem;
+  height: 1rem;
+  margin-right: 1em;
+  margin-left: 1em;
 }
 
 .tag-label {
-	display: unset;
-	margin-right: 0.7em;
+  display: unset;
+  margin-right: 0.7em;
 }

--- a/apps/gauzy/src/app/@shared/tags/tags-color-input/tags-color-input.component.ts
+++ b/apps/gauzy/src/app/@shared/tags/tags-color-input/tags-color-input.component.ts
@@ -1,68 +1,35 @@
-import {
-	Component,
-	OnInit,
-	ViewChild,
-	Input,
-	Output,
-	EventEmitter
-} from '@angular/core';
+import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { TagsService } from '../../../@core/services/tags.service';
-import { NgModel, FormGroup } from '@angular/forms';
+import { Tag } from '@gauzy/models';
 
 @Component({
-	selector: 'ngx-tags-color-input',
+	selector: 'ga-tags-color-input',
 	templateUrl: './tags-color-input.component.html',
 	styleUrls: ['./tags-color-input.component.scss']
 })
 export class TagsColorInputComponent implements OnInit {
-	@ViewChild('shownInput', { static: true })
-	shownInput: NgModel;
-
-	@Input('tags')
-	tags: any;
-
-	@Input('form')
-	form: FormGroup;
+	tags: Tag[];
 
 	@Input('selectedTags')
-	selectedTags: any;
+	selectedTags: Tag[];
 
-	@Input('items')
-	items: any;
+	selectedTagIds: string[];
 
 	@Output()
-	selectedTagsEvent: EventEmitter<any> = new EventEmitter<any>();
+	selectedTagsEvent = new EventEmitter<Tag[]>();
 
 	constructor(private readonly tagsService: TagsService) {}
 
-	async onChange() {
-		const tags = [];
-
-		for (const tag of this.selectedTags) {
-			const tagToCheck = await this.tagsService.findByName(tag.name);
-			if (!tagToCheck) {
-				const tagNew = await this.tagsService.insertTag({
-					name: tag.name,
-					description: '',
-					color: ''
-				});
-				if (tagNew.id) {
-					tags.push(tagNew);
-				}
-			} else {
-				tags.push(tagToCheck);
-			}
-		}
-
-		this.selectedTagsEvent.emit(tags);
+	async onChange(currentSelection: string[]) {
+		const selectedTags = this.tags.filter((tag) =>
+			currentSelection.includes(tag.id)
+		);
+		this.selectedTagsEvent.emit(selectedTags);
 	}
 
-	ngOnInit() {
-		this.getAllTags();
-	}
-
-	selectedTagsHandler(ev) {
-		this.form.get('selectedTags').setValue(ev);
+	async ngOnInit() {
+		await this.getAllTags();
+		this.selectedTagIds = this.selectedTags.map((tag: Tag) => tag.id);
 	}
 
 	async getAllTags() {

--- a/apps/gauzy/src/app/@shared/tags/tags-color-input/tags-color-input.module.ts
+++ b/apps/gauzy/src/app/@shared/tags/tags-color-input/tags-color-input.module.ts
@@ -1,20 +1,20 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TagsColorInputComponent } from './tags-color-input.component';
-import { NgSelectModule } from '@ng-select/ng-select';
-import { NbBadgeModule } from '@nebular/theme';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { NbBadgeModule, NbSelectModule } from '@nebular/theme';
+import { FormsModule } from '@angular/forms';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { HttpLoaderFactory } from '../../../@theme/components/header/selectors/employee/employee.module';
 import { HttpClient } from '@angular/common/http';
+import { NgSelectModule } from '@ng-select/ng-select';
 
 @NgModule({
 	imports: [
 		CommonModule,
-		NgSelectModule,
+		NbSelectModule,
 		NbBadgeModule,
 		FormsModule,
-		ReactiveFormsModule,
+		NgSelectModule,
 		TranslateModule.forChild({
 			loader: {
 				provide: TranslateLoader,

--- a/apps/gauzy/src/app/@shared/user/edit-profile-form/edit-profile-form.component.html
+++ b/apps/gauzy/src/app/@shared/user/edit-profile-form/edit-profile-form.component.html
@@ -160,14 +160,13 @@
 						</div>
 						<div class="col-6">
 							<div class="form-group">
-								<ngx-tags-color-input
-									[form]="form"
+								<ga-tags-color-input
 									[selectedTags]="tags"
 									(selectedTagsEvent)="
 										selectedTagsHandler($event)
 									"
 								>
-								</ngx-tags-color-input>
+								</ga-tags-color-input>
 							</div>
 						</div>
 					</div>

--- a/apps/gauzy/src/app/@shared/user/edit-profile-form/edit-profile-form.component.ts
+++ b/apps/gauzy/src/app/@shared/user/edit-profile-form/edit-profile-form.component.ts
@@ -47,7 +47,7 @@ export class EditProfileFormComponent implements OnInit, OnDestroy {
 	repeatPasswordErrorMsg: string;
 
 	matchPassword = true;
-	tags: Tag[];
+	tags: Tag[] = [];
 	selectedTags: any;
 
 	@Input()
@@ -196,7 +196,6 @@ export class EditProfileFormComponent implements OnInit, OnDestroy {
 	}
 
 	private _initializeForm(user: User) {
-		this.tags = user.tags;
 		this.form = this.fb.group({
 			firstName: [user.firstName],
 			lastName: [user.lastName],
@@ -221,6 +220,7 @@ export class EditProfileFormComponent implements OnInit, OnDestroy {
 			tags: [user.tags],
 			preferredLanguage: [user.preferredLanguage]
 		});
+		this.tags = this.form.get('tags').value || [];
 	}
 
 	bindFormControls() {
@@ -232,8 +232,9 @@ export class EditProfileFormComponent implements OnInit, OnDestroy {
 		this.validations.passwordControl();
 		this.validations.repeatPasswordControl();
 	}
-	selectedTagsHandler(ev: any) {
-		this.form.get('tags').setValue(ev);
+
+	selectedTagsHandler(currentSelection: Tag[]) {
+		this.form.get('tags').setValue(currentSelection);
 	}
 
 	ngOnDestroy(): void {

--- a/apps/gauzy/src/app/@shared/user/forms/basic-info/basic-info-form.component.html
+++ b/apps/gauzy/src/app/@shared/user/forms/basic-info/basic-info-form.component.html
@@ -250,12 +250,11 @@
 		</div>
 		<div class="col-sm-6">
 			<div class="form-group">
-				<ngx-tags-color-input
-					[form]="form"
+				<ga-tags-color-input
 					[selectedTags]="tags"
 					(selectedTagsEvent)="selectedTagsHandler($event)"
 				>
-				</ngx-tags-color-input>
+				</ga-tags-color-input>
 			</div>
 		</div>
 	</div>

--- a/apps/gauzy/src/app/@shared/user/forms/basic-info/basic-info-form.component.ts
+++ b/apps/gauzy/src/app/@shared/user/forms/basic-info/basic-info-form.component.ts
@@ -13,7 +13,6 @@ import { first } from 'rxjs/operators';
 import { RoleService } from 'apps/gauzy/src/app/@core/services/role.service';
 import { TranslateService } from '@ngx-translate/core';
 import { ValidationService } from 'apps/gauzy/src/app/@core/services/validation.service';
-import { TagsService } from 'apps/gauzy/src/app/@core/services/tags.service';
 import { TranslationBaseComponent } from '../../../language-base/translation-base.component';
 import { Store } from 'apps/gauzy/src/app/@core/services/store.service';
 
@@ -33,6 +32,7 @@ export class BasicInfoFormComponent extends TranslationBaseComponent
 	@Input() public isCandidate: boolean;
 	@Input() public isSuperAdmin: boolean;
 	@Input() public createdById: string;
+	@Input() public selectedTags: Tag[];
 
 	allRoles: string[] = Object.values(RolesEnum).filter(
 		(e) => e !== RolesEnum.EMPLOYEE
@@ -55,7 +55,6 @@ export class BasicInfoFormComponent extends TranslationBaseComponent
 	hiredDate: any;
 	rejectDate: any;
 	tags: Tag[] = [];
-	selectedTags: any;
 	items: any;
 
 	constructor(
@@ -64,7 +63,6 @@ export class BasicInfoFormComponent extends TranslationBaseComponent
 		private readonly roleService: RoleService,
 		readonly translateService: TranslateService,
 		private readonly validatorService: ValidationService,
-		private readonly tagsService: TagsService,
 		private readonly store: Store
 	) {
 		super(translateService);
@@ -75,8 +73,6 @@ export class BasicInfoFormComponent extends TranslationBaseComponent
 			role === RolesEnum.SUPER_ADMIN ? this.isSuperAdmin : true
 		);
 		this.loadFormData();
-
-		// this.getAllTags();
 	}
 
 	get uploaderPlaceholder() {
@@ -133,7 +129,7 @@ export class BasicInfoFormComponent extends TranslationBaseComponent
 				appliedDate: [''],
 				hiredDate: [''],
 				rejectDate: [''],
-				tags: ['']
+				tags: [this.selectedTags]
 			},
 			{
 				validator: this.validatorService.validateDate
@@ -152,7 +148,7 @@ export class BasicInfoFormComponent extends TranslationBaseComponent
 		this.appliedDate = this.form.get('appliedDate');
 		this.hiredDate = this.form.get('hiredDate');
 		this.rejectDate = this.form.get('rejectDate');
-		this.selectedTags = this.form.get('selectedTags');
+		this.tags = this.form.get('tags').value || [];
 	};
 
 	get showImageMeta() {
@@ -183,7 +179,7 @@ export class BasicInfoFormComponent extends TranslationBaseComponent
 						imageUrl: this.imageUrl.value,
 						role,
 						tenant: this.tenant,
-						tags: this.selectedTags
+						tags: this.form.get('tags').value
 					},
 					password: this.password.value,
 					organizationId,
@@ -200,9 +196,8 @@ export class BasicInfoFormComponent extends TranslationBaseComponent
 		this.imageUrl.setValue('');
 	}
 
-	selectedTagsHandler(ev: any) {
-		this.form.get('tags').setValue(ev);
-		this.selectedTags = ev;
+	selectedTagsHandler(currentSelection: Tag[]) {
+		this.form.get('tags').setValue(currentSelection);
 	}
 
 	ngAfterViewInit() {

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-employment/edit-candidate-employment.component.html
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-employment/edit-candidate-employment.component.html
@@ -75,12 +75,11 @@
 	<div class="row">
 		<div class="col-md-6">
 			<div class="form-group">
-				<ngx-tags-color-input
-					[form]="form"
+				<ga-tags-color-input
 					[selectedTags]="tags"
 					(selectedTagsEvent)="selectedTagsHandler($event)"
 				>
-				</ngx-tags-color-input>
+				</ga-tags-color-input>
 			</div>
 		</div>
 	</div>

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-employment/edit-candidate-employment.component.ts
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-employment/edit-candidate-employment.component.ts
@@ -111,8 +111,8 @@ export class EditCandidateEmploymentComponent implements OnInit, OnDestroy {
 		}
 	}
 
-	selectedTagsHandler(tags: Tag[]) {
-		this.tags = tags;
+	selectedTagsHandler(currentSelection: Tag[]) {
+		this.form.get('tags').setValue(currentSelection);
 	}
 
 	private _initializeForm(candidate: Candidate) {
@@ -128,7 +128,7 @@ export class EditCandidateEmploymentComponent implements OnInit, OnDestroy {
 			tags: [candidate.tags]
 		});
 
-		this.tags = candidate.tags;
+		this.tags = this.form.get('tags').value || [];
 	}
 
 	ngOnDestroy() {

--- a/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-employment/edit-employee-employment.component.html
+++ b/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-employment/edit-employee-employment.component.html
@@ -106,12 +106,11 @@
 	<div class="row">
 		<div class="col-md-6">
 			<div class="form-group">
-				<ngx-tags-color-input
-					[form]="form"
+				<ga-tags-color-input
 					[selectedTags]="tags"
 					(selectedTagsEvent)="selectedTagsHandler($event)"
 				>
-				</ngx-tags-color-input>
+				</ga-tags-color-input>
 			</div>
 		</div>
 	</div>

--- a/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-employment/edit-employee-employment.component.ts
+++ b/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-employment/edit-employee-employment.component.ts
@@ -18,7 +18,6 @@ import { Store } from 'apps/gauzy/src/app/@core/services/store.service';
 import { Subject, Subscription } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { EmployeeStore } from '../../../../../@core/services/employee-store.service';
-import { EmployeesService } from '../../../../../@core/services/employees.service';
 
 @Component({
 	selector: 'ga-edit-employee-employment',
@@ -47,7 +46,6 @@ export class EditEmployeeEmploymentComponent implements OnInit, OnDestroy {
 		private readonly store: Store,
 		private readonly toastrService: NbToastrService,
 		private readonly employeeStore: EmployeeStore,
-		private readonly employeeService: EmployeesService,
 		private readonly employeeLevelService: EmployeeLevelService,
 		private readonly organizationDepartmentsService: OrganizationDepartmentsService,
 		private readonly organizationPositionsService: OrganizationPositionsService,
@@ -124,8 +122,8 @@ export class EditEmployeeEmploymentComponent implements OnInit, OnDestroy {
 		}
 	}
 
-	selectedTagsHandler(tags: Tag[]) {
-		this.tags = tags;
+	selectedTagsHandler(currentSelection: Tag[]) {
+		this.form.get('tags').setValue(currentSelection);
 	}
 
 	private _initializeForm(employee: Employee) {
@@ -146,7 +144,7 @@ export class EditEmployeeEmploymentComponent implements OnInit, OnDestroy {
 			]
 		});
 
-		this.tags = employee.tags;
+		this.tags = this.form.get('tags').value || [];
 	}
 
 	ngOnDestroy() {

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-departments/edit-organization-departments-mutation/edit-organization-departments-mutation.component.html
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-departments/edit-organization-departments-mutation/edit-organization-departments-mutation.component.html
@@ -47,7 +47,10 @@
 				</ga-employee-multi-select>
 			</div>
 			<div class="form-group col-4">
-				<ngx-tags-color-input> </ngx-tags-color-input>
+				<!-- Tags component does nothing here
+				TODO: create relationship between OrganizationDepartment and Tags in Backend.
+				-->
+				<ga-tags-color-input [selectedTags]="[]"> </ga-tags-color-input>
 			</div>
 		</form>
 	</nb-card-body>

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-main/edit-organization-main.component.html
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-main/edit-organization-main.component.html
@@ -158,12 +158,11 @@
 				</div>
 				<div class="col-6">
 					<div class="form-group">
-						<ngx-tags-color-input
-							[form]="form"
+						<ga-tags-color-input
 							[selectedTags]="tags"
 							(selectedTagsEvent)="selectedTagsEvent($event)"
 						>
-						</ngx-tags-color-input>
+						</ga-tags-color-input>
 					</div>
 				</div>
 			</div>

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-main/edit-organization-main.component.ts
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-main/edit-organization-main.component.ts
@@ -25,7 +25,7 @@ export class EditOrganizationMainComponent extends TranslationBaseComponent
 	employeesCount: number;
 	form: FormGroup;
 	currencies: string[] = Object.values(CurrenciesEnum);
-	tags: Tag[];
+	tags: Tag[] = [];
 	selectedTags: any;
 
 	constructor(
@@ -91,9 +91,8 @@ export class EditOrganizationMainComponent extends TranslationBaseComponent
 		if (!this.organization) {
 			return;
 		}
-		this.tags = this.organization.tags;
 		this.form = this.fb.group({
-			tags: [this.tags],
+			tags: [this.organization.tags],
 			currency: [this.organization.currency, Validators.required],
 			name: [this.organization.name, Validators.required],
 			officialName: [this.organization.officialName],
@@ -105,8 +104,10 @@ export class EditOrganizationMainComponent extends TranslationBaseComponent
 					: null
 			]
 		});
+		this.tags = this.form.get('tags').value || [];
 	}
-	selectedTagsEvent(ev) {
-		this.tags = ev;
+
+	selectedTagsEvent(currentSelection: Tag[]) {
+		this.form.get('tags').setValue(currentSelection);
 	}
 }

--- a/apps/gauzy/src/app/pages/tasks/components/task-dialog/task-dialog.component.html
+++ b/apps/gauzy/src/app/pages/tasks/components/task-dialog/task-dialog.component.html
@@ -104,12 +104,11 @@
 				</div>
 				<div class="col-sm-12">
 					<div class="formGroup">
-						<ngx-tags-color-input
-							[form]="form"
-							[selectedTags]="selectedTask?.tags"
+						<ga-tags-color-input
+							[selectedTags]="tags"
 							(selectedTagsEvent)="selectedTagsHandler($event)"
 						>
-						</ngx-tags-color-input>
+						</ga-tags-color-input>
 					</div>
 				</div>
 				<div class="col-sm-6">

--- a/apps/gauzy/src/app/pages/tasks/components/task-dialog/task-dialog.component.ts
+++ b/apps/gauzy/src/app/pages/tasks/components/task-dialog/task-dialog.component.ts
@@ -3,7 +3,8 @@ import {
 	Task,
 	OrganizationProjects,
 	Employee,
-	OrganizationTeam
+	OrganizationTeam,
+	Tag
 } from '@gauzy/models';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { NbDialogRef, NbToastrService } from '@nebular/theme';
@@ -46,7 +47,7 @@ export class TaskDialogComponent extends TranslationBaseComponent
 	selectedTeams: string[];
 	selectedTask: Task;
 	organizationId: string;
-	selectedTags: any;
+	tags: Tag[] = [];
 	participants = 'employees';
 
 	constructor(
@@ -116,9 +117,11 @@ export class TaskDialogComponent extends TranslationBaseComponent
 			],
 			dueDate: [dueDate],
 			description: [description],
-			tags: [],
+			tags: [tags],
 			teams: [this.selectedTeams]
 		});
+
+		this.tags = this.form.get('tags').value || [];
 	}
 
 	addNewProject = (name: string): Promise<OrganizationProjects> => {
@@ -162,9 +165,8 @@ export class TaskDialogComponent extends TranslationBaseComponent
 		}
 	}
 
-	selectedTagsHandler(ev) {
-		// we dont need this, at least we dont need for create or update TASK
-		// this.tags = ev;
+	selectedTagsHandler(currentSelection: Tag[]) {
+		this.form.get('tags').setValue(currentSelection);
 	}
 
 	private async loadEmployees() {


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

**What got fixed?**
1. Browser warning related to `tags-color-input` component have been resolved.
2. `tags-color-input` component was used in multiple parts of the app but there was no uniform way of interacting with this component. Each page had its own implementation. Refactored all usages of `tags-color-input` component to have a uniform behaviour.
3. Removed unused input properties from `tags-color-input` component. After refactoring,  `tags-color-input` component accepts only the selected tags and emits newly selected tags from the dropdown.
4. Some colours hinder the readability of tag name. Separated tag colour and name in the dropdown for better UX.

**Before**
![image](https://user-images.githubusercontent.com/32574315/82138238-8aa8cf00-983c-11ea-994d-6448a34d4a7f.png)

**After**
![image](https://user-images.githubusercontent.com/32574315/82138244-a44a1680-983c-11ea-8d2f-5ec83f7cfe21.png)

Alternately, I've also tried nebular multiselect component to maintain uniform theme across the app. 
It also supports typing the tag name to locate in the list but is not very intuitive. The current version(5) has autocomplete directive which provides better UX. But we are on version 4.1 of the library which has no auto-complete support.

**Using NbSelect**
![image](https://user-images.githubusercontent.com/32574315/82138289-fee37280-983c-11ea-8b35-ac643f6690dc.png)

