### PR TITLE
Feat/#1123 email templates online editor

### DIFF
--- a/apps/api/src/app/email-template/commands/email-template.save.command.ts
+++ b/apps/api/src/app/email-template/commands/email-template.save.command.ts
@@ -1,0 +1,8 @@
+import { ICommand } from '@nestjs/cqrs';
+import { IEmailTemplateSaveInput } from '@gauzy/models';
+
+export class EmailTemplateSaveCommand implements ICommand {
+	static readonly type = '[EmailTemplate] Save';
+
+	constructor(public readonly input: IEmailTemplateSaveInput) {}
+}

--- a/apps/api/src/app/email-template/commands/handlers/email-template.save.handler.ts
+++ b/apps/api/src/app/email-template/commands/handlers/email-template.save.handler.ts
@@ -1,0 +1,100 @@
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { EmailTemplateSaveCommand } from '../email-template.save.command';
+import { EmailTemplateService } from '../../email-template.service';
+import { EmailTemplate } from '../../email-template.entity';
+import { LanguagesEnum, EmailTemplateNameEnum } from '@gauzy/models';
+import * as mjml2html from 'mjml';
+import { Organization } from '../../../organization/organization.entity';
+import { BadRequestException } from '@nestjs/common';
+
+@CommandHandler(EmailTemplateSaveCommand)
+export class EmailTemplateSaveHandler
+	implements ICommandHandler<EmailTemplateSaveCommand> {
+	constructor(private readonly emailTemplateService: EmailTemplateService) {}
+
+	public async execute(
+		command: EmailTemplateSaveCommand
+	): Promise<EmailTemplate> {
+		const {
+			input: { languageCode, name, organizationId, mjml, subject }
+		} = command;
+
+		try {
+			await this._saveTemplate(
+				languageCode,
+				name,
+				organizationId,
+				mjml,
+				'html'
+			);
+		} catch (error) {
+			// TODO add translation
+			throw new BadRequestException('Invalid html template');
+		}
+
+		return this._saveTemplate(
+			languageCode,
+			name,
+			organizationId,
+			subject,
+			'subject'
+		);
+	}
+
+	private async _saveTemplate(
+		languageCode: LanguagesEnum,
+		name: EmailTemplateNameEnum,
+		organizationId: string,
+		content: string,
+		type: 'html' | 'subject'
+	): Promise<EmailTemplate> {
+		const {
+			success: found,
+			record
+		}: {
+			success: boolean;
+			record?: EmailTemplate;
+		} = await this.emailTemplateService.findOneOrFail({
+			languageCode,
+			name: `${name}/${type}`,
+			organization: { id: organizationId }
+		});
+
+		let entity: EmailTemplate;
+		if (found) {
+			switch (type) {
+				case 'subject':
+					entity = {
+						...record,
+						hbs: content
+					};
+					break;
+				case 'html':
+					entity = {
+						...record,
+						mjml: content,
+						hbs: mjml2html(content).html
+					};
+					break;
+			}
+			await this.emailTemplateService.update(record.id, entity);
+		} else {
+			entity = new EmailTemplate();
+			entity.organization = new Organization();
+			entity.organization.id = organizationId;
+			entity.languageCode = languageCode;
+			entity.name = `${name}/${type}`;
+			switch (type) {
+				case 'subject':
+					entity.hbs = content;
+					break;
+				case 'html':
+					entity.mjml = content;
+					entity.hbs = mjml2html(content).html;
+					break;
+			}
+			await this.emailTemplateService.create(entity);
+		}
+		return entity;
+	}
+}

--- a/apps/api/src/app/email-template/commands/handlers/index.ts
+++ b/apps/api/src/app/email-template/commands/handlers/index.ts
@@ -1,0 +1,3 @@
+import { EmailTemplateSaveHandler } from './email-template.save.handler';
+
+export const CommandHandlers = [EmailTemplateSaveHandler];

--- a/apps/api/src/app/email-template/commands/index.ts
+++ b/apps/api/src/app/email-template/commands/index.ts
@@ -1,0 +1,1 @@
+export { EmailTemplateSaveCommand } from './email-template.save.command';

