### PR TITLE
feat(appointment_scheduling): render booked slots on calendar

### DIFF
--- a/apps/api/src/app/employee-appointment/employee-appointment.entity.ts
+++ b/apps/api/src/app/employee-appointment/employee-appointment.entity.ts
@@ -87,12 +87,15 @@ export class EmployeeAppointment extends Base implements IEmployeeAppointment {
 	@Column({ nullable: true })
 	breakStartTime?: Date;
 
+	@ApiProperty({ type: String })
+	@IsString()
+	@Column({ nullable: true })
+	emails?: string;
+
 	@ApiProperty({ type: AppointmentEmployees, isArray: true })
-	@OneToMany(
-		(type) => AppointmentEmployees,
-		(entity) => entity.employeeId,
-		{ onDelete: 'SET NULL' }
-	)
+	@OneToMany((type) => AppointmentEmployees, (entity) => entity.employeeId, {
+		onDelete: 'SET NULL'
+	})
 	@JoinColumn()
 	invitees: AppointmentEmployees[];
 }

--- a/apps/gauzy/src/app/pages/employees/appointment/appointment.component.ts
+++ b/apps/gauzy/src/app/pages/employees/appointment/appointment.component.ts
@@ -158,11 +158,7 @@ export class AppointmentComponent extends TranslationBaseComponent
 		if (this.employee && this.employee.id) {
 			const findObj = {
 				employee: {
-					id: this.store.selectedEmployee
-						? this.store.selectedEmployee.id
-						: this.employee
-						? this.employee.id
-						: null
+					id: this.employee.id
 				}
 			};
 

--- a/apps/gauzy/src/app/pages/employees/appointment/appointment.component.ts
+++ b/apps/gauzy/src/app/pages/employees/appointment/appointment.component.ts
@@ -70,6 +70,7 @@ export class AppointmentComponent extends TranslationBaseComponent
 	slots: IAvailabilitySlots[];
 	dateSpecificSlots: IAvailabilitySlots[];
 	recurringSlots: IAvailabilitySlots[];
+	appointments: EmployeeAppointment[];
 	timeOff: TimeOff[] = [
 		{
 			start: new Date(
@@ -100,21 +101,21 @@ export class AppointmentComponent extends TranslationBaseComponent
 		readonly translateService: TranslateService
 	) {
 		super(translateService);
-		this._loadAppointments();
 
 		this.calendarOptions = {
 			eventClick: (event) => {
 				let eventObject = event.event;
-				this.router.navigate(
-					[this.appointmentFormURL || this.getRoute('manage')],
-					{
-						state: {
-							dateStart: eventObject.start,
-							dateEnd: eventObject.end,
-							selectedEventType: this.selectedEventType
+				eventObject.extendedProps['type'] !== 'BookedSlot' &&
+					this.router.navigate(
+						[this.appointmentFormURL || this.getRoute('manage')],
+						{
+							state: {
+								dateStart: eventObject.start,
+								dateEnd: eventObject.end,
+								selectedEventType: this.selectedEventType
+							}
 						}
-					}
-				);
+					);
 			},
 			events: this.getEvents.bind(this),
 			initialView: 'timeGridWeek',
@@ -155,7 +156,31 @@ export class AppointmentComponent extends TranslationBaseComponent
 			});
 
 		if (this.employee && this.employee.id) {
-			this._fetchAvailableSlots();
+			const findObj = {
+				employee: {
+					id: this.store.selectedEmployee
+						? this.store.selectedEmployee.id
+						: this.employee
+						? this.employee.id
+						: null
+				}
+			};
+
+			this.employeeAppointmentService
+				.getAll(['employee', 'employee.user'], findObj)
+				.pipe(takeUntil(this._ngDestroy$))
+				.subscribe((appointments) => {
+					this.appointments = appointments.items;
+					for (let appointment of this.appointments) {
+						this.checkAndAddEventToCalendar(
+							moment(appointment.startDateTime).utc().format(),
+							moment(appointment.endDateTime).utc().format(),
+							appointment.id,
+							'BookedSlot'
+						);
+					}
+					this._fetchAvailableSlots();
+				});
 		}
 	}
 
@@ -165,23 +190,6 @@ export class AppointmentComponent extends TranslationBaseComponent
 
 	getRoute(name: string) {
 		return `/pages/employees/appointments/${name}`;
-	}
-
-	private _loadAppointments() {
-		const findObj = {
-			employee: {
-				id: this.store.selectedEmployee
-					? this.store.selectedEmployee.id
-					: null
-			}
-		};
-
-		this.employeeAppointmentService
-			.getAll(['employee', 'employee.user'], findObj)
-			.pipe(takeUntil(this._ngDestroy$))
-			.subscribe((appointments) => {
-				console.log(appointments);
-			});
 	}
 
 	private async _fetchAvailableSlots() {
@@ -234,27 +242,14 @@ export class AppointmentComponent extends TranslationBaseComponent
 				moment(o.startTime).format('MMM Do YY') ===
 				moment(date).format('MMM Do YY')
 		);
+
 		if (slot) {
-			!this.calendarEvents.find(
-				(o) =>
-					new Date(o.start.toString()).getTime() ===
-					new Date(slot.startTime).getTime()
-			) &&
-				moment(slot.endTime).diff(moment(slot.startTime), 'minutes') >
-					this.allowedDuration &&
-				this.calendarEvents.push({
-					start: new Date(slot.startTime),
-					end: new Date(slot.endTime),
-					extendedProps: {
-						id: slot.id,
-						type: 'AvailabilitySlot'
-					},
-					backgroundColor: 'green'
-				});
 			foundDateSpecificSlot = true;
+			this.getAvailabilitySlots(slot);
 		}
 
-		if (foundDateSpecificSlot) return;
+		if (foundDateSpecificSlot)
+			return this.calendarComponent.getApi().refetchEvents();
 
 		for (const slot of this.recurringSlots) {
 			const startDay = moment(slot.startTime).day();
@@ -278,24 +273,119 @@ export class AppointmentComponent extends TranslationBaseComponent
 			slot.startTime = new Date(eventStartDate.format());
 			slot.endTime = new Date(eventEndDate.format());
 
-			!this.calendarEvents.find(
-				(o) =>
-					new Date(o.start.toString()).getTime() ===
-					new Date(slot.startTime).getTime()
-			) &&
-				eventEndDate.diff(eventStartDate, 'minutes') >
-					this.allowedDuration &&
-				this.calendarEvents.push({
-					start: slot.startTime,
-					end: slot.endTime,
-					extendedProps: {
-						id: slot.id,
-						type: 'AvailabilitySlot'
-					},
-					backgroundColor: 'green'
-				});
+			this.getAvailabilitySlots(slot);
 		}
 		this.calendarComponent.getApi().refetchEvents();
+	}
+
+	checkAndAddEventToCalendar(
+		startTime: string,
+		endTime: string,
+		id: string,
+		type: string
+	) {
+		const durationCheck = type === 'AvailabilitySlot' ? true : false;
+		!this.calendarEvents.find(
+			(o) =>
+				new Date(o.start.toString()).getTime() ===
+					new Date(startTime).getTime() &&
+				new Date(o.end.toString()).getTime() ===
+					new Date(endTime).getTime()
+		) &&
+			(!durationCheck ||
+				moment(endTime).diff(moment(startTime), 'minutes') >=
+					this.allowedDuration) &&
+			this.calendarEvents.push({
+				start: new Date(startTime),
+				end: new Date(endTime),
+				extendedProps: {
+					id: id,
+					type: type
+				},
+				backgroundColor: durationCheck ? 'green' : 'red'
+			});
+	}
+
+	getAvailabilitySlots(slot: IAvailabilitySlots) {
+		const appointmentsOnDay = this.appointments
+			.filter(
+				(o) =>
+					moment(o.startDateTime)
+						.utc()
+						.isSame(moment(slot.startTime).utc()) ||
+					moment(o.startDateTime)
+						.utc()
+						.isBetween(
+							moment(slot.startTime).utc(),
+							moment(slot.endTime).utc()
+						)
+			)
+			.sort((a, b) =>
+				moment(a.startDateTime)
+					.utc()
+					.isBefore(moment(b.startDateTime).utc())
+					? -1
+					: 1
+			);
+
+		for (let index = 0; index < appointmentsOnDay.length; index++) {
+			const appointmentOne = appointmentsOnDay[index];
+			const appointmentTwo = appointmentsOnDay[index + 1];
+			if (
+				moment(appointmentOne.startDateTime)
+					.utc()
+					.isSame(moment(slot.startTime).utc()) &&
+				(!appointmentTwo ||
+					moment(appointmentTwo.startDateTime)
+						.utc()
+						.isAfter(moment(appointmentOne.endDateTime).utc()))
+			) {
+				this.checkAndAddEventToCalendar(
+					moment(appointmentOne.endDateTime).utc().format(),
+					moment(
+						(appointmentTwo && appointmentTwo.startDateTime) ||
+							slot.endTime
+					)
+						.utc()
+						.format(),
+					slot.id,
+					'AvailabilitySlot'
+				);
+			} else if (
+				moment(appointmentOne.startDateTime)
+					.utc()
+					.isAfter(moment(slot.startTime).utc())
+			) {
+				const prevAppointment = appointmentsOnDay[index - 1];
+				this.checkAndAddEventToCalendar(
+					moment(
+						(prevAppointment && prevAppointment.endDateTime) ||
+							slot.startTime
+					)
+						.utc()
+						.format(),
+					moment(appointmentOne.startDateTime).utc().format(),
+					slot.id,
+					'AvailabilitySlot'
+				);
+				if (!appointmentTwo) {
+					this.checkAndAddEventToCalendar(
+						moment(appointmentOne.endDateTime).utc().format(),
+						moment(slot.endTime).utc().format(),
+						slot.id,
+						'AvailabilitySlot'
+					);
+				}
+			}
+		}
+
+		appointmentsOnDay.length === 0 &&
+			this.checkAndAddEventToCalendar(
+				moment(slot.startTime).utc().format(),
+				moment(slot.endTime).utc().format(),
+				slot.id,
+				'AvailabilitySlot'
+			);
 	}
 
 	private _prepareEvent(appointment: EmployeeAppointment) {

--- a/apps/gauzy/src/app/pages/employees/appointment/manage-appointment/manage-appointment.component.html
+++ b/apps/gauzy/src/app/pages/employees/appointment/manage-appointment/manage-appointment.component.html
@@ -166,6 +166,7 @@
 								'FORM.LABELS.MEETING_INVITEES' | translate
 							}}</label>
 							<ga-employee-multi-select
+								[label]="false"
 								[selectedEmployeeIds]="selectedEmployeeIds"
 								[allEmployees]="employees"
 								(selectedChange)="onMembersSelected($event)"

--- a/apps/gauzy/src/app/pages/employees/appointment/manage-appointment/manage-appointment.component.scss
+++ b/apps/gauzy/src/app/pages/employees/appointment/manage-appointment/manage-appointment.component.scss
@@ -1,0 +1,29 @@
+@import 'themes';
+
+@include nb-install-component {
+  .item-invalid {
+    ::ng-deep .ng-select-container {
+      border: 1px solid;
+      border-color: nb-theme(color-danger-default);
+    }
+  }
+
+  .item-valid {
+    ::ng-deep .ng-select-container {
+      border: 1px solid;
+      border-color: nb-theme(color-success-default);
+    }
+  }
+
+  // Remove drop down arrow from email select
+  #emailsSelect {
+    ::ng-deep {
+      .ng-clear-wrapper {
+        width: 20px;
+      }
+      .ng-arrow-wrapper {
+        display: none;
+      }
+    }
+  }
+}

