### PR TITLE
feat: added estimate conversion and payment methods

### DIFF
--- a/apps/api/src/app/payment/payment.entity.ts
+++ b/apps/api/src/app/payment/payment.entity.ts
@@ -8,7 +8,11 @@ import {
 	ManyToMany
 } from 'typeorm';
 import { Base } from '../core/entities/base';
-import { Payment as IPayment, CurrenciesEnum } from '@gauzy/models';
+import {
+	Payment as IPayment,
+	CurrenciesEnum,
+	PaymentMethodEnum
+} from '@gauzy/models';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
 	IsEnum,
@@ -89,6 +93,11 @@ export class Payment extends Base implements IPayment {
 	@IsEnum(CurrenciesEnum)
 	@Column()
 	currency?: string;
+
+	@ApiPropertyOptional({ type: String, enum: PaymentMethodEnum })
+	@IsEnum(PaymentMethodEnum)
+	@Column()
+	paymentMethod?: string;
 
 	@ApiPropertyOptional({ type: Boolean })
 	@IsBoolean()

--- a/apps/gauzy/src/app/pages/invoices/invoice-add/invoice-add.component.ts
+++ b/apps/gauzy/src/app/pages/invoices/invoice-add/invoice-add.component.ts
@@ -117,12 +117,12 @@ export class InvoiceAddComponent extends TranslationBaseComponent
 	initializeForm() {
 		this.createInvoiceNumber();
 		this.form = this.fb.group({
-			invoiceDate: ['', Validators.required],
+			invoiceDate: [new Date(), Validators.required],
 			invoiceNumber: [
 				this.formInvoiceNumber,
 				Validators.compose([Validators.required, Validators.min(1)])
 			],
-			dueDate: ['', Validators.required],
+			dueDate: [this.getNextMonth(), Validators.required],
 			currency: ['', Validators.required],
 			discountValue: [
 				0,
@@ -316,7 +316,7 @@ export class InvoiceAddComponent extends TranslationBaseComponent
 		};
 		if (this.organization.separateInvoiceItemTaxAndDiscount) {
 			this.settingsSmartTable['columns']['applyTax'] = {
-				title: 'Apply tax',
+				title: this.getTranslation('INVOICES_PAGE.APPLY_TAX'),
 				editor: {
 					type: 'custom',
 					component: InvoiceApplyTaxDiscountComponent
@@ -325,14 +325,14 @@ export class InvoiceAddComponent extends TranslationBaseComponent
 				width: '10%',
 				valuePrepareFunction: (cell) => {
 					if (cell) {
-						return 'Applied';
+						return this.getTranslation('INVOICES_PAGE.APPLIED');
 					} else {
-						return ' Not applied';
+						return this.getTranslation('INVOICES_PAGE.NOT_APPLIED');
 					}
 				}
 			};
 			this.settingsSmartTable['columns']['applyDiscount'] = {
-				title: 'Apply discount',
+				title: this.getTranslation('INVOICES_PAGE.APPLY_DISCOUNT'),
 				editor: {
 					type: 'custom',
 					component: InvoiceApplyTaxDiscountComponent
@@ -341,9 +341,9 @@ export class InvoiceAddComponent extends TranslationBaseComponent
 				width: '10%',
 				valuePrepareFunction: (cell) => {
 					if (cell) {
-						return 'Applied';
+						return this.getTranslation('INVOICES_PAGE.APPLIED');
 					} else {
-						return ' Not applied';
+						return this.getTranslation('INVOICES_PAGE.NOT_APPLIED');
 					}
 				}
 			};
@@ -867,6 +867,16 @@ export class InvoiceAddComponent extends TranslationBaseComponent
 	}
 	selectedTagsEvent(currentTagSelection: Tag[]) {
 		this.tags = currentTagSelection;
+	}
+
+	getNextMonth() {
+		const date = new Date();
+		const d = date.getDate();
+		date.setMonth(date.getMonth() + 1);
+		if (date.getDate() !== d) {
+			date.setDate(0);
+		}
+		return date;
 	}
 
 	ngOnDestroy() {

--- a/apps/gauzy/src/app/pages/invoices/invoice-edit/invoice-edit.component.html
+++ b/apps/gauzy/src/app/pages/invoices/invoice-edit/invoice-edit.component.html
@@ -260,10 +260,14 @@
 			<div class="row">
 				<div class="col-sm-3">
 					<div class="form-group">
-						<label for="inputTax" class="label">Tax 2</label>
+						<label for="inputTax" class="label"
+							>{{ 'INVOICES_PAGE.TAX_2' | translate }}
+						</label>
 						<input
 							nbInput
-							placeholder="Tax 2"
+							placeholder="{{
+								'INVOICES_PAGE.TAX_2' | translate
+							}}"
 							type="number"
 							formControlName="tax2"
 							id="inputTax"

--- a/apps/gauzy/src/app/pages/invoices/invoice-edit/invoice-edit.component.ts
+++ b/apps/gauzy/src/app/pages/invoices/invoice-edit/invoice-edit.component.ts
@@ -360,7 +360,7 @@ export class InvoiceEditComponent extends TranslationBaseComponent
 		};
 		if (this.organization.separateInvoiceItemTaxAndDiscount) {
 			this.settingsSmartTable['columns']['applyTax'] = {
-				title: 'Apply tax',
+				title: this.getTranslation('INVOICES_PAGE.APPLY_TAX'),
 				editor: {
 					type: 'custom',
 					component: InvoiceApplyTaxDiscountComponent
@@ -369,14 +369,14 @@ export class InvoiceEditComponent extends TranslationBaseComponent
 				width: '10%',
 				valuePrepareFunction: (cell) => {
 					if (cell) {
-						return 'Applied';
+						return this.getTranslation('INVOICES_PAGE.APPLIED');
 					} else {
-						return ' Not applied';
+						return this.getTranslation('INVOICES_PAGE.NOT_APPLIED');
 					}
 				}
 			};
 			this.settingsSmartTable['columns']['applyDiscount'] = {
-				title: 'Apply discount',
+				title: this.getTranslation('INVOICES_PAGE.APPLY_DISCOUNT'),
 				editor: {
 					type: 'custom',
 					component: InvoiceApplyTaxDiscountComponent
@@ -385,9 +385,9 @@ export class InvoiceEditComponent extends TranslationBaseComponent
 				width: '10%',
 				valuePrepareFunction: (cell) => {
 					if (cell) {
-						return 'Applied';
+						return this.getTranslation('INVOICES_PAGE.APPLIED');
 					} else {
-						return ' Not applied';
+						return this.getTranslation('INVOICES_PAGE.NOT_APPLIED');
 					}
 				}
 			};

--- a/apps/gauzy/src/app/pages/invoices/invoice-payments/payment-mutation/payment-mutation.component.html
+++ b/apps/gauzy/src/app/pages/invoices/invoice-payments/payment-mutation/payment-mutation.component.html
@@ -34,6 +34,31 @@
 						<nb-datepicker #paymentDatePicker></nb-datepicker>
 					</div>
 				</div>
+				<div class="col-sm-6">
+					<div class="form-group">
+						<label for="inputPaymentDate" class="label">
+							{{
+								'INVOICES_PAGE.PAYMENTS.PAYMENT_METHOD'
+									| translate
+							}}
+						</label>
+						<nb-select
+							class="d-block"
+							formControlName="paymentMethod"
+							placeholder="{{
+								'INVOICES_PAGE.PAYMENTS.PAYMENT_METHOD'
+									| translate
+							}}"
+							fullWidth
+						>
+							<nb-option
+								*ngFor="let paymentMethod of paymentMethods"
+								value="{{ paymentMethod }}"
+								>{{ paymentMethod }}</nb-option
+							>
+						</nb-select>
+					</div>
+				</div>
 			</div>
 			<div class="row">
 				<div class="col-sm-6">

--- a/apps/gauzy/src/app/pages/invoices/invoice-payments/payment-mutation/payment-mutation.component.ts
+++ b/apps/gauzy/src/app/pages/invoices/invoice-payments/payment-mutation/payment-mutation.component.ts
@@ -1,7 +1,12 @@
 import { Component, OnInit } from '@angular/core';
 import { TranslationBaseComponent } from '../../../../@shared/language-base/translation-base.component';
 import { TranslateService } from '@ngx-translate/core';
-import { Invoice, CurrenciesEnum, Payment } from '@gauzy/models';
+import {
+	Invoice,
+	CurrenciesEnum,
+	Payment,
+	PaymentMethodEnum
+} from '@gauzy/models';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { NbDialogRef, NbToastrService } from '@nebular/theme';
 import { PaymentService } from '../../../../@core/services/payment.service';
@@ -29,6 +34,7 @@ export class PaymentMutationComponent extends TranslationBaseComponent
 	payment: Payment;
 	form: FormGroup;
 	currencies = Object.values(CurrenciesEnum);
+	paymentMethods = Object.values(PaymentMethodEnum);
 	get currency() {
 		return this.form.get('currency');
 	}
@@ -38,7 +44,6 @@ export class PaymentMutationComponent extends TranslationBaseComponent
 		if (this.currency && !this.currency.value) {
 			this.currency.setValue(this.invoice.currency);
 		}
-		this.form.get('currency').disable();
 	}
 
 	initializeForm() {
@@ -53,7 +58,8 @@ export class PaymentMutationComponent extends TranslationBaseComponent
 					new Date(this.payment.paymentDate),
 					Validators.required
 				],
-				note: [this.payment.note, Validators.required]
+				note: [this.payment.note, Validators.required],
+				paymentMethod: [this.payment.paymentMethod, Validators.required]
 			});
 		} else {
 			this.form = this.fb.group({
@@ -63,7 +69,8 @@ export class PaymentMutationComponent extends TranslationBaseComponent
 				],
 				currency: ['', Validators.required],
 				paymentDate: ['', Validators.required],
-				note: ['', Validators.required]
+				note: ['', Validators.required],
+				paymentMethod: ['', Validators.required]
 			});
 		}
 	}