--- a/apps/api/src/app/email-template/email-template.module.ts
+++ b/apps/api/src/app/email-template/email-template.module.ts
@@ -4,12 +4,13 @@ import { EmailTemplate } from './email-template.entity';
 import { EmailTemplateService } from './email-template.service';
 import { EmailTemplateController } from './email-template.controller';
 import { QueryHandlers } from './queries/handlers';
+import { CommandHandlers } from './commands/handlers';
 import { CqrsModule } from '@nestjs/cqrs';
 
 @Module({
 	imports: [TypeOrmModule.forFeature([EmailTemplate]), CqrsModule],
 	controllers: [EmailTemplateController],
-	providers: [EmailTemplateService, ...QueryHandlers],
+	providers: [EmailTemplateService, ...QueryHandlers, ...CommandHandlers],
 	exports: [TypeOrmModule, EmailTemplateService]
 })
 export class EmailTemplateModule {}

--- a/apps/api/src/app/email-template/queries/email-template.find.query.ts
+++ b/apps/api/src/app/email-template/queries/email-template.find.query.ts
@@ -1,8 +1,8 @@
-import { CustomizeEmailTemplateFindInput } from '@gauzy/models';
+import { ICustomizeEmailTemplateFindInput } from '@gauzy/models';
 import { IQuery } from '@nestjs/cqrs';
 
 export class FindEmailTemplateQuery implements IQuery {
 	static readonly type = '[EmailTemplate] Find';
 
-	constructor(public readonly input: CustomizeEmailTemplateFindInput) {}
+	constructor(public readonly input: ICustomizeEmailTemplateFindInput) {}
 }

