### PR TITLE
Feat/public page

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -5,7 +5,7 @@
 			"typescriptMismatch": false,
 			"versionMismatch": false
 		},
-		"defaultCollection": "@nrwl/angular",
+		"defaultCollection": "@nstudio/xplat",
 		"packageManager": "yarn",
 		"analytics": false
 	},

--- a/apps/gauzy/src/app/@core/services/income.service.ts
+++ b/apps/gauzy/src/app/@core/services/income.service.ts
@@ -13,7 +13,6 @@ export class IncomeService {
 	constructor(private http: HttpClient) {}
 
 	create(createInput: IIncomeCreateInput): Promise<Income> {
-		
 		return this.http
 			.post<Income>('/api/income/create', createInput)
 			.pipe(first())
@@ -58,9 +57,6 @@ export class IncomeService {
 	}
 
 	delete(id: string): Promise<any> {
-		return this.http
-			.delete(`/api/income/${id}`)
-			.pipe(first())
-			.toPromise();
+		return this.http.delete(`/api/income/${id}`).pipe(first()).toPromise();
 	}
 }

--- a/apps/gauzy/src/app/share/organization/organization.component.html
+++ b/apps/gauzy/src/app/share/organization/organization.component.html
@@ -168,7 +168,9 @@
 						</h5>
 						<span
 							class="org-value"
-							[textContent]="'$' + total_income"
+							[textContent]="
+								organization.currency + ' ' + total_income
+							"
 						></span>
 					</div>
 				</div>
@@ -181,7 +183,9 @@
 						</h5>
 						<span
 							class="org-value"
-							[textContent]="'$' + profits"
+							[textContent]="
+								organization.currency + ' ' + profits
+							"
 						></span>
 					</div>
 				</div>
@@ -276,7 +280,9 @@
 						</h5>
 						<span
 							class="paid_bonuses"
-							[textContent]="'$' + bonuses_paid"
+							[textContent]="
+								organization.currency + ' ' + bonuses_paid
+							"
 						></span>
 					</div>
 				</div>

--- a/apps/gauzy/src/app/share/organization/organization.component.html
+++ b/apps/gauzy/src/app/share/organization/organization.component.html
@@ -200,7 +200,7 @@
 				<div class="col">
 					<div class="org-year-found">
 						<h5 class="org-title org-key">
-							{{ 'PUBLIC_PAGE.MONTHLY_INCOME' | translate }} :
+							{{ 'PUBLIC_PAGE.TOTAL_INCOME' | translate }} :
 						</h5>
 						<span
 							class="org-value"
@@ -337,6 +337,7 @@
 									class="employee_name"
 									[name]="
 										employee.user.firstName +
+										' ' +
 										employee.user.lastName
 									"
 									[picture]="employee.user.imageUrl"

--- a/apps/gauzy/src/app/share/organization/organization.component.html
+++ b/apps/gauzy/src/app/share/organization/organization.component.html
@@ -183,9 +183,7 @@
 				<div class="col">
 					<div class="org-year-found">
 						<h5 class="org-title org-key">
-							{{
-								'PUBLIC_PAGE.MINIMUM_PROJECT_SIZE' | translate
-							}}
+							{{ 'PUBLIC_PAGE.MINIMUM_PROJECT_SIZE' | translate }}
 							:
 						</h5>
 						<span
@@ -231,7 +229,7 @@
 					</div>
 				</div>
 			</div>
-			<div class="row" *ngIf="this.organization.show_profits && profits">
+			<div class="row" *ngIf="this.organization.show_profits">
 				<div class="col">
 					<div class="org-year-found">
 						<h5 class="org-title org-key">

--- a/apps/gauzy/src/app/share/organization/organization.component.html
+++ b/apps/gauzy/src/app/share/organization/organization.component.html
@@ -157,6 +157,22 @@
 				</div>
 			</div>
 			<div class="section_block"></div>
+			<div
+				class="row"
+				*ngIf="this.organization.show_income && total_income"
+			>
+				<div class="col">
+					<div class="org-year-found">
+						<h5 class="org-title org-key">
+							{{ 'PUBLIC_PAGE.TOTAL_INCOME' | translate }} :
+						</h5>
+						<span
+							class="org-value"
+							[textContent]="'$' + total_income"
+						></span>
+					</div>
+				</div>
+			</div>
 			<div class="row" *ngIf="languageExist">
 				<div class="col">
 					<div class="org-year-found">

--- a/apps/gauzy/src/app/share/organization/organization.component.html
+++ b/apps/gauzy/src/app/share/organization/organization.component.html
@@ -129,7 +129,7 @@
 					</div>
 					<div
 						class="org-size"
-						*ngIf="organization.show_clients_count && total_clients"
+						*ngIf="organization.show_clients_count"
 					>
 						<h5
 							class="org-title"
@@ -159,6 +159,44 @@
 			<div class="section_block"></div>
 			<div
 				class="row"
+				*ngIf="this.organization.show_projects_count && total_projects"
+			>
+				<div class="col">
+					<div class="org-year-found">
+						<h5 class="org-title org-key">
+							{{ 'PUBLIC_PAGE.TOTAL_PROJECTS' | translate }} :
+						</h5>
+						<span
+							class="org-value"
+							[textContent]="total_projects"
+						></span>
+					</div>
+				</div>
+			</div>
+			<div
+				class="row"
+				*ngIf="
+					this.organization.show_minimum_project_size &&
+					minimum_project_size
+				"
+			>
+				<div class="col">
+					<div class="org-year-found">
+						<h5 class="org-title org-key">
+							{{
+								'PUBLIC_PAGE.MINIMUM_PROJECT_SIZE' | translate
+							}}
+							:
+						</h5>
+						<span
+							class="org-value"
+							[textContent]="minimum_project_size"
+						></span>
+					</div>
+				</div>
+			</div>
+			<div
+				class="row"
 				*ngIf="this.organization.show_income && total_income"
 			>
 				<div class="col">
@@ -170,6 +208,24 @@
 							class="org-value"
 							[textContent]="
 								organization.currency + ' ' + total_income
+							"
+						></span>
+					</div>
+				</div>
+			</div>
+			<div
+				class="row"
+				*ngIf="this.organization.show_bonuses_paid && bonuses_paid"
+			>
+				<div class="col">
+					<div class="org-year-found">
+						<h5 class="org-title org-key">
+							{{ 'PUBLIC_PAGE.TOTAL_BONUSES_PAID' | translate }} :
+						</h5>
+						<span
+							class="org-value"
+							[textContent]="
+								organization.currency + ' ' + bonuses_paid
 							"
 						></span>
 					</div>
@@ -265,25 +321,6 @@
 								></span>
 							</nb-list-item>
 						</nb-list>
-					</div>
-				</div>
-			</div>
-
-			<div
-				class="row"
-				*ngIf="organization.show_bonuses_paid && bonuses_paid"
-			>
-				<div class="col">
-					<div class="org-bonuses-paid">
-						<h5 class="org-title">
-							{{ 'PUBLIC_PAGE.TOTAL_BONUSES_PAID' | translate }}
-						</h5>
-						<span
-							class="paid_bonuses"
-							[textContent]="
-								organization.currency + ' ' + bonuses_paid
-							"
-						></span>
 					</div>
 				</div>
 			</div>

--- a/apps/gauzy/src/app/share/organization/organization.component.html
+++ b/apps/gauzy/src/app/share/organization/organization.component.html
@@ -164,7 +164,7 @@
 				<div class="col">
 					<div class="org-year-found">
 						<h5 class="org-title org-key">
-							{{ 'PUBLIC_PAGE.TOTAL_INCOME' | translate }} :
+							{{ 'PUBLIC_PAGE.MONTHLY_INCOME' | translate }} :
 						</h5>
 						<span
 							class="org-value"

--- a/apps/gauzy/src/app/share/organization/organization.component.html
+++ b/apps/gauzy/src/app/share/organization/organization.component.html
@@ -247,44 +247,39 @@
 			<div class="row" *ngIf="languageExist">
 				<div class="col">
 					<div class="org-year-found">
-						<h5 class="org-title">
-							{{ 'PUBLIC_PAGE.LANGUAGES' | translate }}
+						<h5 class="org-title org-key">
+							{{ 'PUBLIC_PAGE.LANGUAGES' | translate }} :
 						</h5>
-						<nb-list class="nb_list block_style org_languages">
-							<nb-list-item
+						<span class="org-value">
+							<span
+								class="org_list_data"
 								*ngFor="
 									let l of organization_languages;
 									let i = index
 								"
-								class="nb_list_item item"
+								[textContent]="
+									(i !== 0 ? ', ' : ' ') +
+									l.name +
+									' (' +
+									l.level +
+									')'
+								"
 							>
-								<span
-									class="award_title"
-									[textContent]="
-										(i !== 0 ? ', ' : ' ') +
-										l.name +
-										' (' +
-										l.level +
-										')'
-									"
-								></span>
-							</nb-list-item>
-						</nb-list>
+							</span>
+						</span>
 					</div>
 				</div>
 			</div>
 			<div class="row" *ngIf="awardExist">
 				<div class="col">
-					<h5 class="org-title">
-						{{ 'PUBLIC_PAGE.AWARDS' | translate }}
-					</h5>
-					<nb-list class="nb_list block_style org_awards">
-						<nb-list-item
-							*ngFor="let a of awards; let i = index"
-							class="nb_list_item item"
-						>
+					<div class="org-year-found">
+						<h5 class="org-title org-key">
+							{{ 'PUBLIC_PAGE.AWARDS' | translate }} :
+						</h5>
+						<span class="org-value">
 							<span
-								class="award_title"
+								class="org_list_data"
+								*ngFor="let a of awards; let i = index"
 								[textContent]="
 									(i !== 0 ? ', ' : ' ') +
 									a.name +
@@ -292,31 +287,60 @@
 									a.year +
 									')'
 								"
-							></span>
-						</nb-list-item>
-					</nb-list>
+							>
+							</span>
+						</span>
+					</div>
 				</div>
 			</div>
 			<div class="row" *ngIf="organization.skills">
 				<div class="col">
 					<div class="org-skills">
-						<h5 class="org-title">
-							{{ 'PUBLIC_PAGE.COMPANY_SKILLS' | translate }}
+						<h5 class="org-title org-key">
+							{{ 'PUBLIC_PAGE.COMPANY_SKILLS' | translate }} :
 						</h5>
-						<nb-list class="nb_list block_style org_skills">
-							<nb-list-item
+						<span class="org-value">
+							<span
+								class="org_list_data"
 								*ngFor="
 									let skill of organization.skills;
 									let i = index
 								"
-								class="nb_list_item item"
+								[textContent]="
+									(i !== 0 ? ', ' : ' ') + skill.name
+								"
 							>
-								<span
-									class="skill_title"
-									[textContent]="
-										(i !== 0 ? ', ' : ' ') + skill.name
+							</span>
+						</span>
+					</div>
+				</div>
+			</div>
+
+			<div class="row" *ngIf="employees">
+				<div class="col">
+					<h5 class="org-title title-employees">
+						{{ 'PUBLIC_PAGE.EMPLOYEES' | translate }}
+						<span
+							class="org-employee-total"
+							[textContent]="'(' + employees.length + ')'"
+						></span>
+					</h5>
+					<div class="employee-list">
+						<nb-list class="nb_list block_style org_skills">
+							<nb-list-item
+								*ngFor="
+									let employee of employees;
+									let i = index
+								"
+								class="nb_list_employee"
+								><nb-user
+									class="employee_name"
+									[name]="
+										employee.user.firstName +
+										employee.user.lastName
 									"
-								></span>
+									[picture]="employee.user.imageUrl"
+								></nb-user>
 							</nb-list-item>
 						</nb-list>
 					</div>

--- a/apps/gauzy/src/app/share/organization/organization.component.html
+++ b/apps/gauzy/src/app/share/organization/organization.component.html
@@ -173,6 +173,19 @@
 					</div>
 				</div>
 			</div>
+			<div class="row" *ngIf="this.organization.show_profits && profits">
+				<div class="col">
+					<div class="org-year-found">
+						<h5 class="org-title org-key">
+							{{ 'PUBLIC_PAGE.PROFITS' | translate }} :
+						</h5>
+						<span
+							class="org-value"
+							[textContent]="'$' + profits"
+						></span>
+					</div>
+				</div>
+			</div>
 			<div class="row" *ngIf="languageExist">
 				<div class="col">
 					<div class="org-year-found">

--- a/apps/gauzy/src/app/share/organization/organization.component.scss
+++ b/apps/gauzy/src/app/share/organization/organization.component.scss
@@ -117,6 +117,18 @@ h5.org-title {
   margin: 0;
 }
 
+h5.org-title.org-key {
+  float: left;
+  display: block;
+  line-height: 2rem;
+}
+
+span.org-value {
+  float: left;
+  line-height: 2rem;
+  padding-left: 10px;
+}
+
 h5.org-title span.client-focus {
   font-size: 16px;
   font-weight: 500;

--- a/apps/gauzy/src/app/share/organization/organization.component.scss
+++ b/apps/gauzy/src/app/share/organization/organization.component.scss
@@ -149,7 +149,7 @@ h5.org-title span.client-focus {
   padding-bottom: 17px;
   float: left;
   padding-right: 30px;
-  min-width: 14%;
+  min-width: 20%;
   max-width: 100%;
 }
 

--- a/apps/gauzy/src/app/share/organization/organization.component.scss
+++ b/apps/gauzy/src/app/share/organization/organization.component.scss
@@ -92,13 +92,6 @@
     }
   }
 