@@ -86,7 +93,8 @@ export class PaymentMutationComponent extends TranslationBaseComponent
 			organizationId: this.invoice.organizationId,
 			recordedBy: this.store.user,
 			userId: this.store.userId,
-			overdue: overdue
+			overdue: overdue,
+			paymentMethod: paymentData.paymentMethod
 		});
 
 		this.toastrService.primary(

--- a/apps/gauzy/src/app/pages/invoices/invoice-payments/payments.component.ts
+++ b/apps/gauzy/src/app/pages/invoices/invoice-payments/payments.component.ts
@@ -14,6 +14,7 @@ import { InvoicePaymentOverdueComponent } from '../table-components/invoice-paym
 import * as pdfMake from 'pdfmake/build/pdfmake';
 import * as pdfFonts from 'pdfmake/build/vfs_fonts';
 import { generatePdf } from '../../../@shared/payment/generate-pdf';
+import { MethodCall } from '@angular/compiler';
 
 export interface SelectedPayment {
 	data: Payment;
@@ -222,6 +223,12 @@ export class InvoicePaymentsComponent extends TranslationBaseComponent
 				},
 				note: {
 					title: this.getTranslation('INVOICES_PAGE.PAYMENTS.NOTE'),
+					type: 'text'
+				},
+				paymentMethod: {
+					title: this.getTranslation(
+						'INVOICES_PAGE.PAYMENTS.PAYMENT_METHOD'
+					),
 					type: 'text'
 				},
 				overdue: {

--- a/apps/gauzy/src/app/pages/invoices/invoice-payments/payments.component.ts
+++ b/apps/gauzy/src/app/pages/invoices/invoice-payments/payments.component.ts
@@ -14,7 +14,6 @@ import { InvoicePaymentOverdueComponent } from '../table-components/invoice-paym
 import * as pdfMake from 'pdfmake/build/pdfmake';
 import * as pdfFonts from 'pdfmake/build/vfs_fonts';
 import { generatePdf } from '../../../@shared/payment/generate-pdf';
-import { MethodCall } from '@angular/compiler';
 
 export interface SelectedPayment {
 	data: Payment;

--- a/apps/gauzy/src/app/pages/invoices/invoices.component.html
+++ b/apps/gauzy/src/app/pages/invoices/invoices.component.html
@@ -64,6 +64,17 @@
 				{{ 'BUTTONS.EMAIL' | translate }}
 			</button>
 			<button
+				*ngIf="isEstimate"
+				nbButton
+				status="info"
+				(click)="convert()"
+				class="mr-2"
+				[disabled]="disableButton"
+			>
+				<nb-icon class="mr-1" icon="swap"> </nb-icon>
+				{{ 'BUTTONS.CONVERT_TO_INVOICE' | translate }}
+			</button>
+			<button
 				nbButton
 				status="danger"
 				(click)="delete()"

--- a/apps/gauzy/src/app/pages/invoices/invoices.component.ts
+++ b/apps/gauzy/src/app/pages/invoices/invoices.component.ts
@@ -201,6 +201,17 @@ export class InvoicesComponent extends TranslationBaseComponent
 		}
 	}
 
+	async convert() {
+		await this.invoicesService.update(this.selectedInvoice.id, {
+			isEstimate: false
+		});
+		this.toastrService.primary(
+			this.getTranslation('INVOICES_PAGE.ESTIMATES.ESTIMATE_CONVERT'),
+			this.getTranslation('TOASTR.TITLE.SUCCESS')
+		);
+		await this.loadSettings();
+	}
+
 	async delete() {
 		const result = await this.dialogService
 			.open(DeleteConfirmationComponent)

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -48,7 +48,8 @@
 		"MAKE_PUBLIC": "make public",
 		"KNOWLEDGE_BASES": "Knowledge bases",
 		"SELECT": "Select",
-		"EMAIL": "Email"
+		"EMAIL": "Email",
+		"CONVERT_TO_INVOICE": "Convert to invoice"
 	},
 	"SM_TABLE": {
 		"DATE": "Date",
@@ -1397,6 +1398,7 @@
 		"ESTIMATE_DATE": "Estimate Date",
 		"TOTAL_VALUE": "Total Value",
 		"PAID_STATUS": "Paid Status",
+		"TAX_2": "Tax 2",
 		"INVOICES_ADD_INVOICE": "Invoice Added",
 		"INVOICES_ADD_ESTIMATE": "Estimated Added",
 		"INVOICES_EDIT_INVOICE": "Invoice Edited",
@@ -1439,6 +1441,10 @@
 		"RECEIVED_ESTIMATES": "Received Estimates",
 		"SEND_INVOICE": "Invoice Sent",
 		"SEND_ESTIMATE": "Estimate Sent",
+		"APPLY_TAX": "Apply Tax",
+		"APPLY_DISCOUNT": "Apply Discount",
+		"APPLIED": "Applied",
+		"NOT_APPLIED": "Not Applied",
 		"INVOICE_TYPE": {
 			"INVOICE_TYPE": "Invoice Type",
 			"ESTIMATE_TYPE": "Estimate Type",
@@ -1507,7 +1513,8 @@
 			"REJECT": "Reject",
 			"ACCEPTED": "Accepted",
 			"REJECTED": "Rejected",
-			"ACCEPTED_STATUS": "Accepted Status"
+			"ACCEPTED_STATUS": "Accepted Status",
+			"ESTIMATE_CONVERT": "Estimate Converted"
 		},
 		"PAYMENTS": {
 			"HEADER": "Payments for Invoice",
@@ -1528,7 +1535,8 @@
 			"ON_TIME": "On time",
 			"OVERDUE": "Overdue",
 			"NO_PAYMENTS_RECORDED": "No payments recorded",
-			"LEFT_TO_PAY": "Left to pay"
+			"LEFT_TO_PAY": "Left to pay",
+			"PAYMENT_METHOD": "Payment Method"
 		}
 	},
 	"PAYMENTS_PAGE": {

--- a/libs/models/src/lib/invoice.model.ts
+++ b/libs/models/src/lib/invoice.model.ts
@@ -54,6 +54,7 @@ export interface InvoiceUpdateInput {
 	tags?: Tag[];
 	sentStatus?: boolean;
 	isAccepted?: boolean;
+	isEstimate?: boolean;
 }
 
 export interface InvoiceFindInput {

--- a/libs/models/src/lib/payment.model.ts
+++ b/libs/models/src/lib/payment.model.ts
@@ -19,6 +19,7 @@ export interface Payment extends IBaseEntityModel {
 	amount?: number;
 	currency?: string;
 	overdue?: boolean;
+	paymentMethod?: string;
 }
 
 export interface PaymentUpdateInput {
@@ -31,4 +32,13 @@ export interface PaymentUpdateInput {
 export interface PaymentFindInput {
 	invoiceId?: string;
 	organizationId?: string;
+}
+
+export enum PaymentMethodEnum {
+	BANK_TRANSFER = 'Bank transfer',
+	CASH = 'Cash',
+	CHEQUE = 'Cheque',
+	CREDIT_CARD = 'Credit card',
+	DEBIT = 'Debit',
+	ONLINE = 'Online'
 }


### PR DESCRIPTION
Added "Convert to invoice" button to the estimates page that converts the selected estimate to an invoice.
Added a dropdown to the payment add/edit form for payment methods.
When adding an invoice/estimate the invoice/estimate date is now set to today's date by default and the due date is set to 1 month after the invoice/estimate date.
Added translations.

Video: https://www.loom.com/share/3b950847e6744ba6a0c9e2b498d78f3c
