### PR TITLE
fix: #1266 create tags from combobox and background contrast

### DIFF
--- a/apps/gauzy/src/app/@shared/table-components/picture-name-tags/picture-name-tags.component.ts
+++ b/apps/gauzy/src/app/@shared/table-components/picture-name-tags/picture-name-tags.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { ViewCell } from 'ng2-smart-table';
+import { getContrastColor } from 'libs/utils';
 
 @Component({
 	template: `
@@ -38,6 +39,7 @@ import { ViewCell } from 'ng2-smart-table';
 				class="color"
 				position="centered"
 				[style.background]="tag.color"
+				[style.color]="backgroundContrast(tag.color)"
 				text="{{ tag.name }}"
 			>
 			</nb-badge>
@@ -68,12 +70,16 @@ import { ViewCell } from 'ng2-smart-table';
 				height: 100%;
 				max-width: 70px;
 			}
-		`
-	]
+		`,
+	],
 })
 export class PictureNameTagsComponent implements ViewCell {
 	@Input()
 	rowData: any;
 
 	value: string | number;
+
+	backgroundContrast(bgColor: string) {
+		return getContrastColor(bgColor);
+	}
 }

--- a/apps/gauzy/src/app/@shared/tags/tags-color-input/tags-color-input.component.html
+++ b/apps/gauzy/src/app/@shared/tags/tags-color-input/tags-color-input.component.html
@@ -2,27 +2,12 @@
 	<label class="label" for="addTags">
 		{{ 'TAGS_PAGE.HEADER' | translate }}
 	</label>
-	<!-- <nb-select
-		class="d-block"
-		multiple
-		id="addTags"
-		(selectedChange)="onChange($event)"
-		[(selected)]="selectedTagIds"
-	>
-		<nb-option *ngFor="let tag of tags" value="{{ tag.id }}">
-			<nb-badge
-				class="tag-color"
-				[style.background]="tag.color"
-				text=""
-			></nb-badge>
-			{{ tag.name }}
-		</nb-option>
-	</nb-select> -->
-
 	<ng-select
 		[items]="tags"
 		multiple="true"
 		bindLabel="name"
+		[loading]="loading"
+		[addTag]="addTag"
 		(change)="selectedTagsEvent.emit($event)"
 		[ngModel]="selectedTags"
 		[closeOnSelect]="false"
@@ -42,10 +27,16 @@
 			<nb-badge
 				class="tag-color tag-label"
 				[style.background]="tag.color"
+				[style.color]="backgroundContrast(tag.color)"
 				text="X"
 				(click)="clear(tag)"
 			></nb-badge>
 			<span>{{ tag.name }}</span>
+		</ng-template>
+
+		<ng-template ng-tag-tmp let-newTagName="searchTerm">
+			<b>{{ 'TAGS_PAGE.ADD_NEW_TAG' | translate }}</b
+			>: {{ newTagName }}
 		</ng-template>
 	</ng-select>
 </div>

--- a/apps/gauzy/src/app/@shared/tags/tags-color-input/tags-color-input.component.ts
+++ b/apps/gauzy/src/app/@shared/tags/tags-color-input/tags-color-input.component.ts
@@ -1,14 +1,16 @@
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { TagsService } from '../../../@core/services/tags.service';
 import { Tag } from '@gauzy/models';
+import { getContrastColor } from 'libs/utils';
 
 @Component({
 	selector: 'ga-tags-color-input',
 	templateUrl: './tags-color-input.component.html',
-	styleUrls: ['./tags-color-input.component.scss']
+	styleUrls: ['./tags-color-input.component.scss'],
 })
 export class TagsColorInputComponent implements OnInit {
 	tags: Tag[];
+	loading = false;
 
 	@Input('selectedTags')
 	selectedTags: Tag[];
@@ -27,6 +29,18 @@ export class TagsColorInputComponent implements OnInit {
 		this.selectedTagsEvent.emit(selectedTags);
 	}
 
+	addTag = async (tagName: string) => {
+		const newTag: Tag = {
+			name: tagName,
+			color: '#' + Math.floor(Math.random() * 16777215).toString(16),
+			description: '',
+		};
+		this.loading = true;
+		const tag = await this.tagsService.insertTag(newTag);
+		this.loading = false;
+		return tag;
+	};
+
 	async ngOnInit() {
 		await this.getAllTags();
 		this.selectedTagIds = this.selectedTags.map((tag: Tag) => tag.id);
@@ -35,5 +49,9 @@ export class TagsColorInputComponent implements OnInit {
 	async getAllTags() {
 		const { items } = await this.tagsService.getAllTags();
 		this.tags = items;
+	}
+
+	backgroundContrast(bgColor: string) {
+		return getContrastColor(bgColor);
 	}
 }

--- a/apps/gauzy/src/app/@shared/tags/tags-color-input/tags-color-input.module.ts
+++ b/apps/gauzy/src/app/@shared/tags/tags-color-input/tags-color-input.module.ts
@@ -7,6 +7,7 @@ import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { HttpLoaderFactory } from '../../../@theme/components/header/selectors/employee/employee.module';
 import { HttpClient } from '@angular/common/http';
 import { NgSelectModule } from '@ng-select/ng-select';
+import { TagsService } from '../../../@core/services/tags.service';
 
 @NgModule({
 	imports: [
@@ -19,11 +20,12 @@ import { NgSelectModule } from '@ng-select/ng-select';
 			loader: {
 				provide: TranslateLoader,
 				useFactory: HttpLoaderFactory,
-				deps: [HttpClient]
-			}
-		})
+				deps: [HttpClient],
+			},
+		}),
 	],
 	exports: [TagsColorInputComponent],
-	declarations: [TagsColorInputComponent]
+	declarations: [TagsColorInputComponent],
+	providers: [TagsService],
 })
 export class TagsColorInputModule {}

--- a/apps/gauzy/src/app/pages/tags/tags-color/tags-color.component.html
+++ b/apps/gauzy/src/app/pages/tags/tags-color/tags-color.component.html
@@ -3,6 +3,7 @@
 		class="color"
 		position="centered"
 		[style.background]="rowData.color"
+		[style.color]="backgroundContrast(rowData.color)"
 		text="{{ rowData.name }}"
 	>
 	</nb-badge>

--- a/apps/gauzy/src/app/pages/tags/tags-color/tags-color.component.ts
+++ b/apps/gauzy/src/app/pages/tags/tags-color/tags-color.component.ts
@@ -1,13 +1,16 @@
 import { Component, Input } from '@angular/core';
 import { ViewCell } from 'ng2-smart-table';
-
+import { getContrastColor } from 'libs/utils';
 @Component({
 	selector: 'ngx-tags-color',
 	templateUrl: './tags-color.component.html',
-	styleUrls: ['./tags-color.component.scss']
+	styleUrls: ['./tags-color.component.scss'],
 })
 export class TagsColorComponent implements ViewCell {
 	@Input()
 	value: string | number;
 	rowData: any;
+	backgroundContrast(bgColor: string) {
+		return getContrastColor(bgColor);
+	}
 }

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -889,7 +889,8 @@
 		"TAGS_DELETE_TAG": "Tag deleted",
 		"TAGS_SELECT_NAME": "Tag name",
 		"TAGS_SELECT_COLOR": "Tag color",
-		"TAGS_SELECT_DESCRIPTION": "Tag description"
+		"TAGS_SELECT_DESCRIPTION": "Tag description",
+		"ADD_NEW_TAG": "Add new Tag"
 	},
 	"SKILLS_PAGE": {
 		"HEADER": "Skills"

--- a/libs/utils.ts
+++ b/libs/utils.ts
@@ -7,3 +7,19 @@ export function toUTC(data: string | Date | moment.Moment): moment.Moment {
 export function toLocal(data: string | Date | moment.Moment): moment.Moment {
 	return moment.utc(data).local();
 }
+
+export function getContrastColor(hex: string) {
+	const threshold = 130;
+	const hexToRGB = (h) => {
+		const hexValue = h.charAt(0) === '#' ? h.substring(1, 7) : h;
+		return {
+			red: parseInt(hexValue.substring(0, 2), 16),
+			blue: parseInt(hexValue.substring(2, 4), 16),
+			green: parseInt(hexValue.substring(4, 6), 16),
+		};
+	};
+	const { red, green, blue } = hexToRGB(hex);
+	const cBrightness = (red * 299 + green * 587 + blue * 114) / 1000;
+
+	return cBrightness > threshold ? '#000000' : '#ffffff';
+}


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
**What got fixed?**
- Ability to add a new tag directly from the Tags combobox was removed during refactoring. This feature has been added back.
- Tag names in badges for darker colours were unreadable, the text colour for badges set based on the background colour of the badge.

Before:
![image](https://user-images.githubusercontent.com/32574315/82665798-2b8af600-9c52-11ea-91bb-b5d5b8edb282.png)
After:
![image](https://user-images.githubusercontent.com/32574315/82665662-e8c91e00-9c51-11ea-8162-7bcb3712967c.png)


**demo**
https://www.loom.com/share/103192e77a224fa18b619c0d5bf30cbf
