### PR TITLE
fix: #1159 style specificity for icons in buttons

### DIFF
--- a/apps/gauzy/src/app/@theme/styles/_overrides.scss
+++ b/apps/gauzy/src/app/@theme/styles/_overrides.scss
@@ -85,16 +85,16 @@ body {
 		font-size: 0.8125rem;
 		line-height: 1.5rem;
 	}
-	
+
 	.ng-dropdown-panel .ng-dropdown-panel-items .ng-option:hover {
 		color: nb-theme(text-primary-hover-color);
 	}
-	
+
 	.ng-dropdown-panel .ng-dropdown-panel-items .ng-option-marked {
 		color: nb-theme(text-primary-active-color);
 		background: nb-theme(background-basic-color-1);
 	}
-	
+
 	.ng-dropdown-panel .ng-dropdown-panel-items .ng-option-selected {
 		color: nb-theme(text-primary-active-color);
 		background: nb-theme(background-basic-color-1);
@@ -113,7 +113,7 @@ body {
 		border-width: 1px;
 		border-style: solid;
 	}
-	
+
 	tr {
 		background-color: nb-theme(background-basic-color-1) !important;
 	}
@@ -139,15 +139,15 @@ body {
 	.info-text {
 		color: nb-theme(text-basic-color) !important;
 	}
-	nb-icon {
+	a > nb-icon {
 		color: nb-theme(text-basic-color) !important;
 	}
 	.records {
-		box-shadow: 0px 0px 16px 9px  nb-theme(shadow) !important;
+		box-shadow: 0px 0px 16px 9px nb-theme(shadow) !important;
 		background: nb-theme(background-basic-color-1) !important;
 	}
 	.profit-history {
-		box-shadow: 0px 0px 16px 9px  nb-theme(shadow) !important;
+		box-shadow: 0px 0px 16px 9px nb-theme(shadow) !important;
 		background: nb-theme(background-basic-color-1) !important;
 	}
 	tr {
@@ -156,7 +156,6 @@ body {
 	.table {
 		color: nb-theme(text-basic-color) !important;
 	}
-
 }
 
 @mixin f-window-mode($padding-top) {


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
**What got fixed?**
The icons in the sidebar menu are grey in the default theme. The screen looks something like this.
![image](https://user-images.githubusercontent.com/32574315/82140981-63f49380-9850-11ea-9e9b-4c3496c784d2.png)

Assuming that the icons in the sidebar needed to appear more prominent, updated the css rule more specific so that it is applied to the menu icons but not the icons within the buttons.

**Screens in each theme after making the change**

**Light**
![image](https://user-images.githubusercontent.com/32574315/82140899-cbf6aa00-984f-11ea-9c2a-5a2e506040a1.png)

**Dark**
![image](https://user-images.githubusercontent.com/32574315/82140916-e92b7880-984f-11ea-9b8c-5e075123ef51.png)

**Cosmic**
![image](https://user-images.githubusercontent.com/32574315/82140926-fba5b200-984f-11ea-8974-30183e95abc6.png)

**Corporate**
![image](https://user-images.githubusercontent.com/32574315/82140939-16782680-9850-11ea-943c-200d726a501c.png)