--- a/apps/api/src/app/email-template/queries/handlers/email-template.find.handler.ts
+++ b/apps/api/src/app/email-template/queries/handlers/email-template.find.handler.ts
@@ -2,7 +2,7 @@ import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
 import { EmailTemplateService } from '../../email-template.service';
 import { FindEmailTemplateQuery } from '../email-template.find.query';
 import {
-	CustomizableEmailTemplate,
+	ICustomizableEmailTemplate,
 	LanguagesEnum,
 	EmailTemplateNameEnum,
 	EmailTemplate
@@ -16,12 +16,12 @@ export class FindEmailTemplateHandler
 
 	public async execute(
 		command: FindEmailTemplateQuery
-	): Promise<CustomizableEmailTemplate> {
+	): Promise<ICustomizableEmailTemplate> {
 		const {
 			input: { languageCode, name, organizationId }
 		} = command;
 
-		const emailTemplate: CustomizableEmailTemplate = {
+		const emailTemplate: ICustomizableEmailTemplate = {
 			subject: '',
 			template: ''
 		};
@@ -44,7 +44,7 @@ export class FindEmailTemplateHandler
 		let template = '';
 
 		const {
-			success,
+			success: found,
 			record
 		}: {
 			success: boolean;
@@ -55,7 +55,7 @@ export class FindEmailTemplateHandler
 			organization: { id: organizationId }
 		});
 
-		if (success) {
+		if (found) {
 			subject = record.hbs;
 			template = record.mjml;
 		} else {

--- a/apps/gauzy/src/app/@core/services/email-template.service.ts
+++ b/apps/gauzy/src/app/@core/services/email-template.service.ts
@@ -3,8 +3,9 @@ import { HttpClient } from '@angular/common/http';
 import {
 	EmailTemplate,
 	EmailTemplateFindInput,
-	CustomizeEmailTemplateFindInput,
-	CustomizableEmailTemplate
+	ICustomizeEmailTemplateFindInput,
+	ICustomizableEmailTemplate,
+	IEmailTemplateSaveInput
 } from '@gauzy/models';
 import { first } from 'rxjs/operators';
 
@@ -31,12 +32,12 @@ export class EmailTemplateService {
 			.toPromise();
 	}
 	getTemplate(
-		findInput?: CustomizeEmailTemplateFindInput
-	): Promise<CustomizableEmailTemplate> {
+		findInput?: ICustomizeEmailTemplateFindInput
+	): Promise<ICustomizableEmailTemplate> {
 		const data = JSON.stringify({ findInput });
 
 		return this.http
-			.get<CustomizableEmailTemplate>(
+			.get<ICustomizableEmailTemplate>(
 				`/api/email-template/findTemplate`,
 				{
 					params: { data }
@@ -49,6 +50,15 @@ export class EmailTemplateService {
 	generateTemplatePreview(data: string): Promise<{ html: string }> {
 		return this.http
 			.post<{ html: string }>(`/api/email-template/emailPreview`, {
+				data
+			})
+			.pipe(first())
+			.toPromise();
+	}
+
+	saveEmailTemplate(data: IEmailTemplateSaveInput): Promise<EmailTemplate> {
+		return this.http
+			.post<EmailTemplate>(`/api/email-template/saveTemplate`, {
 				data
 			})
 			.pipe(first())

--- a/apps/gauzy/src/app/pages/email-templates/email-templates.component.html
+++ b/apps/gauzy/src/app/pages/email-templates/email-templates.component.html
@@ -1,20 +1,20 @@
 <form class="main-form" [formGroup]="form" *ngIf="form">
-	<nb-layout>
-		<nb-layout-header class="row">
-			<div class="col-6">
-				{{ organizationName }}
-			</div>
+	<nb-card>
+		<nb-card-header>
+			<div class="row">
+				<div class="col-6">
+					<h4>Email Templates for {{ organizationName }}</h4>
+				</div>
 
-			<div class="col-2">
-				<div class="form-group">
-					<label class="label">
+				<div class="col-2 select-block">
+					<label class="label" for="languageCode">
 						{{ 'Language' | translate }}
 					</label>
 					<nb-select
+						id="languageCode"
 						class="d-block"
 						size="small"
 						formControlName="languageCode"
-						placeholder="{{ 'Language Select' | translate }}"
 						(selectedChange)="getTemplate()"
 					>
 						<nb-option
@@ -28,16 +28,15 @@
 						</nb-option>
 					</nb-select>
 				</div>
-			</div>
-			<div class="col-2">
-				<div class="form-group">
-					<label class="label">
+				<div class="col-2 select-block">
+					<label class="label" for="templateName">
 						{{ 'Template Name' | translate }}
 					</label>
 					<nb-select
+						id="templateName"
 						class="d-block"
 						size="small"
-						formControlName="templateName"
+						formControlName="name"
 						placeholder="{{ 'Template Names' | translate }}"
 						(selectedChange)="getTemplate()"
 					>
@@ -49,46 +48,80 @@
 						</nb-option>
 					</nb-select>
 				</div>
-			</div>
-			<div class="col-2">
-				<button
-					[disabled]="form.invalid"
-					(click)="submitForm()"
-					nbButton
-					status="success"
-				>
-					{{ 'PROFILE_PAGE.SAVE' | translate }}
-				</button>
-			</div>
-		</nb-layout-header>
-		<nb-layout-column class="colored-column-warning">
-			<nb-card fullWidth>
-				<nb-card-body class="example-items-col">
-					<input
-						type="text"
-						nbInput
-						fullWidth
-						fieldSize="small"
-						placeholder="Input"
-						value="{{ subject }}"
-						#subjectEditor
-						formControlName="subject"
-					/>
-					<textarea
-						class="mjml-editor"
-						#mjmlEditor
-						nbInput
-						fullWidth
-						placeholder="Textarea"
-						formControlName="mjml"
-						>{{ template }}</textarea
+				<div class="col-2 template-save">
+					<button
+						[disabled]="form.invalid"
+						(click)="submitForm()"
+						nbButton
+						status="success"
 					>
-				</nb-card-body>
-			</nb-card>
-		</nb-layout-column>
-		<nb-layout-column class="colored-column-danger">
-			<div [innerHtml]="previewSubject"></div>
-			<div [innerHtml]="previewEmail"></div>
-		</nb-layout-column>
-	</nb-layout>
+						{{ 'PROFILE_PAGE.SAVE' | translate }}
+					</button>
+				</div>
+			</div>
+		</nb-card-header>
+		<nb-card-body>
+			<nb-layout>
+				<nb-layout-column class="email-template-column">
+					<nb-card>
+						<nb-card-body>
+							<div class="form-group">
+								<label class="label" for="subject"
+									>Subject</label
+								>
+								<ace-editor
+									id="subject"
+									#subjectEditor
+									style="height: 10vh; font-size: medium;"
+									[durationBeforeCallback]="400"
+									[mode]="'handlebars'"
+									(textChange)="onSubjectChange($event)"
+								>
+								</ace-editor>
+							</div>
+							<div class="form-group">
+								<label class="label" for="email"
+									>Email Body</label
+								>
+								<ace-editor
+									#emailEditor
+									id="email"
+									[mode]="'handlebars'"
+									style="height: 80vh; font-size: medium;"
+									[durationBeforeCallback]="400"
+									(textChange)="onEmailChange($event)"
+								>
+								</ace-editor>
+							</div>
+						</nb-card-body>
+					</nb-card>
+				</nb-layout-column>
+				<!-- Live Preview column -->
+				<nb-layout-column class="email-template-column">
+					<nb-card>
+						<nb-card-body>
+							<div class="form-group">
+								<label class="label" for="previewSubject"
+									>Subject Preview
+								</label>
+								<div
+									id="previewSubject"
+									[innerHtml]="previewSubject"
+								></div>
+							</div>
+							<div class="form-group">
+								<label class="label" for="previewEmail"
+									>Email Preview
+								</label>
+								<div
+									id="previewEmail"
+									[innerHtml]="previewEmail"
+								></div>
+							</div>
+						</nb-card-body>
+					</nb-card>
+				</nb-layout-column>
+			</nb-layout>
+		</nb-card-body>
+	</nb-card>
 </form>

--- a/apps/gauzy/src/app/pages/email-templates/email-templates.component.html
+++ b/apps/gauzy/src/app/pages/email-templates/email-templates.component.html
@@ -51,7 +51,14 @@
 				</div>
 			</div>
 			<div class="col-2">
-				<button nbButton>Save</button>
+				<button
+					[disabled]="form.invalid"
+					(click)="submitForm()"
+					nbButton
+					status="success"
+				>
+					{{ 'PROFILE_PAGE.SAVE' | translate }}
+				</button>
 			</div>
 		</nb-layout-header>
 		<nb-layout-column class="colored-column-warning">
@@ -65,6 +72,7 @@
 						placeholder="Input"
 						value="{{ subject }}"
 						#subjectEditor
+						formControlName="subject"
 					/>
 					<textarea
 						class="mjml-editor"
@@ -72,6 +80,7 @@
 						nbInput
 						fullWidth
 						placeholder="Textarea"
+						formControlName="mjml"
 						>{{ template }}</textarea
 					>
 				</nb-card-body>

--- a/apps/gauzy/src/app/pages/email-templates/email-templates.component.html
+++ b/apps/gauzy/src/app/pages/email-templates/email-templates.component.html
@@ -3,12 +3,18 @@
 		<nb-card-header>
 			<div class="row">
 				<div class="col-6">
-					<h4>Email Templates for {{ organizationName }}</h4>
+					<h4>
+						{{
+							'EMAIL_TEMPLATES_PAGE.HEADER'
+								| translate
+									: { organizationName: organizationName }
+						}}
+					</h4>
 				</div>
 
 				<div class="col-2 select-block">
 					<label class="label" for="languageCode">
-						{{ 'Language' | translate }}
+						{{ 'EMAIL_TEMPLATES_PAGE.LABELS.LANGUAGE' | translate }}
 					</label>
 					<nb-select
 						id="languageCode"
@@ -22,7 +28,7 @@
 							[value]="language"
 						>
 							{{
-								'USERS_PAGE.EDIT_USER.PREFERRED_LANGUAGE.' +
+								'EMAIL_TEMPLATES_PAGE.LANGUAGE_CODES.' +
 									language | translate
 							}}
 						</nb-option>
@@ -30,7 +36,10 @@
 				</div>
 				<div class="col-2 select-block">
 					<label class="label" for="templateName">
-						{{ 'Template Name' | translate }}
+						{{
+							'EMAIL_TEMPLATES_PAGE.LABELS.TEMPLATE_NAME'
+								| translate
+						}}
 					</label>
 					<nb-select
 						id="templateName"
@@ -44,7 +53,10 @@
 							*ngFor="let name of templateNames"
 							[value]="name"
 						>
-							{{ name }}
+							{{
+								'EMAIL_TEMPLATES_PAGE.TEMPLATE_NAMES.' + name
+									| translate
+							}}
 						</nb-option>
 					</nb-select>
 				</div>
@@ -55,7 +67,7 @@
 						nbButton
 						status="success"
 					>
-						{{ 'PROFILE_PAGE.SAVE' | translate }}
+						{{ 'EMAIL_TEMPLATES_PAGE.SAVE' | translate }}
 					</button>
 				</div>
 			</div>
@@ -66,9 +78,12 @@
 					<nb-card>
 						<nb-card-body>
 							<div class="form-group">
-								<label class="label" for="subject"
-									>Subject</label
-								>
+								<label class="label" for="subject">
+									{{
+										'EMAIL_TEMPLATES_PAGE.LABELS.SUBJECT'
+											| translate
+									}}
+								</label>
 								<ace-editor
 									id="subject"
 									#subjectEditor
@@ -80,9 +95,12 @@
 								</ace-editor>
 							</div>
 							<div class="form-group">
-								<label class="label" for="email"
-									>Email Body</label
-								>
+								<label class="label" for="email">
+									{{
+										'EMAIL_TEMPLATES_PAGE.LABELS.EMAIL_BODY'
+											| translate
+									}}
+								</label>
 								<ace-editor
 									#emailEditor
 									id="email"
@@ -102,7 +120,10 @@
 						<nb-card-body>
 							<div class="form-group">
 								<label class="label" for="previewSubject"
-									>Subject Preview
+									>{{
+										'EMAIL_TEMPLATES_PAGE.LABELS.SUBJECT_PREVIEW'
+											| translate
+									}}
 								</label>
 								<div
 									id="previewSubject"
@@ -111,7 +132,10 @@
 							</div>
 							<div class="form-group">
 								<label class="label" for="previewEmail"
-									>Email Preview
+									>{{
+										'EMAIL_TEMPLATES_PAGE.LABELS.EMAIL_PREVIEW'
+											| translate
+									}}
 								</label>
 								<div
 									id="previewEmail"

--- a/apps/gauzy/src/app/pages/email-templates/email-templates.component.scss
+++ b/apps/gauzy/src/app/pages/email-templates/email-templates.component.scss
@@ -1,3 +1,12 @@
-.mjml-editor {
-  min-height: 90vh;
+.main-form {
+  .template-save {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+  }
+  nb-layout {
+    nb-layout-column.email-template-column {
+      padding: 0;
+    }
+  }
 }

--- a/apps/gauzy/src/app/pages/email-templates/email-templates.component.ts
+++ b/apps/gauzy/src/app/pages/email-templates/email-templates.component.ts
@@ -172,7 +172,10 @@ export class EmailTemplatesComponent extends TranslationBaseComponent
 			});
 			this.toastrService.primary(
 				this.getTranslation('TOASTR.MESSAGE.EMAIL_TEMPLATE_SAVED', {
-					templateName: this.form.get('name').value
+					templateName: this.getTranslation(
+						'EMAIL_TEMPLATES_PAGE.TEMPLATE_NAMES.' +
+							this.form.get('name').value
+					)
 				}),
 				this.getTranslation('TOASTR.TITLE.SUCCESS')
 			);

--- a/apps/gauzy/src/app/pages/email-templates/email-templates.module.ts
+++ b/apps/gauzy/src/app/pages/email-templates/email-templates.module.ts
@@ -20,6 +20,7 @@ import { UserFormsModule } from '../../@shared/user/forms/user-forms.module';
 import { EmailTemplatesRoutingModule } from './email-templates-routing.module';
 import { EmailTemplatesComponent } from './email-templates.component';
 import { EmailTemplateService } from '../../@core/services/email-template.service';
+import { AceEditorModule } from 'ng2-ace-editor';
 
 export function HttpLoaderFactory(http: HttpClient) {
 	return new TranslateHttpLoader(http, './assets/i18n/', '.json');
@@ -48,7 +49,8 @@ export function HttpLoaderFactory(http: HttpClient) {
 				deps: [HttpClient]
 			}
 		}),
-		NbSpinnerModule
+		NbSpinnerModule,
+		AceEditorModule
 	],
 	providers: [EmailTemplateService],
 	entryComponents: [EmailTemplatesComponent],

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -1514,5 +1514,32 @@
 		"DURATION": "Duration:",
 		"EVENT_TYPE": "Event Type:",
 		"CONFIRM_APPOINTMENT": "Appointment confirmation page"
+	},
+	"EMAIL_TEMPLATES_PAGE": {
+		"HEADER": "Email Templates for {{ organizationName }}",
+		"SAVE": "Save",
+		"LABELS": {
+			"LANGUAGE": "Language",
+			"TEMPLATE_NAME": "Template Name",
+			"SUBJECT": "Subject",
+			"EMAIL_BODY": "Email Body",
+			"EMAIL_PREVIEW": "Email Preview",
+			"SUBJECT_PREVIEW": "Subject Preview"
+		},
+		"TEMPLATE_NAMES": {
+			"password": "Password Reset",
+			"welcome-user": "Welcome User",
+			"invite-organization-client": "Invite Organization Client",
+			"email-estimate": "Email Estimate",
+			"email-invoice": "Email Invoice",
+			"invite-employee": "Invite Employee",
+			"invite-user": "Invite User"
+		},
+		"LANGUAGE_CODES": {
+			"en": "English",
+			"ru": "Russian",
+			"he": "Hebrew",
+			"bg": "Bulgarian"
+		}
 	}
 }

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -1329,7 +1329,8 @@
 			"EMAIL_SHOULD_BE_REAL": "Email should be a real one!",
 			"PHONE_REQUIRED": "Phone is required!",
 			"PHONE_CONTAINS_ONLY_NUMBERS": "Phone should only contain numbers!",
-			"SOMETHING_BAD_HAPPENED": "Something bad happened!"
+			"SOMETHING_BAD_HAPPENED": "Something bad happened!",
+			"EMAIL_TEMPLATE_SAVED": "{{templateName}} Email template saved successfully"
 		}
 	},
 	"ACCEPT_INVITE": {

--- a/libs/models/src/lib/email-template.model.ts
+++ b/libs/models/src/lib/email-template.model.ts
@@ -19,7 +19,8 @@ export enum EmailTemplateNameEnum {
 	INVITE_ORGANIZATION_CLIENT = 'invite-organization-client',
 	INVITE_EMPLOYEE = 'invite-employee',
 	INVITE_USER = 'invite-user',
-	EMAIL_INVOICE = 'email-invoice'
+	EMAIL_INVOICE = 'email-invoice',
+	EMAIL_ESTIMATE = 'email-estimate'
 }
 
 export interface ICustomizeEmailTemplateFindInput {

--- a/libs/models/src/lib/email-template.model.ts
+++ b/libs/models/src/lib/email-template.model.ts
@@ -22,20 +22,19 @@ export enum EmailTemplateNameEnum {
 	EMAIL_INVOICE = 'email-invoice'
 }
 
-export interface CustomizeEmailTemplateFindInput {
+export interface ICustomizeEmailTemplateFindInput {
 	name: EmailTemplateNameEnum;
 	languageCode: LanguagesEnum;
 	organizationId: string;
 }
 
-export interface CustomizableEmailTemplate {
+export interface ICustomizableEmailTemplate {
 	template: string;
 	subject: string;
-	params?: EmailTemplateOptions;
 }
 
-export interface EmailTemplateOptions {
-	organizationName?: string;
-	email?: string;
-	host?: string;
+export interface IEmailTemplateSaveInput
+	extends ICustomizeEmailTemplateFindInput {
+	mjml: string;
+	subject: string;
 }

--- a/package.json
+++ b/package.json
@@ -244,7 +244,9 @@
 		"upwork-api": "^1.3.6",
 		"uuid": "^7.0.2",
 		"web-animations-js": "^2.3.2",
-		"zone.js": "~0.10.2"
+		"zone.js": "~0.10.2",
+		"ng2-ace-editor": "^0.3.7",
+		"brace": "^0.11.1"
 	},
 	"devDependencies": {
 		"@angular-builders/custom-webpack": "^9.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5087,6 +5087,11 @@ accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
     mime-types "~2.1.24"
     negotiator "0.6.2"
 
+ace-builds@^1.2.9:
+  version "1.4.11"
+  resolved "https://registry.yarnpkg.com/ace-builds/-/ace-builds-1.4.11.tgz#b1f19a891afcef1d26522473082baf80067e855f"
+  integrity sha512-keACH1d7MvAh72fE/us36WQzOFQPJbHphNpj33pXwVZOM84pTWcdFzIAvngxOGIGLTm7gtUP2eJ4Ku6VaPo8bw==
+
 acorn-globals@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-3.1.0.tgz#fd8270f71fbb4996b004fa880ee5d46573a731bf"
@@ -6539,6 +6544,18 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+brace@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/brace/-/brace-0.10.0.tgz#edef4eb9b0928ba1ee5f717ffc157749a6dd5d76"
+  integrity sha1-7e9OubCSi6HuX3F//BV3SabdXXY=
+  dependencies:
+    w3c-blob "0.0.1"
+
+brace@^0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/brace/-/brace-0.11.1.tgz#4896fcc9d544eef45f4bb7660db320d3b379fe58"
+  integrity sha1-SJb8ydVE7vRfS7dmDbMg07N5/lg=
 
 braces@^2.3.0, braces@^2.3.1, braces@^2.3.2:
   version "2.3.2"
@@ -9692,7 +9709,7 @@ debug@^4.2.0:
   dependencies:
     ms "2.1.2"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -13571,7 +13588,7 @@ imul@^1.0.0:
   resolved "https://registry.yarnpkg.com/imul/-/imul-1.0.1.tgz#9d5867161e8b3de96c2c38d5dc7cb102f35e2ac9"
   integrity sha1-nVhnFh6LPelsLDjV3HyxAvNeKsk=
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -16129,11 +16146,6 @@ lodash-es@^4.17.15:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
   integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -16142,32 +16154,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -16328,11 +16318,6 @@ lodash.reject@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.reject/-/lodash.reject-4.6.0.tgz#80d6492dc1470864bbf583533b651f42a9f52415"
   integrity sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -18074,6 +18059,14 @@ ng-packagr@^9.1.5:
     stylus "^0.54.7"
     terser "^4.3.8"
     update-notifier "^4.0.0"
+
+ng2-ace-editor@0.3.7:
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/ng2-ace-editor/-/ng2-ace-editor-0.3.7.tgz#f62af0beeee5c2791739c6b42519db74a1c1a6da"
+  integrity sha512-ddsLikPgQBzxr7bPR2DyPntBaOnsggF/1jqfIkEGPD99bhJvagcEnKjM8UYkGJdAJJ8TiZeH+FgNyiSabMqxbA==
+  dependencies:
+    ace-builds "^1.2.9"
+    brace "^0.10.0"
 
 ng2-ckeditor@^1.2.6:
   version "1.2.7"
@@ -24667,6 +24660,7 @@ terser@4.6.10:
     source-map-support "~0.5.12"
 
 terser@^4.1.2, terser@^4.1.3, terser@^4.3.8, terser@^4.4.3, terser@^4.6.13, terser@^4.7.0, uglify-js@3.4.x, uglify-js@^2.6.1, uglify-js@^3.1.4, "uglify-js@npm:terser":
+  name uglify-js
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.7.0.tgz#15852cf1a08e3256a80428e865a2fa893ffba006"
   integrity sha512-Lfb0RiZcjRDXCC3OSHJpEkxJ9Qeqs6mp2v4jf2MHfy8vGERmVDuvjXdd/EnP5Deme5F2yBRBymKmKHCBg2echw==
@@ -25990,6 +25984,11 @@ vscode-languageserver-types@^3.5.0:
   version "3.15.1"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz#17be71d78d2f6236d414f0001ce1ef4d23e6b6de"
   integrity sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ==
+
+w3c-blob@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/w3c-blob/-/w3c-blob-0.0.1.tgz#b0cd352a1a50f515563420ffd5861f950f1d85b8"
+  integrity sha1-sM01KhpQ9RVWNCD/1YYflQ8dhbg=
 
 w3c-hr-time@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
**What got added?**
1. Backend API to save the modified Template
   - Updates the template if it already exists for a selected organization, language and template name otherwise a new record is created.
 2. Added a light weight editor with html syntax highlighting and autocomplete features to easily edit templates from the frontend. Editor is configured to switch between light and dark themes when theme is updated in the app.

**Demo**

https://www.loom.com/share/6c1f8419917248fdac113e86eacd1bd0

**Known issue:**
For email template preview, a compiled html is injected into the app dynamically. For security reasons, Angular blocks parts of theexternal html which make the email template in dark theme difficult to read. 