-  .org-bonuses-paid span.paid_bonuses {
-    padding: 10px 0;
-    font-size: 15px;
-    font-weight: 500;
-    display: block;
-  }
-
   .org-details {
     width: 100%;
     display: block;

--- a/apps/gauzy/src/app/share/organization/organization.component.scss
+++ b/apps/gauzy/src/app/share/organization/organization.component.scss
@@ -143,8 +143,26 @@ h5.org-title span.client-focus {
   padding-left: 0;
 }
 
-.nb_list.org_skills .nb_list_item.item,
-.nb_list.org_languages .nb_list_item.item,
-.nb_list.org_awards .nb_list_item.item {
-  padding-right: 0;
+.nb_list_employee {
+  border: none;
+  padding: 0;
+  padding-bottom: 17px;
+  float: left;
+  padding-right: 30px;
+  min-width: 14%;
+  max-width: 100%;
+}
+
+.nb_list_employee:first-child {
+  border: none;
+}
+
+h5.org-title.title-employees {
+  text-align: center;
+  padding: 9px;
+  border-bottom: 1px solid #222b45;
+  margin: 0 auto;
+  max-width: 180px;
+  margin-bottom: 25px;
+  line-height: 15px;
 }

--- a/apps/gauzy/src/app/share/organization/organization.component.ts
+++ b/apps/gauzy/src/app/share/organization/organization.component.ts
@@ -37,6 +37,7 @@ export class OrganizationComponent extends TranslationBaseComponent
 	loading = true;
 	bonuses_paid = 0;
 	total_clients = 0;
+	total_income = 0;
 	imageUrl: string;
 	hoverState: boolean;
 	languageExist: boolean;
@@ -96,6 +97,9 @@ export class OrganizationComponent extends TranslationBaseComponent
 					}
 					if (!!this.organization.show_clients_count) {
 						await this.getClientsCount();
+					}
+					if (!!this.organization.show_income) {
+						await this.getTotalIncome();
 					}
 					this.reloadPageData();
 				} catch (error) {
@@ -169,6 +173,18 @@ export class OrganizationComponent extends TranslationBaseComponent
 			organizationId: this.organization.id
 		});
 		this.total_clients = total;
