### PR TITLE
fix: #1019 fix duplicate get queries when header loads

### DIFF
--- a/apps/gauzy/src/app/@theme/components/header/header.component.html
+++ b/apps/gauzy/src/app/@theme/components/header/header.component.html
@@ -38,7 +38,10 @@
 			</button>
 		</nb-action>
 
-		<nb-action *ngIf="showEmployeesSelector" class="show-large-up">
+		<nb-action
+			*ngIf="showEmployeesSelector && !showExtraActions"
+			class="show-large-up"
+		>
 			<ga-employee-selector
 				class="header-selector employee-selector"
 			></ga-employee-selector>
@@ -119,7 +122,7 @@
 <div
 	(window:resize)="closeExtraActionsIfLarge($event)"
 	class="extra-actions"
-	[hidden]="!showExtraActions"
+	*ngIf="showExtraActions"
 >
 	<div>
 		<h6>{{ 'HEADER.SELECT_EMPLOYEE' | translate }}</h6>


### PR DESCRIPTION
Issue number - https://github.com/ever-co/gauzy/issues/1019 
Change rendering logic so that only one employee selector has to be loaded at a time, which will stop duplicate get query to api

-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
