### PR TITLE
feat: #1123 email template live edit preview and fetch APIs

### DIFF
--- a/apps/api/src/app/email-template/email-template.controller.ts
+++ b/apps/api/src/app/email-template/email-template.controller.ts
@@ -1,13 +1,65 @@
-import { Controller } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import {
+	CustomizableEmailTemplate,
+	CustomizeEmailTemplateFindInput
+} from '@gauzy/models';
+import { Body, Controller, Get, HttpStatus, Post, Query } from '@nestjs/common';
+import { QueryBus } from '@nestjs/cqrs';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { CrudController } from '../core/crud/crud.controller';
 import { EmailTemplate } from './email-template.entity';
 import { EmailTemplateService } from './email-template.service';
+import {
+	EmailTemplateGeneratePreviewQuery,
+	FindEmailTemplateQuery
+} from './queries';
 
 @ApiTags('EmailTemplate')
 @Controller()
 export class EmailTemplateController extends CrudController<EmailTemplate> {
-	constructor(private readonly emailTemplateService: EmailTemplateService) {
+	constructor(
+		private readonly emailTemplateService: EmailTemplateService,
+		private readonly queryBus: QueryBus
+	) {
 		super(emailTemplateService);
+	}
+
+	@ApiOperation({
+		summary:
+			'Find email template by name and language code for organization'
+	})
+	@ApiResponse({
+		status: HttpStatus.OK,
+		description: 'Found email template',
+		type: EmailTemplate
+	})
+	@ApiResponse({
+		status: HttpStatus.NOT_FOUND,
+		description: 'Record not found'
+	})
+	@Get('findTemplate')
+	async findEmailTemplate(
+		@Query('data') data: string
+	): Promise<CustomizableEmailTemplate> {
+		const {
+			findInput
+		}: { findInput: CustomizeEmailTemplateFindInput } = JSON.parse(data);
+		return this.queryBus.execute(new FindEmailTemplateQuery(findInput));
+	}
+
+	@ApiOperation({
+		summary: 'Converts mjml or handlebar text to html for email preview'
+	})
+	@ApiResponse({
+		status: HttpStatus.OK,
+		description: 'text converted to html',
+		type: EmailTemplate
+	})
+	@Post('emailPreview')
+	async generateEmailPreview(
+		@Body('data') data: string
+	): Promise<CustomizableEmailTemplate> {
+		return this.queryBus.execute(
+			new EmailTemplateGeneratePreviewQuery(data)
+		);
 	}
 }

--- a/apps/api/src/app/email-template/email-template.module.ts
+++ b/apps/api/src/app/email-template/email-template.module.ts
@@ -3,11 +3,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { EmailTemplate } from './email-template.entity';
 import { EmailTemplateService } from './email-template.service';
 import { EmailTemplateController } from './email-template.controller';
+import { QueryHandlers } from './queries/handlers';
+import { CqrsModule } from '@nestjs/cqrs';
 
 @Module({
-	imports: [TypeOrmModule.forFeature([EmailTemplate])],
+	imports: [TypeOrmModule.forFeature([EmailTemplate]), CqrsModule],
 	controllers: [EmailTemplateController],
-	providers: [EmailTemplateService],
+	providers: [EmailTemplateService, ...QueryHandlers],
 	exports: [TypeOrmModule, EmailTemplateService]
 })
 export class EmailTemplateModule {}

--- a/apps/api/src/app/email-template/queries/email-template.find.query.ts
+++ b/apps/api/src/app/email-template/queries/email-template.find.query.ts
@@ -1,0 +1,8 @@
+import { CustomizeEmailTemplateFindInput } from '@gauzy/models';
+import { IQuery } from '@nestjs/cqrs';
+
+export class FindEmailTemplateQuery implements IQuery {
+	static readonly type = '[EmailTemplate] Find';
+
+	constructor(public readonly input: CustomizeEmailTemplateFindInput) {}
+}

--- a/apps/api/src/app/email-template/queries/email-template.generate-preview.query.ts
+++ b/apps/api/src/app/email-template/queries/email-template.generate-preview.query.ts
@@ -1,0 +1,7 @@
+import { IQuery } from '@nestjs/cqrs';
+
+export class EmailTemplateGeneratePreviewQuery implements IQuery {
+	static readonly type = '[EmailTemplate] GeneratePreview';
+
+	constructor(public readonly input: string) {}
+}

--- a/apps/api/src/app/email-template/queries/handlers/email-template.find.handler.ts
+++ b/apps/api/src/app/email-template/queries/handlers/email-template.find.handler.ts
@@ -1,0 +1,78 @@
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import { EmailTemplateService } from '../../email-template.service';
+import { FindEmailTemplateQuery } from '../email-template.find.query';
+import {
+	CustomizableEmailTemplate,
+	LanguagesEnum,
+	EmailTemplateNameEnum,
+	EmailTemplate
+} from '@gauzy/models';
+import { IsNull } from 'typeorm';
+
+@QueryHandler(FindEmailTemplateQuery)
+export class FindEmailTemplateHandler
+	implements IQueryHandler<FindEmailTemplateQuery> {
+	constructor(private readonly emailTemplateService: EmailTemplateService) {}
+
+	public async execute(
+		command: FindEmailTemplateQuery
+	): Promise<CustomizableEmailTemplate> {
+		const {
+			input: { languageCode, name, organizationId }
+		} = command;
+
+		const emailTemplate: CustomizableEmailTemplate = {
+			subject: '',
+			template: ''
+		};
+
+		[emailTemplate.subject, emailTemplate.template] = await Promise.all([
+			this._fetchTemplate(languageCode, name, organizationId, 'subject'),
+			this._fetchTemplate(languageCode, name, organizationId, 'html')
+		]);
+
+		return emailTemplate;
+	}
+
+	private async _fetchTemplate(
+		languageCode: LanguagesEnum,
+		name: EmailTemplateNameEnum,
+		organizationId: string,
+		type: 'html' | 'subject'
+	): Promise<string> {
+		let subject = '';
+		let template = '';
+
+		const {
+			success,
+			record
+		}: {
+			success: boolean;
+			record?: EmailTemplate;
+		} = await this.emailTemplateService.findOneOrFail({
+			languageCode,
+			name: `${name}/${type}`,
+			organization: { id: organizationId }
+		});
+
+		if (success) {
+			subject = record.hbs;
+			template = record.mjml;
+		} else {
+			const { hbs, mjml } = await this.emailTemplateService.findOne({
+				languageCode,
+				name: `${name}/${type}`,
+				organization: IsNull()
+			});
+			subject = hbs;
+			template = mjml;
+		}
+
+		switch (type) {
+			case 'subject':
+				return subject;
+			case 'html':
+				return template;
+		}
+	}
+}

--- a/apps/api/src/app/email-template/queries/handlers/email-template.generate-preview.handler.ts
+++ b/apps/api/src/app/email-template/queries/handlers/email-template.generate-preview.handler.ts
@@ -1,0 +1,34 @@
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+import * as Handlebars from 'handlebars';
+import * as mjml2html from 'mjml';
+import { EmailTemplateService } from '../../email-template.service';
+import { EmailTemplateGeneratePreviewQuery } from '../email-template.generate-preview.query';
+
+@QueryHandler(EmailTemplateGeneratePreviewQuery)
+export class EmailTemplateGeneratePreviewHandler
+	implements IQueryHandler<EmailTemplateGeneratePreviewQuery> {
+	constructor(private readonly emailTemplateService: EmailTemplateService) {}
+
+	public async execute(
+		command: EmailTemplateGeneratePreviewQuery
+	): Promise<{ html: string }> {
+		const { input } = command;
+		let textToHtml = input;
+
+		try {
+			const mjmlTohtml = mjml2html(input);
+			textToHtml = mjmlTohtml.errors.length ? input : mjmlTohtml.html;
+		} catch (error) {
+			// ignore mjml conversion errors for non-mjml text such as subject
+		}
+
+		const handlebarsTemplate = Handlebars.compile(textToHtml);
+		const html = handlebarsTemplate({
+			organizationName: 'Organization',
+			email: 'user@domain.com',
+			name: 'John Doe',
+			role: 'USER_ROLE'
+		});
+		return { html };
+	}
+}

--- a/apps/api/src/app/email-template/queries/handlers/index.ts
+++ b/apps/api/src/app/email-template/queries/handlers/index.ts
@@ -1,0 +1,7 @@
+import { FindEmailTemplateHandler } from './email-template.find.handler';
+import { EmailTemplateGeneratePreviewHandler } from './email-template.generate-preview.handler';
+
+export const QueryHandlers = [
+	FindEmailTemplateHandler,
+	EmailTemplateGeneratePreviewHandler
+];

--- a/apps/api/src/app/email-template/queries/index.ts
+++ b/apps/api/src/app/email-template/queries/index.ts
@@ -1,0 +1,2 @@
+export { FindEmailTemplateQuery } from './email-template.find.query';
+export { EmailTemplateGeneratePreviewQuery } from './email-template.generate-preview.query';

--- a/apps/api/src/app/email/email.service.ts
+++ b/apps/api/src/app/email/email.service.ts
@@ -313,7 +313,6 @@ export class EmailService extends CrudService<IEmail> {
 		organizationId: string,
 		originUrl?: string
 	) {
-		console.log('organizationId:', organizationId);
 		const sendOptions = {
 			template: 'password',
 			message: {

--- a/apps/gauzy/src/app/@core/services/email-template.service.ts
+++ b/apps/gauzy/src/app/@core/services/email-template.service.ts
@@ -1,6 +1,11 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { EmailTemplate, EmailTemplateFindInput } from '@gauzy/models';
+import {
+	EmailTemplate,
+	EmailTemplateFindInput,
+	CustomizeEmailTemplateFindInput,
+	CustomizableEmailTemplate
+} from '@gauzy/models';
 import { first } from 'rxjs/operators';
 
 @Injectable({
@@ -22,6 +27,30 @@ export class EmailTemplateService {
 					params: { data }
 				}
 			)
+			.pipe(first())
+			.toPromise();
+	}
+	getTemplate(
+		findInput?: CustomizeEmailTemplateFindInput
+	): Promise<CustomizableEmailTemplate> {
+		const data = JSON.stringify({ findInput });
+
+		return this.http
+			.get<CustomizableEmailTemplate>(
+				`/api/email-template/findTemplate`,
+				{
+					params: { data }
+				}
+			)
+			.pipe(first())
+			.toPromise();
+	}
+
+	generateTemplatePreview(data: string): Promise<{ html: string }> {
+		return this.http
+			.post<{ html: string }>(`/api/email-template/emailPreview`, {
+				data
+			})
 			.pipe(first())
 			.toPromise();
 	}

--- a/apps/gauzy/src/app/pages/email-templates/email-templates-routing.module.ts
+++ b/apps/gauzy/src/app/pages/email-templates/email-templates-routing.module.ts
@@ -1,0 +1,16 @@
+import { Routes, RouterModule } from '@angular/router';
+import { NgModule } from '@angular/core';
+import { EmailTemplatesComponent } from './email-templates.component';
+
+const routes: Routes = [
+	{
+		path: '',
+		component: EmailTemplatesComponent
+	}
+];
+
+@NgModule({
+	imports: [RouterModule.forChild(routes)],
+	exports: [RouterModule]
+})
+export class EmailTemplatesRoutingModule {}

--- a/apps/gauzy/src/app/pages/email-templates/email-templates.component.html
+++ b/apps/gauzy/src/app/pages/email-templates/email-templates.component.html
@@ -1,0 +1,85 @@
+<form class="main-form" [formGroup]="form" *ngIf="form">
+	<nb-layout>
+		<nb-layout-header class="row">
+			<div class="col-6">
+				{{ organizationName }}
+			</div>
+
+			<div class="col-2">
+				<div class="form-group">
+					<label class="label">
+						{{ 'Language' | translate }}
+					</label>
+					<nb-select
+						class="d-block"
+						size="small"
+						formControlName="languageCode"
+						placeholder="{{ 'Language Select' | translate }}"
+						(selectedChange)="getTemplate()"
+					>
+						<nb-option
+							*ngFor="let language of languageCodes"
+							[value]="language"
+						>
+							{{
+								'USERS_PAGE.EDIT_USER.PREFERRED_LANGUAGE.' +
+									language | translate
+							}}
+						</nb-option>
+					</nb-select>
+				</div>
+			</div>
+			<div class="col-2">
+				<div class="form-group">
+					<label class="label">
+						{{ 'Template Name' | translate }}
+					</label>
+					<nb-select
+						class="d-block"
+						size="small"
+						formControlName="templateName"
+						placeholder="{{ 'Template Names' | translate }}"
+						(selectedChange)="getTemplate()"
+					>
+						<nb-option
+							*ngFor="let name of templateNames"
+							[value]="name"
+						>
+							{{ name }}
+						</nb-option>
+					</nb-select>
+				</div>
+			</div>
+			<div class="col-2">
+				<button nbButton>Save</button>
+			</div>
+		</nb-layout-header>
+		<nb-layout-column class="colored-column-warning">
+			<nb-card fullWidth>
+				<nb-card-body class="example-items-col">
+					<input
+						type="text"
+						nbInput
+						fullWidth
+						fieldSize="small"
+						placeholder="Input"
+						value="{{ subject }}"
+						#subjectEditor
+					/>
+					<textarea
+						class="mjml-editor"
+						#mjmlEditor
+						nbInput
+						fullWidth
+						placeholder="Textarea"
+						>{{ template }}</textarea
+					>
+				</nb-card-body>
+			</nb-card>
+		</nb-layout-column>
+		<nb-layout-column class="colored-column-danger">
+			<div [innerHtml]="previewSubject"></div>
+			<div [innerHtml]="previewEmail"></div>
+		</nb-layout-column>
+	</nb-layout>
+</form>

--- a/apps/gauzy/src/app/pages/email-templates/email-templates.component.scss
+++ b/apps/gauzy/src/app/pages/email-templates/email-templates.component.scss
@@ -1,0 +1,3 @@
+.mjml-editor {
+  min-height: 90vh;
+}

--- a/apps/gauzy/src/app/pages/email-templates/email-templates.component.ts
+++ b/apps/gauzy/src/app/pages/email-templates/email-templates.component.ts
@@ -1,0 +1,153 @@
+import {
+	Component,
+	ElementRef,
+	OnDestroy,
+	OnInit,
+	SecurityContext,
+	ViewChild,
+	AfterViewInit
+} from '@angular/core';
+import { FormBuilder, FormGroup } from '@angular/forms';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { EmailTemplateNameEnum, LanguagesEnum } from '@gauzy/models';
+import { TranslateService } from '@ngx-translate/core';
+import { fromEvent, Subject } from 'rxjs';
+import {
+	debounceTime,
+	distinctUntilChanged,
+	map,
+	takeUntil
+} from 'rxjs/operators';
+import { EmailTemplateService } from '../../@core/services/email-template.service';
+import { Store } from '../../@core/services/store.service';
+import { TranslationBaseComponent } from '../../@shared/language-base/translation-base.component';
+
+@Component({
+	templateUrl: './email-templates.component.html',
+	styleUrls: ['./email-templates.component.scss']
+})
+export class EmailTemplatesComponent extends TranslationBaseComponent
+	implements OnInit, AfterViewInit, OnDestroy {
+	private _ngDestroy$ = new Subject<void>();
+
+	previewEmail: SafeHtml;
+	previewSubject: SafeHtml;
+	organizationName: string;
+	organizationId: string;
+	form: FormGroup;
+
+	@ViewChild('mjmlEditor', { read: ElementRef }) mjmlEditor: ElementRef;
+	@ViewChild('subjectEditor', { read: ElementRef }) subjectEditor: ElementRef;
+
+	subject = '';
+	template = '';
+
+	name: EmailTemplateNameEnum = EmailTemplateNameEnum.INVITE_USER;
+	languageCode: LanguagesEnum = LanguagesEnum.ENGLISH;
+	languageCodes: string[] = Object.values(LanguagesEnum);
+	templateNames: string[] = Object.values(EmailTemplateNameEnum);
+
+	constructor(
+		readonly translateService: TranslateService,
+		private sanitizer: DomSanitizer,
+		private store: Store,
+		private fb: FormBuilder,
+		private emailTemplateService: EmailTemplateService
+	) {
+		super(translateService);
+	}
+
+	async ngOnInit() {
+		this.store.selectedOrganization$
+			.pipe(takeUntil(this._ngDestroy$))
+			.subscribe((org) => {
+				if (org) {
+					this.organizationName = org.name;
+					this.organizationId = org.id;
+					this.getTemplate();
+				}
+			});
+		this._initializeForm();
+	}
+
+	ngAfterViewInit() {
+		fromEvent(this.mjmlEditor.nativeElement, 'keyup')
+			.pipe(
+				takeUntil(this._ngDestroy$),
+				map((event: any) => event.target.value),
+				debounceTime(500),
+				distinctUntilChanged()
+			)
+			.subscribe(async (text) => {
+				const {
+					html
+				} = await this.emailTemplateService.generateTemplatePreview(
+					text
+				);
+				this.previewEmail = this.sanitizer.bypassSecurityTrustHtml(
+					html
+				);
+			});
+
+		fromEvent(this.subjectEditor.nativeElement, 'keyup')
+			.pipe(
+				takeUntil(this._ngDestroy$),
+				map((event: any) => event.target.value),
+				debounceTime(500),
+				distinctUntilChanged()
+			)
+			.subscribe(async (text) => {
+				const {
+					html
+				} = await this.emailTemplateService.generateTemplatePreview(
+					text
+				);
+				this.previewSubject = this.sanitizer.sanitize(
+					SecurityContext.HTML,
+					html
+				);
+			});
+		this.getTemplate();
+	}
+
+	async getTemplate() {
+		console.log('changed');
+		const result = await this.emailTemplateService.getTemplate({
+			languageCode: this.form.get('languageCode').value,
+			name: this.form.get('templateName').value,
+			organizationId: this.organizationId
+		});
+		this.subject = result.subject;
+		this.template = result.template;
+
+		const {
+			html: email
+		} = await this.emailTemplateService.generateTemplatePreview(
+			this.template
+		);
+		const {
+			html: subject
+		} = await this.emailTemplateService.generateTemplatePreview(
+			this.subject
+		);
+		this.previewEmail = this.sanitizer.bypassSecurityTrustHtml(email);
+		this.previewSubject = this.sanitizer.sanitize(
+			SecurityContext.HTML,
+			subject
+		);
+	}
+
+	private _initializeForm() {
+		this.form = this.fb.group({
+			templateName: [EmailTemplateNameEnum.WELCOME_USER],
+			languageCode: [LanguagesEnum.ENGLISH],
+			subject: [this.subject],
+			mjml: [this.template]
+		});
+	}
+
+	ngOnDestroy() {
+		this._ngDestroy$.next();
+		this._ngDestroy$.complete();
+	}
+}

--- a/apps/gauzy/src/app/pages/email-templates/email-templates.module.ts
+++ b/apps/gauzy/src/app/pages/email-templates/email-templates.module.ts
@@ -1,0 +1,57 @@
+import { NgModule } from '@angular/core';
+import { ThemeModule } from '../../@theme/theme.module';
+import {
+	NbCardModule,
+	NbButtonModule,
+	NbInputModule,
+	NbIconModule,
+	NbDialogModule,
+	NbSpinnerModule,
+	NbLayoutModule,
+	NbSelectModule
+} from '@nebular/theme';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { Ng2SmartTableModule } from 'ng2-smart-table';
+import { TableComponentsModule } from '../../@shared/table-components/table-components.module';
+import { TranslateModule, TranslateLoader } from '@ngx-translate/core';
+import { HttpClient } from '@angular/common/http';
+import { TranslateHttpLoader } from '@ngx-translate/http-loader';
+import { UserFormsModule } from '../../@shared/user/forms/user-forms.module';
+import { EmailTemplatesRoutingModule } from './email-templates-routing.module';
+import { EmailTemplatesComponent } from './email-templates.component';
+import { EmailTemplateService } from '../../@core/services/email-template.service';
+
+export function HttpLoaderFactory(http: HttpClient) {
+	return new TranslateHttpLoader(http, './assets/i18n/', '.json');
+}
+
+@NgModule({
+	imports: [
+		NbLayoutModule,
+		EmailTemplatesRoutingModule,
+		ThemeModule,
+		UserFormsModule,
+		NbCardModule,
+		FormsModule,
+		ReactiveFormsModule,
+		NbButtonModule,
+		NbInputModule,
+		NbSelectModule,
+		NbIconModule,
+		Ng2SmartTableModule,
+		NbDialogModule.forChild(),
+		TableComponentsModule,
+		TranslateModule.forChild({
+			loader: {
+				provide: TranslateLoader,
+				useFactory: HttpLoaderFactory,
+				deps: [HttpClient]
+			}
+		}),
+		NbSpinnerModule
+	],
+	providers: [EmailTemplateService],
+	entryComponents: [EmailTemplatesComponent],
+	declarations: [EmailTemplatesComponent]
+})
+export class EmailTemplatesModule {}

--- a/apps/gauzy/src/app/pages/pages-routing.module.ts
+++ b/apps/gauzy/src/app/pages/pages-routing.module.ts
@@ -255,8 +255,8 @@ const routes: Routes = [
 						path: 'email-templates',
 						loadChildren: () =>
 							import(
-								'./work-in-progress/work-in-progress.module'
-							).then((m) => m.WorkInProgressModule)
+								'./email-templates/email-templates.module'
+							).then((m) => m.EmailTemplatesModule)
 					},
 					{
 						path: 'help-center',

--- a/libs/models/src/lib/email-template.model.ts
+++ b/libs/models/src/lib/email-template.model.ts
@@ -1,4 +1,5 @@
 import { BaseEntityModel as IBaseEntityModel } from './base-entity.model';
+import { LanguagesEnum } from './user.model';
 
 export interface EmailTemplate extends IBaseEntityModel {
 	name: string;
@@ -10,4 +11,31 @@ export interface EmailTemplate extends IBaseEntityModel {
 export interface EmailTemplateFindInput extends IBaseEntityModel {
 	name?: string;
 	languageCode?: string;
+}
+
+export enum EmailTemplateNameEnum {
+	PASSWORD_RESET = 'password',
+	WELCOME_USER = 'welcome-user',
+	INVITE_ORGANIZATION_CLIENT = 'invite-organization-client',
+	INVITE_EMPLOYEE = 'invite-employee',
+	INVITE_USER = 'invite-user',
+	EMAIL_INVOICE = 'email-invoice'
+}
+
+export interface CustomizeEmailTemplateFindInput {
+	name: EmailTemplateNameEnum;
+	languageCode: LanguagesEnum;
+	organizationId: string;
+}
+
+export interface CustomizableEmailTemplate {
+	template: string;
+	subject: string;
+	params?: EmailTemplateOptions;
+}
+
+export interface EmailTemplateOptions {
+	organizationName?: string;
+	email?: string;
+	host?: string;
 }


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
**What got added**
1. API's to fetch Email templates based on name, language and organization.
 - if organization does not have a customized template, default template is loaded for editing.
2. Live preview of of the edited mjml is shown in the UI. API calls to recompile the template to html is debounced at 500ms and allowed previous template text is different from the current template text.

**TODO**
1. Save modified templates to the DB
2. Styling the UI