--- a/apps/gauzy/src/app/pages/employees/appointment/manage-appointment/manage-appointment.component.ts
+++ b/apps/gauzy/src/app/pages/employees/appointment/manage-appointment/manage-appointment.component.ts
@@ -27,13 +27,15 @@ import { Store } from '../../../../@core/services/store.service';
 
 @Component({
 	selector: 'ga-manage-appointment',
-	templateUrl: './manage-appointment.component.html'
+	templateUrl: './manage-appointment.component.html',
+	styleUrls: ['./manage-appointment.component.scss']
 })
 export class ManageAppointmentComponent extends TranslationBaseComponent
 	implements OnInit, OnDestroy {
 	private _ngDestroy$ = new Subject<void>();
 	form: FormGroup;
 	employees: Employee[];
+	@Input() employee: Employee;
 	@Input() employeeAppointment: EmployeeAppointment;
 	@Input() disabled: boolean;
 	@Input() allowedDuration: number;
@@ -190,6 +192,7 @@ export class ManageAppointmentComponent extends TranslationBaseComponent
 
 	async onSaveRequest() {
 		const employeeAppointmentRequest = {
+			emails: this.emails.value,
 			agenda: this.form.get('agenda').value,
 			location: this.form.get('location').value,
 			description: this.form.get('description').value,
@@ -235,7 +238,11 @@ export class ManageAppointmentComponent extends TranslationBaseComponent
 		}
 
 		this.toastrService.primary(this.getTranslation('TOASTR.TITLE.SUCCESS'));
-		this.router.navigate(['/pages/employees/appointments']);
+		this.employee
+			? this.router.navigate([
+					`/share/employee/${this.employee.id}/confirm/${this.employeeAppointment.id}`
+			  ])
+			: this.router.navigate(['/pages/employees/appointments']);
 	}
 
 	onMembersSelected(ev) {

--- a/apps/gauzy/src/app/pages/employees/appointment/manage-appointment/manage-appointment.component.ts
+++ b/apps/gauzy/src/app/pages/employees/appointment/manage-appointment/manage-appointment.component.ts
@@ -209,7 +209,9 @@ export class ManageAppointmentComponent extends TranslationBaseComponent
 					' ' +
 					this.form.get('breakStartTime').value
 			),
-			employeeId: this.store.selectedEmployee
+			employeeId: this.employee
+				? this.employee.id
+				: this.store.selectedEmployee
 				? this.store.selectedEmployee.id
 				: null
 		};