+	}
+
+	private async getTotalIncome() {
+		let { items } = await this.incomeService.getAll(null, {
+			organization: {
+				id: this.organization.id
+			}
+		});
+
+		for (let inc = 0; inc < items.length; inc++) {
+			this.total_income += parseFloat(String(items[inc].amount));
+		}
 	}
 
 	private reloadPageData() {

--- a/apps/gauzy/src/app/share/organization/organization.component.ts
+++ b/apps/gauzy/src/app/share/organization/organization.component.ts
@@ -89,13 +89,13 @@ export class OrganizationComponent extends TranslationBaseComponent
 						.toPromise();
 					this.imageUrl = this.organization.imageUrl;
 					if (typeof this.organization.totalEmployees !== 'number') {
-						this.loadEmployeesCount();
+						await this.loadEmployeesCount();
 					}
 					if (!!this.organization.show_bonuses_paid) {
-						this.getTotalBonusesPaid();
+						await this.getTotalBonusesPaid();
 					}
 					if (!!this.organization.show_clients_count) {
-						this.getClientsCount();
+						await this.getClientsCount();
 					}
 					this.reloadPageData();
 				} catch (error) {

--- a/apps/gauzy/src/app/share/organization/organization.component.ts
+++ b/apps/gauzy/src/app/share/organization/organization.component.ts
@@ -11,7 +11,6 @@ import {
 	OrganizationAwards,
 	OrganizationLanguages,
 	PermissionsEnum,
-	TimeLogFilters,
 	Timesheet
 } from '@gauzy/models';
 import { NbDialogService, NbToastrService } from '@nebular/theme';
@@ -26,7 +25,6 @@ import { OrganizationClientsService } from '../../@core/services/organization-cl
 import { EmployeeStatisticsService } from '../../@core/services/employee-statistics.service';
 import { OrganizationProjectsService } from '../../@core/services/organization-projects.service';
 import { TimesheetService } from '../../@shared/timesheet/timesheet.service';
-import { toUTC } from '../../../../../../libs/utils';
 
 @Component({
 	selector: 'ngx-organization',

--- a/apps/gauzy/src/app/share/organization/organization.component.ts
+++ b/apps/gauzy/src/app/share/organization/organization.component.ts
@@ -21,6 +21,7 @@ import * as moment from 'moment';
 import { IncomeService } from '../../@core/services/income.service';
 import { OrganizationClientsService } from '../../@core/services/organization-clients.service ';
 import { EmployeeStatisticsService } from '../../@core/services/employee-statistics.service';
+import { OrganizationProjectsService } from '../../@core/services/organization-projects.service';
 
 @Component({
 	selector: 'ngx-organization',
@@ -40,6 +41,8 @@ export class OrganizationComponent extends TranslationBaseComponent
 	total_clients = 0;
 	total_income = 0;
 	profits = 0;
+	minimum_project_size = 0;
+	total_projects = 0;
 	imageUrl: string;
 	hoverState: boolean;
 	languageExist: boolean;
@@ -58,6 +61,7 @@ export class OrganizationComponent extends TranslationBaseComponent
 		private incomeService: IncomeService,
 		private organizationClientsService: OrganizationClientsService,
 		private employeeStatisticsService: EmployeeStatisticsService,
+		private organizationProjectsService: OrganizationProjectsService,
 		private store: Store,
 		private dialogService: NbDialogService,
 		readonly translateService: TranslateService
@@ -96,6 +100,9 @@ export class OrganizationComponent extends TranslationBaseComponent
 					await this.getEmployeeStatistics();
 					if (!!this.organization.show_clients_count) {
 						await this.getClientsCount();
+					}
+					if (!!this.organization.show_projects_count) {
+						await this.getProjectCount();
 					}
 				} catch (error) {
 					await this.router.navigate(['/share/404']);
@@ -141,6 +148,25 @@ export class OrganizationComponent extends TranslationBaseComponent
 			organizationId: this.organization.id
 		});
 		this.total_clients = total;
+	}
+
+	private async getProjectCount() {
+		const { items, total } = await this.organizationProjectsService.getAll(
+			['members'],
+			{
+				organizationId: this.organization.id,
+				public: true
+			}
+		);
+		this.total_projects = total;
+		if (total) {
+			this.minimum_project_size = items[0].members.length;
+			for (let inc = 0; inc < items.length; inc++) {
+				if (items[inc].members.length < this.minimum_project_size) {
+					this.minimum_project_size = items[inc].members.length;
+				}
+			}
+		}
 	}
 
 	private async getTotalIncome() {

--- a/apps/gauzy/src/app/share/organization/organization.component.ts
+++ b/apps/gauzy/src/app/share/organization/organization.component.ts
@@ -151,6 +151,7 @@ export class OrganizationComponent extends TranslationBaseComponent
 
 	private async getTotalBonusesPaid() {
 		let { items } = await this.incomeService.getAll(['employee'], {
+			isBonus: true,
 			organization: {
 				id: this.organization.id
 			}

--- a/apps/gauzy/src/app/share/organization/organization.component.ts
+++ b/apps/gauzy/src/app/share/organization/organization.component.ts
@@ -43,6 +43,7 @@ export class OrganizationComponent extends TranslationBaseComponent
 	profits = 0;
 	minimum_project_size = 0;
 	total_projects = 0;
+	employees = [];
 	imageUrl: string;
 	hoverState: boolean;
 	languageExist: boolean;
@@ -170,15 +171,12 @@ export class OrganizationComponent extends TranslationBaseComponent
 	}
 
 	private async getTotalIncome() {
-		let { items } = await this.incomeService.getAll(null, {
+		let { items } = await this.incomeService.getAll(['employee'], {
 			organization: {
 				id: this.organization.id
-			}
+			},
+			isBonus: true
 		});
-
-		for (let inc = 0; inc < items.length; inc++) {
-			this.total_income += parseFloat(String(items[inc].amount));
-		}
 	}
 
 	private async getEmployeeStatistics() {
@@ -188,9 +186,10 @@ export class OrganizationComponent extends TranslationBaseComponent
 				filterDate: new Date()
 			}
 		);
-
+		this.employees = statistics.employees;
+		console.log(this.employees);
 		if (typeof this.organization.totalEmployees !== 'number') {
-			this.organization.totalEmployees = statistics.employees.length;
+			this.organization.totalEmployees = this.employees.length;
 		}
 		if (!!this.organization.show_bonuses_paid) {
 			this.bonuses_paid = statistics.total.bonus;
@@ -199,7 +198,7 @@ export class OrganizationComponent extends TranslationBaseComponent
 			this.total_income = statistics.total.income;
 		}
 		if (!!this.organization.show_profits) {
-			this.total_income = statistics.total.profit;
+			this.profits = statistics.total.profit;
 		}
 	}
 

--- a/apps/gauzy/src/app/share/organization/organization.component.ts
+++ b/apps/gauzy/src/app/share/organization/organization.component.ts
@@ -6,10 +6,13 @@ import { OrganizationsService } from '../../@core/services/organizations.service
 import { EmployeesService } from '../../@core/services';
 import { TranslateService } from '@ngx-translate/core';
 import {
+	IGetTimeLogInput,
 	Organization,
 	OrganizationAwards,
 	OrganizationLanguages,
-	PermissionsEnum
+	PermissionsEnum,
+	TimeLogFilters,
+	Timesheet
 } from '@gauzy/models';
 import { NbDialogService, NbToastrService } from '@nebular/theme';
 import { Subject } from 'rxjs';
@@ -22,6 +25,8 @@ import { IncomeService } from '../../@core/services/income.service';
 import { OrganizationClientsService } from '../../@core/services/organization-clients.service ';
 import { EmployeeStatisticsService } from '../../@core/services/employee-statistics.service';
 import { OrganizationProjectsService } from '../../@core/services/organization-projects.service';
+import { TimesheetService } from '../../@shared/timesheet/timesheet.service';
+import { toUTC } from '../../../../../../libs/utils';
 
 @Component({
 	selector: 'ngx-organization',
@@ -51,6 +56,7 @@ export class OrganizationComponent extends TranslationBaseComponent
 	awardExist: boolean;
 	imageUpdateButton: boolean = false;
 	moment = moment;
+	timeSheets: Timesheet[];
 
 	constructor(
 		private route: ActivatedRoute,
@@ -64,6 +70,7 @@ export class OrganizationComponent extends TranslationBaseComponent
 		private organizationClientsService: OrganizationClientsService,
 		private employeeStatisticsService: EmployeeStatisticsService,
 		private organizationProjectsService: OrganizationProjectsService,
+		private timesheetService: TimesheetService,
 		private store: Store,
 		private dialogService: NbDialogService,
 		readonly translateService: TranslateService
@@ -105,6 +112,9 @@ export class OrganizationComponent extends TranslationBaseComponent
 					}
 					if (!!this.organization.show_projects_count) {
 						await this.getProjectCount();
+					}
+					if (!!this.organization.show_total_hours) {
+						await this.getTimeSheets();
 					}
 					await this.getEmployees();
 				} catch (error) {
@@ -191,6 +201,17 @@ export class OrganizationComponent extends TranslationBaseComponent
 		this.employee_bonuses = employeeBonuses.items.filter(
 			(item) => !!item.employee.anonymousBonus
 		);
+	}
+
+	private async getTimeSheets() {
+		const request: IGetTimeLogInput = {
+			organizationId: this.organization.id
+		};
+		this.loading = true;
+		this.timeSheets = await this.timesheetService
+			.getTimeSheets(request)
+			.then((logs) => logs)
+			.finally(() => (this.loading = false));
 	}
 
 	private async getEmployeeStatistics() {

--- a/apps/gauzy/src/app/share/organization/organization.component.ts
+++ b/apps/gauzy/src/app/share/organization/organization.component.ts
@@ -39,6 +39,7 @@ export class OrganizationComponent extends TranslationBaseComponent
 	bonuses_paid = 0;
 	total_clients = 0;
 	total_income = 0;
+	profits = 0;
 	imageUrl: string;
 	hoverState: boolean;
 	languageExist: boolean;
@@ -170,6 +171,9 @@ export class OrganizationComponent extends TranslationBaseComponent
 		}
 		if (!!this.organization.show_income) {
 			this.total_income = statistics.total.income;
+		}
+		if (!!this.organization.show_profits) {
+			this.total_income = statistics.total.profit;
 		}
 	}
 

--- a/apps/gauzy/src/app/share/organization/organization.module.ts
+++ b/apps/gauzy/src/app/share/organization/organization.module.ts
@@ -6,7 +6,8 @@ import {
 	NbInputModule,
 	NbIconModule,
 	NbDialogModule,
-	NbListModule
+	NbListModule,
+	NbUserModule
 } from '@nebular/theme';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { OrganizationComponent } from './organization.component';
@@ -42,7 +43,8 @@ export function HttpLoaderFactory(http: HttpClient) {
 				deps: [HttpClient]
 			}
 		}),
-		NbListModule
+		NbListModule,
+		NbUserModule
 	],
 	declarations: [OrganizationComponent],
 	entryComponents: [],

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -930,7 +930,8 @@
 		"YEAR_FOUNDED": "Year Founded",
 		"COMPANY_SIZE": "Company Size",
 		"CLIENT_FOCUS": "Client Focus",
-		"MONTHLY_INCOME": "Monthly Income"
+		"MONTHLY_INCOME": "Monthly Income",
+		"PROFITS": "Profits"
 	},
 	"PROPOSALS_PAGE": {
 		"HEADER": "Proposals Management Page",

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -931,6 +931,7 @@
 		"COMPANY_SIZE": "Company Size",
 		"CLIENT_FOCUS": "Client Focus",
 		"MONTHLY_INCOME": "Monthly Income",
+		"TOTAL_INCOME": "Total Income",
 		"TOTAL_PROJECTS": "Total Projects",
 		"MINIMUM_PROJECT_SIZE": "Minimum Project Size",
 		"EMPLOYEES": "Employees",

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -929,7 +929,8 @@
 		"TOTAL_CLIENTS": "Total Clients",
 		"YEAR_FOUNDED": "Year Founded",
 		"COMPANY_SIZE": "Company Size",
-		"CLIENT_FOCUS": "Client Focus"
+		"CLIENT_FOCUS": "Client Focus",
+		"TOTAL_INCOME": "Total Income"
 	},
 	"PROPOSALS_PAGE": {
 		"HEADER": "Proposals Management Page",

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -933,6 +933,7 @@
 		"MONTHLY_INCOME": "Monthly Income",
 		"TOTAL_PROJECTS": "Total Projects",
 		"MINIMUM_PROJECT_SIZE": "Minimum Project Size",
+		"EMPLOYEES": "Employees",
 		"PROFITS": "Profits"
 	},
 	"PROPOSALS_PAGE": {

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -930,7 +930,7 @@
 		"YEAR_FOUNDED": "Year Founded",
 		"COMPANY_SIZE": "Company Size",
 		"CLIENT_FOCUS": "Client Focus",
-		"TOTAL_INCOME": "Total Income"
+		"MONTHLY_INCOME": "Monthly Income"
 	},
 	"PROPOSALS_PAGE": {
 		"HEADER": "Proposals Management Page",

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -931,6 +931,8 @@
 		"COMPANY_SIZE": "Company Size",
 		"CLIENT_FOCUS": "Client Focus",
 		"MONTHLY_INCOME": "Monthly Income",
+		"TOTAL_PROJECTS": "Total Projects",
+		"MINIMUM_PROJECT_SIZE": "Minimum Project Size",
 		"PROFITS": "Profits"
 	},
 	"PROPOSALS_PAGE": {

--- a/apps/gauzy/src/environments/environment.ts
+++ b/apps/gauzy/src/environments/environment.ts
@@ -6,39 +6,45 @@
 
 import { Environment } from './model';
 import { CloudinaryConfiguration } from '@cloudinary/angular-5.x';
-
+import { ElectronService } from 'ngx-electron';
+let API_BASE_URL = '';
+try {
+	const el: ElectronService = new ElectronService();
+	let variableGlobal = el.remote.getGlobal('variableGlobal');
+	API_BASE_URL = variableGlobal.API_BASE_URL;
+} catch (e) {}
 export const environment: Environment = {
-  production: false,
+	production: false,
 
-  API_BASE_URL: 'http://localhost:3000',
-  COMPANY_NAME: 'Ever Co. LTD',
-  COMPANY_SITE: 'Gauzy',
-  COMPANY_LINK: 'https://ever.co/',
-  COMPANY_SITE_LINK: 'https://gauzy.co',
-  COMPANY_GITHUB_LINK: 'https://github.com/ever-co',
-  COMPANY_FACEBOOK_LINK: 'https://www.facebook.com/gauzyplatform',
-  COMPANY_TWITTER_LINK: 'https://twitter.com/gauzyplatform',
-  COMPANY_LINKEDIN_LINK: 'https://www.linkedin.com/company/ever-co.',
-  CLOUDINARY_CLOUD_NAME: 'dv6ezkfxg',
-  CLOUDINARY_API_KEY: '256868982483961',
-  GOOGLE_AUTH_LINK: 'http://localhost:3000/api/auth/google',
-  FACEBOOK_AUTH_LINK: 'http://localhost:3000/api/auth/facebook',
-  LINKEDIN_AUTH_LINK: '#',
-  NO_INTERNET_LOGO: 'assets/images/logos/logo_Gauzy.svg',
-  SENTRY_DNS: 'https://19293d39eaa14d03aac4d3c156c4d30e@sentry.io/4397292',
-  HUBSTAFF_REDIRECT_URI: 'http://localhost:4200/pages/integrations/hubstaff'
+	API_BASE_URL: API_BASE_URL ? API_BASE_URL : 'http://localhost:3000',
+	COMPANY_NAME: 'Ever Co. LTD',
+	COMPANY_SITE: 'Gauzy',
+	COMPANY_LINK: 'https://ever.co/',
+	COMPANY_SITE_LINK: 'https://gauzy.co',
+	COMPANY_GITHUB_LINK: 'https://github.com/ever-co',
+	COMPANY_FACEBOOK_LINK: 'https://www.facebook.com/gauzyplatform',
+	COMPANY_TWITTER_LINK: 'https://twitter.com/gauzyplatform',
+	COMPANY_LINKEDIN_LINK: 'https://www.linkedin.com/company/ever-co.',
+	CLOUDINARY_CLOUD_NAME: 'dv6ezkfxg',
+	CLOUDINARY_API_KEY: '256868982483961',
+	GOOGLE_AUTH_LINK: 'http://localhost:3000/api/auth/google',
+	FACEBOOK_AUTH_LINK: 'http://localhost:3000/api/auth/facebook',
+	LINKEDIN_AUTH_LINK: '#',
+	NO_INTERNET_LOGO: 'assets/images/logos/logo_Gauzy.svg',
+	SENTRY_DNS: 'https://19293d39eaa14d03aac4d3c156c4d30e@sentry.io/4397292',
+	HUBSTAFF_REDIRECT_URI: 'http://localhost:4200/pages/integrations/hubstaff'
 };
 
 export const cloudinaryConfiguration: CloudinaryConfiguration = {
-  cloud_name: environment.CLOUDINARY_CLOUD_NAME,
-  api_key: environment.CLOUDINARY_API_KEY
+	cloud_name: environment.CLOUDINARY_CLOUD_NAME,
+	api_key: environment.CLOUDINARY_API_KEY
 };
 
 /*
-* For easier debugging in development mode, you can import the following file
-* to ignore zone related error stack frames such as 'zone.run', 'zoneDelegate.invokeTask'.
-*
-* This import should be commented out in production mode because it will have a negative impact
-* on performance if an error is thrown.
-*/
+ * For easier debugging in development mode, you can import the following file
+ * to ignore zone related error stack frames such as 'zone.run', 'zoneDelegate.invokeTask'.
+ *
+ * This import should be commented out in production mode because it will have a negative impact
+ * on performance if an error is thrown.
+ */
 // import 'zone.js/dist/zone-error';  // Included with Angular CLI.

--- a/libs/models/src/lib/income.model.ts
+++ b/libs/models/src/lib/income.model.ts
@@ -48,6 +48,7 @@ export interface IncomeFindInput extends IBaseEntityModel {
 	employee?: EmployeeFindInput;
 	organization?: OrganizationFindInput;
 	amount?: number;
+	isBonus?: boolean;
 	clientId?: string;
 	clientName?: string;
 	valueDate?: Date;

--- a/libs/models/src/lib/timesheet.model.ts
+++ b/libs/models/src/lib/timesheet.model.ts
@@ -1,5 +1,5 @@
 import { BaseEntityModel as IBaseEntityModel } from './base-entity.model';
-import { Tag, Task, Employee } from '..';
+import { Tag, Task, Employee, EmployeeFindInput } from '..';
 import { OrganizationClients } from './organization-clients.model';
 import { OrganizationProjects } from './organization-projects.model';
 
@@ -33,6 +33,18 @@ export interface ITimesheetCreateInput {
 	lockedAt?: Date;
 	isBilled?: boolean;
 	status?: string;
+}
+
+export interface TimeSheetFindInput {
+	employeeId: string;
+	approvedById?: string;
+	employee: EmployeeFindInput;
+	isBilled?: boolean;
+	status?: string;
+	startedAt: Date;
+	stoppedAt?: Date;
+	approvedAt?: Date;
+	submittedAt?: Date;
 }
 
 export enum TimesheetStatus {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3246,7 +3246,7 @@
   resolved "https://registry.yarnpkg.com/@nstudio/electron/-/electron-9.0.3.tgz#ff9bfb8147170b50b8fc4efb8a5b2d9d26810456"
   integrity sha512-j2P8N+A1l+s9MNWe6KJl1WT3OUovnmUQVNiMQe6yrd8v8aX7qH05O1sul1PRTLNe4+hkf/yeRmQu0Ttoohjprw==
 
-"@nstudio/web-angular@^9.0.3":
+"@nstudio/web-angular@9.0.3":
   version "9.0.3"
   resolved "https://registry.yarnpkg.com/@nstudio/web-angular/-/web-angular-9.0.3.tgz#fcdc0ffc33feceecd576cb7e5ae353706bd74837"
   integrity sha512-WeCSGxFXeoAoE1cAZl/Y9Ke20wxZkweeS32T95/JxE3nR40RtfsYdw6jLOGc5bOWXoIyFmx+bhz5LT1NQqJCDA==
@@ -6246,6 +6246,11 @@ base64-arraybuffer@0.1.5:
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz#73926771923b5a19747ad666aa5cd4bf9c6e9ce8"
   integrity sha1-c5JncZI7Whl0etZmqlzUv5xunOg=
 
+base64-arraybuffer@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz#4b944fac0191aa5907afe2d8c999ccc57ce80f45"
+  integrity sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==
+
 base64-js@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-0.0.8.tgz#1101e9544f4a76b1bc3b26d452ca96d7a35e7978"
@@ -8843,6 +8848,13 @@ css-declaration-sorter@^4.0.1:
     postcss "^7.0.1"
     timsort "^0.3.0"
 
+css-line-break@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/css-line-break/-/css-line-break-1.1.1.tgz#d5e9bdd297840099eb0503c7310fd34927a026ef"
+  integrity sha512-1feNVaM4Fyzdj4mKPIQNL2n70MmuYzAXZ1aytlROFX1JsOo070OsugwGjj7nl6jnDJWHDM8zRZswkmeYVWZJQA==
+  dependencies:
+    base64-arraybuffer "^0.2.0"
+
 css-loader@3.4.2:
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-3.4.2.tgz#d3fdb3358b43f233b78501c5ed7b1c6da6133202"
@@ -10470,10 +10482,10 @@ electron-reload@~1.5.0:
   dependencies:
     chokidar "^3.0.2"
 
-electron-store@~5.1.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/electron-store/-/electron-store-5.1.1.tgz#3040e5b4ad25d2e4caea59d505646c1e7c94a09b"
-  integrity sha512-FLidOVE8JVCdJXHd7xY/JojKJ2r2WNmWt0O/LlX2LuSVV7dkG2RSy2/Gm2LFw8OKDfrNBd9c/s4X1ikMrJEUKg==
+electron-store@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/electron-store/-/electron-store-5.2.0.tgz#a15718fc1fa21acfd07af55f9b94f9fa6a536665"
+  integrity sha512-iU3WDqEDAYNYR9XV7p0tJajq/zs9z7Nrn0sAoR5nDyn8h/9dr9kusKbTxD8NtVEBD1TB1pkGMqcbIt/y6knDwQ==
   dependencies:
     conf "^6.2.1"
     type-fest "^0.7.1"
@@ -13158,6 +13170,13 @@ html-to-text@5.1.1, html-to-text@^5.1.1:
     htmlparser2 "^3.10.1"
     lodash "^4.17.11"
     minimist "^1.2.0"
+
+html2canvas@^1.0.0-rc.5:
+  version "1.0.0-rc.5"
+  resolved "https://registry.yarnpkg.com/html2canvas/-/html2canvas-1.0.0-rc.5.tgz#4ee3cac9f6e20a0fa0c2f35a6f99c960ae7ec4c1"
+  integrity sha512-DtNqPxJNXPoTajs+lVQzGS1SULRI4GQaROeU5R41xH8acffHukxRh/NBVcTBsfCkJSkLq91rih5TpbEwUP9yWA==
+  dependencies:
+    css-line-break "1.1.1"
 
 htmlparser2@^3.10.0, htmlparser2@^3.10.1, htmlparser2@^3.9.1, htmlparser2@^3.9.2:
   version "3.10.1"
@@ -18101,6 +18120,13 @@ ngx-echarts@^4.2.1:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/ngx-echarts/-/ngx-echarts-4.2.2.tgz#9eb5f69f923084869ea014f117915cd6cc366343"
   integrity sha512-iLxOFnfKhUYP8Qw22AUY2ugSEd1Uvt6AeYhiaSqpg/G6NDmM/NwpdLt+fGAjax2aY7e94ORuwhXnl2gxtNzt7Q==
+  dependencies:
+    tslib "^1.9.0"
+
+ngx-electron@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ngx-electron/-/ngx-electron-2.2.0.tgz#8ab65427476153b499d26f332fa5ca88714d8477"
+  integrity sha512-Yl7Dsnvp97k0XpIuiB54X7Ij2+zU5x0pCAYnN//VZ9tF7c6S3//OZ9dN9Et7p/zIjCV3Hg9vyw68dPJEZGk+LQ==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
#515 Gauzy Companies public pages - update
 
Added following things recently.
- Total Projects, Income, Profits
- Minimum project size
- Employee listing
- Some Design Changes

Also there are 2 things remaining for the public page as mentioned #515,
- Bonus per Employee (I have data, but would you please let me know how can I show there the bonuses for the particular employee - any hints would be great in that case)
- Total Hours worked (for the hours count I see we have existing data at `timesheet` table, would you like to count hours from `startedAt` to `stoppedAt` field?)

The following are the current screenshot and video screencast for the latest changes,

![public_page_preview_21_06](https://user-images.githubusercontent.com/3712162/85218029-25567980-b3b8-11ea-8eb4-5841c289312a.png)

the video screencast for the current look,
https://nimb.ws/l5apoF