--- a/apps/gauzy/src/app/share/public-appointments/appointment-form/appointment-form.component.html
+++ b/apps/gauzy/src/app/share/public-appointments/appointment-form/appointment-form.component.html
@@ -1,5 +1,7 @@
 <nb-card [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
 	<ga-manage-appointment
+		*ngIf="employee"
+		[employee]="employee"
 		[selectedRange]="selectedRange"
 		[hidePrivateFields]="true"
 		[allowedDuration]="allowedDuration"

--- a/apps/gauzy/src/app/share/public-appointments/confirm-appointment/confirm-appointment,routing.module.ts
+++ b/apps/gauzy/src/app/share/public-appointments/confirm-appointment/confirm-appointment,routing.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { ConfirmAppointmentComponent } from './confirm-appointment.component';
+const routes: Routes = [
+	{
+		path: '',
+		component: ConfirmAppointmentComponent
+	}
+];
+
+@NgModule({
+	imports: [RouterModule.forChild(routes)],
+	exports: [RouterModule]
+})
+export class ConfirmAppointmentRoutingModule {}

--- a/apps/gauzy/src/app/share/public-appointments/confirm-appointment/confirm-appointment.component.html
+++ b/apps/gauzy/src/app/share/public-appointments/confirm-appointment/confirm-appointment.component.html
@@ -1,0 +1,7 @@
+<nb-card [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
+	<nb-card-header>
+		<div class="main-header">
+			<h4>{{ 'PUBLIC_APPOINTMENTS.CONFIRM_APPOINTMENT' | translate }}</h4>
+		</div>
+	</nb-card-header>
+</nb-card>

--- a/apps/gauzy/src/app/share/public-appointments/confirm-appointment/confirm-appointment.component.ts
+++ b/apps/gauzy/src/app/share/public-appointments/confirm-appointment/confirm-appointment.component.ts
@@ -1,0 +1,31 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { TranslationBaseComponent } from '../../../@shared/language-base/translation-base.component';
+import { Subject } from 'rxjs';
+import { Router, ActivatedRoute } from '@angular/router';
+import { TranslateService } from '@ngx-translate/core';
+import { EmployeesService } from '../../../@core/services';
+
+@Component({
+	templateUrl: './confirm-appointment.component.html'
+})
+export class ConfirmAppointmentComponent extends TranslationBaseComponent
+	implements OnInit, OnDestroy {
+	private _ngDestroy$ = new Subject<void>();
+	loading: boolean;
+
+	constructor(
+		private route: ActivatedRoute,
+		private router: Router,
+		private employeeService: EmployeesService,
+		readonly translateService: TranslateService
+	) {
+		super(translateService);
+	}
+
+	ngOnInit(): void {}
+
+	ngOnDestroy() {
+		this._ngDestroy$.next();
+		this._ngDestroy$.complete();
+	}
+}

--- a/apps/gauzy/src/app/share/public-appointments/confirm-appointment/confirm-appointment.module.ts
+++ b/apps/gauzy/src/app/share/public-appointments/confirm-appointment/confirm-appointment.module.ts
@@ -1,0 +1,35 @@
+import { HttpClient } from '@angular/common/http';
+import { NgModule } from '@angular/core';
+import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
+import { TranslateHttpLoader } from '@ngx-translate/http-loader';
+import { ThemeModule } from '../../../@theme/theme.module';
+import { NbCardModule, NbSpinnerModule, NbButtonModule } from '@nebular/theme';
+import { ConfirmAppointmentRoutingModule } from './confirm-appointment,routing.module';
+import { ConfirmAppointmentComponent } from './confirm-appointment.component';
+import { ManageAppointmentModule } from '../../../pages/employees/appointment/manage-appointment/manage-appointment.module';
+
+export function HttpLoaderFactory(http: HttpClient) {
+	return new TranslateHttpLoader(http, './assets/i18n/', '.json');
+}
+
+@NgModule({
+	imports: [
+		ThemeModule,
+		NbButtonModule,
+		NbSpinnerModule,
+		NbCardModule,
+		ConfirmAppointmentRoutingModule,
+		ManageAppointmentModule,
+		TranslateModule.forChild({
+			loader: {
+				provide: TranslateLoader,
+				useFactory: HttpLoaderFactory,
+				deps: [HttpClient]
+			}
+		})
+	],
+	declarations: [ConfirmAppointmentComponent],
+	entryComponents: [ConfirmAppointmentComponent],
+	providers: []
+})
+export class ConfirmAppointmentModule {}

--- a/apps/gauzy/src/app/share/share-routing.module.ts
+++ b/apps/gauzy/src/app/share/share-routing.module.ts
@@ -12,46 +12,53 @@ const routes: Routes = [
 			{
 				path: '',
 				redirectTo: 'organization',
-				pathMatch: 'full',
+				pathMatch: 'full'
 			},
 			{
 				path: 'organization/:link',
 				loadChildren: () =>
 					import('./organization/organization.module').then(
 						(m) => m.OrganizationModule
-					),
+					)
 			},
 			{
 				path: 'employee/:id',
 				loadChildren: () =>
 					import(
 						'./public-appointments/public-appointments.module'
-					).then((m) => m.PublicAppointmentsModule),
+					).then((m) => m.PublicAppointmentsModule)
+			},
+			{
+				path: 'employee/:id/confirm/:appointmentId',
+				loadChildren: () =>
+					import(
+						'./public-appointments/confirm-appointment/confirm-appointment.module'
+					).then((m) => m.ConfirmAppointmentModule)
 			},
 			{
 				path: 'employee/:employeeid/create-appointment',
 				loadChildren: () =>
 					import(
 						'./public-appointments/appointment-form/appointment-form.module'
-					).then((m) => m.AppointmentFormModule),
+					).then((m) => m.AppointmentFormModule)
 			},
 			{
 				path: 'employee/:id/:eventId',
 				loadChildren: () =>
 					import(
 						'./public-appointments/create-appointment/create-appointment.module'
-					).then((m) => m.CreateAppointmentModule),
+					).then((m) => m.CreateAppointmentModule)
 			},
 			{
 				path: '**',
-				component: NotFoundComponent,
-			},
-		],
-	},
+				component: NotFoundComponent
+			}
+		]
+	}
 ];
 
 @NgModule({
 	imports: [RouterModule.forChild(routes)],
-	exports: [RouterModule],
+	exports: [RouterModule]
 })
 export class ShareRoutingModule {}

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -1493,6 +1493,7 @@
 		"SELECT_EVENT_TYPES": "Please select an event type",
 		"PICK_DATETIME": "Pick a date and time",
 		"DURATION": "Duration:",
-		"EVENT_TYPE": "Event Type:"
+		"EVENT_TYPE": "Event Type:",
+		"CONFIRM_APPOINTMENT": "Appointment confirmation page"
 	}
 }


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

This PR adds functionality to show booked slots on the calendar. The user can see the booked slots but cannot click on it, so the user is only allowed to book appointments from the free slots (the green ones). This implementation took longer than expected because it needed thoughts on the various cases possible and merge the availability slot timings with booked slot timings so that they do not overlap. 
If we select 60 min duration or any other duration, then free slots with greater or equal duration will only be shown. For eg: See the second appointment creation in below video, after creation the half hour above the booked event is not shown as selected event duration is 60 mins. If we select 30 mins, then it will show up.

WIP: Confirmation page for appointment bookings and send mail logic

![Screen-Recording-2020-06-05-at-1](https://user-images.githubusercontent.com/16370987/83799451-703b7600-a6c3-11ea-90f5-cb06ea1e16d5.gif)

---
