### PR TITLE
feat(appointment_scheduling): added public appointment edit page

### DIFF
--- a/apps/api/src/app/employee-appointment/commands/handlers/employee-appointment.update.handler.ts
+++ b/apps/api/src/app/employee-appointment/commands/handlers/employee-appointment.update.handler.ts
@@ -26,28 +26,44 @@ export class EmployeeAppointmentUpdateHandler
 					employeeAppointmentUpdateRequest.employeeId
 			  )
 			: null;
-		const organization = await this.organizationService.findOne(
-			employeeAppointmentUpdateRequest.organizationId
-		);
+		const organization = employeeAppointmentUpdateRequest.organizationId
+			? await this.organizationService.findOne(
+					employeeAppointmentUpdateRequest.organizationId
+			  )
+			: null;
 
-		appointment.employee = employee;
-		appointment.organization = organization;
-		appointment.agenda = employeeAppointmentUpdateRequest.agenda;
-		appointment.description = employeeAppointmentUpdateRequest.description;
-		appointment.bufferTimeEnd =
-			employeeAppointmentUpdateRequest.bufferTimeEnd;
-		appointment.bufferTimeInMins =
-			employeeAppointmentUpdateRequest.bufferTimeInMins;
-		appointment.breakStartTime =
-			employeeAppointmentUpdateRequest.breakStartTime;
-		appointment.breakTimeInMins =
-			employeeAppointmentUpdateRequest.breakTimeInMins;
-		appointment.bufferTimeStart =
-			employeeAppointmentUpdateRequest.bufferTimeStart;
-		appointment.startDateTime =
-			employeeAppointmentUpdateRequest.startDateTime;
-		appointment.endDateTime = employeeAppointmentUpdateRequest.endDateTime;
-		appointment.location = employeeAppointmentUpdateRequest.location;
+		employee && (appointment.employee = employee);
+		organization && (appointment.organization = organization);
+		employeeAppointmentUpdateRequest.agenda &&
+			(appointment.agenda = employeeAppointmentUpdateRequest.agenda);
+		employeeAppointmentUpdateRequest.description &&
+			(appointment.description =
+				employeeAppointmentUpdateRequest.description);
+		employeeAppointmentUpdateRequest.bufferTimeEnd &&
+			(appointment.bufferTimeEnd =
+				employeeAppointmentUpdateRequest.bufferTimeEnd);
+		employeeAppointmentUpdateRequest.bufferTimeInMins &&
+			(appointment.bufferTimeInMins =
+				employeeAppointmentUpdateRequest.bufferTimeInMins);
+		employeeAppointmentUpdateRequest.breakStartTime &&
+			(appointment.breakStartTime =
+				employeeAppointmentUpdateRequest.breakStartTime);
+		employeeAppointmentUpdateRequest.breakTimeInMins &&
+			(appointment.breakTimeInMins =
+				employeeAppointmentUpdateRequest.breakTimeInMins);
+		employeeAppointmentUpdateRequest.bufferTimeStart &&
+			(appointment.bufferTimeStart =
+				employeeAppointmentUpdateRequest.bufferTimeStart);
+		employeeAppointmentUpdateRequest.startDateTime &&
+			(appointment.startDateTime =
+				employeeAppointmentUpdateRequest.startDateTime);
+		employeeAppointmentUpdateRequest.endDateTime &&
+			(appointment.endDateTime =
+				employeeAppointmentUpdateRequest.endDateTime);
+		employeeAppointmentUpdateRequest.location &&
+			(appointment.location = employeeAppointmentUpdateRequest.location);
+		employeeAppointmentUpdateRequest.status &&
+			(appointment.status = employeeAppointmentUpdateRequest.status);
 
 		const updatedAppointment = await this.employeeAppointmentService.update(
 			id,

--- a/apps/api/src/app/employee-appointment/employee-appointment.controller.ts
+++ b/apps/api/src/app/employee-appointment/employee-appointment.controller.ts
@@ -126,4 +126,37 @@ export class EmployeeAppointmentController extends CrudController<
 	): Promise<EmployeeAppointment> {
 		return this.employeeAppointmentService.findOne(id);
 	}
+
+	@ApiOperation({ summary: 'Sign appointment id payload' })
+	@ApiResponse({
+		status: HttpStatus.OK,
+		description: 'Token generated',
+		type: String
+	})
+	@ApiResponse({
+		status: HttpStatus.EXPECTATION_FAILED,
+		description: 'Token generation failure'
+	})
+	@UseGuards(AuthGuard('jwt'))
+	@Get('/sign/:id')
+	async signAppointment(@Param('id') id: string): Promise<String> {
+		return await this.employeeAppointmentService.signAppointmentId(id);
+	}
+
+	@ApiOperation({ summary: 'Verify token' })
+	@ApiResponse({
+		status: HttpStatus.OK,
+		description: 'Token verified',
+		type: String
+	})
+	@ApiResponse({
+		status: HttpStatus.EXPECTATION_FAILED,
+		description: 'Token verification failure'
+	})
+	@UseGuards(AuthGuard('jwt'))
+	@Get('/decode/:token')
+	async decodeToken(@Param('token') token: string): Promise<string> {
+		const decoded = this.employeeAppointmentService.decode(token);
+		return decoded['appointmentId'];
+	}
 }

--- a/apps/api/src/app/employee-appointment/employee-appointment.service.ts
+++ b/apps/api/src/app/employee-appointment/employee-appointment.service.ts
@@ -4,6 +4,8 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, FindManyOptions } from 'typeorm';
 import { Injectable } from '@nestjs/common';
 import { IEmployeeAppointmentCreateInput } from '@gauzy/models';
+import { environment as env } from '@env-api/environment';
+import { sign, decode } from 'jsonwebtoken';
 
 @Injectable()
 export class EmployeeAppointmentService extends CrudService<
@@ -33,5 +35,19 @@ export class EmployeeAppointmentService extends CrudService<
 		return await this.employeeAppointmentRepository.save(
 			employeeAppointmentRequest
 		);
+	}
+
+	async signAppointmentId(id: string) {
+		return await sign(
+			{
+				appointmentId: id
+			},
+			env.JWT_SECRET,
+			{}
+		);
+	}
+
+	decode(token: string) {
+		return decode(token);
 	}
 }

--- a/apps/gauzy/src/app/@core/services/employee-appointment.service.ts
+++ b/apps/gauzy/src/app/@core/services/employee-appointment.service.ts
@@ -28,6 +28,22 @@ export class EmployeeAppointmentService {
 		);
 	}
 
+	decodeToken(token: string): Promise<string> {
+		return this.http
+			.get(this.EMPLOYEE_APPOINTMENT_URL + '/decode/' + token, {
+				responseType: 'text'
+			})
+			.toPromise();
+	}
+
+	signAppointmentId(id: string): Promise<string> {
+		return this.http
+			.get(this.EMPLOYEE_APPOINTMENT_URL + '/sign/' + id, {
+				responseType: 'text'
+			})
+			.toPromise();
+	}
+
 	getById(id: string = ''): Observable<EmployeeAppointment> {
 		return this.http.get<EmployeeAppointment>(
 			this.EMPLOYEE_APPOINTMENT_URL + '/' + id

--- a/apps/gauzy/src/app/@shared/timer-picker/timer-range-picker/timer-range-picker.component.ts
+++ b/apps/gauzy/src/app/@shared/timer-picker/timer-range-picker/timer-range-picker.component.ts
@@ -4,6 +4,7 @@ import {
 	forwardRef,
 	Input,
 	ViewChild,
+	ChangeDetectorRef,
 	AfterViewInit
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR, NgModel } from '@angular/forms';
@@ -82,7 +83,7 @@ export class TimerRangePickerComponent implements OnInit, AfterViewInit {
 	maxSlotEndTime: string;
 	minSlotEndTime: string;
 
-	constructor() {}
+	constructor(private cd: ChangeDetectorRef) {}
 
 	onChange: any = () => {};
 	onTouched: any = () => {};
@@ -142,6 +143,7 @@ export class TimerRangePickerComponent implements OnInit, AfterViewInit {
 					start: isNaN(start.getTime()) ? null : start,
 					end: isNaN(start.getTime()) ? null : end
 				};
+				this.cd.detectChanges();
 			});
 	}
 

--- a/apps/gauzy/src/app/pages/employees/appointment/appointment.component.ts
+++ b/apps/gauzy/src/app/pages/employees/appointment/appointment.component.ts
@@ -139,6 +139,8 @@ export class AppointmentComponent extends TranslationBaseComponent
 
 					if (
 						prevSlot &&
+						nextSlot &&
+						nextSlot.extendedProps['type'] !== 'BookedSlot' &&
 						prevSlot.extendedProps['type'] !== 'BookedSlot'
 					) {
 						config.dateStart = new Date(prevSlot.start.toString());

--- a/apps/gauzy/src/app/pages/employees/appointment/manage-appointment/manage-appointment.component.ts
+++ b/apps/gauzy/src/app/pages/employees/appointment/manage-appointment/manage-appointment.component.ts
@@ -39,14 +39,15 @@ export class ManageAppointmentComponent extends TranslationBaseComponent
 	@Input() employee: Employee;
 	@Input() employeeAppointment: EmployeeAppointment;
 	@Input() disabled: boolean;
+	@Input() appointmentID: string;
 	@Input() allowedDuration: number;
 	@Input() hidePrivateFields: boolean = false;
 
 	@Output() save = new EventEmitter<EmployeeAppointment>();
 	@Output() cancel = new EventEmitter<string>();
 
-	selectedEmployeeIds: string[];
-	selectedEmployeeAppointmentIds: string[];
+	selectedEmployeeIds: string[] = [];
+	selectedEmployeeAppointmentIds: string[] = [];
 	emailAddresses: any[] = [];
 	_selectedOrganizationId: string;
 	emails: any;
@@ -112,7 +113,11 @@ export class ManageAppointmentComponent extends TranslationBaseComponent
 	private _initializeForm() {
 		this.form = this.fb.group({
 			emails: [
-				'',
+				this.employeeAppointment && this.employeeAppointment.emails
+					? this.employeeAppointment.emails
+							.split(', ')
+							.map((o) => ({ emailAddress: o }))
+					: '',
 				Validators.compose([
 					Validators.required,
 					this.EmailListValidator
@@ -182,7 +187,7 @@ export class ManageAppointmentComponent extends TranslationBaseComponent
 		this.route.params
 			.pipe(takeUntil(this._ngDestroy$))
 			.subscribe(async (params) => {
-				const id = params.appointmentId;
+				const id = params.appointmentId || this.appointmentID;
 				if (id) {
 					this.editMode = true;
 					const appointment = await this.employeeAppointmentService
@@ -203,6 +208,12 @@ export class ManageAppointmentComponent extends TranslationBaseComponent
 					);
 					this.start = new Date(appointment.startDateTime);
 					this.end = new Date(appointment.endDateTime);
+					if (!this.selectedRange.start) {
+						this.selectedRange = {
+							start: this.start,
+							end: this.end
+						};
+					}
 					this.employeeAppointment = appointment;
 				}
 				this._initializeForm();
@@ -318,7 +329,7 @@ export class ManageAppointmentComponent extends TranslationBaseComponent
 	}
 
 	onMembersSelected(ev) {
-		this.selectedEmployeeIds = ev;
+		this.selectedEmployeeIds = ev || [];
 	}
 
 	ngOnDestroy() {

--- a/apps/gauzy/src/app/pages/employees/appointment/manage-appointment/manage-appointment.module.ts
+++ b/apps/gauzy/src/app/pages/employees/appointment/manage-appointment/manage-appointment.module.ts
@@ -19,6 +19,7 @@ import { TimerPickerModule } from 'apps/gauzy/src/app/@shared/timer-picker/timer
 import { SharedModule } from 'apps/gauzy/src/app/@shared/shared.module';
 import { EmployeeMultiSelectModule } from 'apps/gauzy/src/app/@shared/employee/employee-multi-select/employee-multi-select.module';
 import { AlertModalModule } from 'apps/gauzy/src/app/@shared/alert-modal/alert-modal.module';
+import { AppointmentEmployeesService } from 'apps/gauzy/src/app/@core/services/appointment-employees.service';
 
 export function HttpLoaderFactory(http: HttpClient) {
 	return new TranslateHttpLoader(http, './assets/i18n/', '.json');
@@ -51,6 +52,6 @@ export function HttpLoaderFactory(http: HttpClient) {
 	],
 	exports: [ManageAppointmentComponent],
 	declarations: [ManageAppointmentComponent],
-	providers: []
+	providers: [AppointmentEmployeesService]
 })
 export class ManageAppointmentModule {}

--- a/apps/gauzy/src/app/share/public-appointments/appointment-form/appointment-form.component.ts
+++ b/apps/gauzy/src/app/share/public-appointments/appointment-form/appointment-form.component.ts
@@ -13,7 +13,7 @@ import { EmployeesService } from '../../../@core/services';
 export class AppointmentFormComponent extends TranslationBaseComponent
 	implements OnInit, OnDestroy {
 	private _ngDestroy$ = new Subject<void>();
-	loading: boolean;
+	loading: boolean = true;
 	selectedRange: { start: Date; end: Date };
 	selectedEventType: IEventType;
 	allowedDuration: Number;
@@ -53,6 +53,8 @@ export class AppointmentFormComponent extends TranslationBaseComponent
 								  'Hour(s)'
 								? this.selectedEventType.duration * 60
 								: this.selectedEventType.duration * 1;
+
+						this.loading = false;
 					} else {
 						history.go(-1);
 					}

--- a/apps/gauzy/src/app/share/public-appointments/confirm-appointment/confirm-appointment.component.html
+++ b/apps/gauzy/src/app/share/public-appointments/confirm-appointment/confirm-appointment.component.html
@@ -62,6 +62,14 @@
 				<span>{{ 'PUBLIC_APPOINTMENTS.EMAIL_SENT' | translate }} </span>
 			</div>
 		</nb-card>
+		<nb-card *ngIf="editLink">
+			<div class="p-3" style="overflow-wrap: break-word;">
+				<strong
+					>{{ 'PUBLIC_APPOINTMENTS.RESCHEDULE' | translate }}:
+				</strong>
+				<a href> {{ editLink }} </a>
+			</div>
+		</nb-card>
 		<nb-card *ngIf="appointment.status">
 			<div class="p-3">
 				<span style="color: red;"

--- a/apps/gauzy/src/app/share/public-appointments/confirm-appointment/confirm-appointment.component.ts
+++ b/apps/gauzy/src/app/share/public-appointments/confirm-appointment/confirm-appointment.component.ts
@@ -21,6 +21,7 @@ export class ConfirmAppointmentComponent extends TranslationBaseComponent
 	appointment: EmployeeAppointment;
 	participants: string;
 	duration: string;
+	editLink: string;
 
 	constructor(
 		private route: ActivatedRoute,
@@ -41,6 +42,10 @@ export class ConfirmAppointmentComponent extends TranslationBaseComponent
 				const employeeId = params.id;
 				if (employeeId && appointmentId) {
 					this.loadAppointment(appointmentId, employeeId);
+					const token = await this.employeeAppointmentService.signAppointmentId(
+						appointmentId
+					);
+					this.editLink = `/share/employee/edit-appointment?token=${token}`;
 					this.loading = false;
 				} else {
 					this.router.navigate(['/share/404']);

--- a/apps/gauzy/src/app/share/public-appointments/edit-appointment/edit-appointment.component.html
+++ b/apps/gauzy/src/app/share/public-appointments/edit-appointment/edit-appointment.component.html
@@ -1,0 +1,8 @@
+<nb-card [nbSpinner]="loading" nbSpinnerStatus="primary" nbSpinnerSize="large">
+	<ga-manage-appointment
+		*ngIf="appointmentID"
+		[hidePrivateFields]="true"
+		[disabled]="true"
+		[appointmentID]="appointmentID"
+	></ga-manage-appointment>
+</nb-card>

--- a/apps/gauzy/src/app/share/public-appointments/edit-appointment/edit-appointment.component.ts
+++ b/apps/gauzy/src/app/share/public-appointments/edit-appointment/edit-appointment.component.ts
@@ -3,7 +3,6 @@ import { TranslationBaseComponent } from '../../../@shared/language-base/transla
 import { Subject } from 'rxjs';
 import { Router, ActivatedRoute } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
-import { IEventType, Employee } from '@gauzy/models';
 import { EmployeeAppointmentService } from '../../../@core/services/employee-appointment.service';
 
 @Component({

--- a/apps/gauzy/src/app/share/public-appointments/edit-appointment/edit-appointment.component.ts
+++ b/apps/gauzy/src/app/share/public-appointments/edit-appointment/edit-appointment.component.ts
@@ -1,0 +1,44 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { TranslationBaseComponent } from '../../../@shared/language-base/translation-base.component';
+import { Subject } from 'rxjs';
+import { Router, ActivatedRoute } from '@angular/router';
+import { TranslateService } from '@ngx-translate/core';
+import { IEventType, Employee } from '@gauzy/models';
+import { EmployeeAppointmentService } from '../../../@core/services/employee-appointment.service';
+
+@Component({
+	templateUrl: './edit-appointment.component.html'
+})
+export class EditAppointmentComponent extends TranslationBaseComponent
+	implements OnInit, OnDestroy {
+	private _ngDestroy$ = new Subject<void>();
+	loading: boolean;
+	appointmentID: string;
+
+	constructor(
+		private route: ActivatedRoute,
+		private router: Router,
+		private employeeAppointmentService: EmployeeAppointmentService,
+		readonly translateService: TranslateService
+	) {
+		super(translateService);
+	}
+
+	ngOnInit(): void {
+		this.route.queryParams.subscribe(async ({ token }) => {
+			try {
+				if (!token) throw new Error('token missing');
+				this.appointmentID = await this.employeeAppointmentService.decodeToken(
+					token
+				);
+			} catch (error) {
+				await this.router.navigate(['/share/404']);
+			}
+		});
+	}
+
+	ngOnDestroy() {
+		this._ngDestroy$.next();
+		this._ngDestroy$.complete();
+	}
+}

--- a/apps/gauzy/src/app/share/public-appointments/edit-appointment/edit-appointment.module.ts
+++ b/apps/gauzy/src/app/share/public-appointments/edit-appointment/edit-appointment.module.ts
@@ -1,0 +1,36 @@
+import { HttpClient } from '@angular/common/http';
+import { NgModule } from '@angular/core';
+import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
+import { TranslateHttpLoader } from '@ngx-translate/http-loader';
+import { ThemeModule } from '../../../@theme/theme.module';
+import { EditAppointmentComponent } from './edit-appointment.component';
+import { EditAppointmentRoutingModule } from './edit-appointment.routing.module';
+import { NbCardModule, NbSpinnerModule, NbButtonModule } from '@nebular/theme';
+import { EmployeeAppointmentService } from '../../../@core/services/employee-appointment.service';
+import { ManageAppointmentModule } from '../../../pages/employees/appointment/manage-appointment/manage-appointment.module';
+
+export function HttpLoaderFactory(http: HttpClient) {
+	return new TranslateHttpLoader(http, './assets/i18n/', '.json');
+}
+
+@NgModule({
+	imports: [
+		ThemeModule,
+		NbButtonModule,
+		NbSpinnerModule,
+		NbCardModule,
+		EditAppointmentRoutingModule,
+		ManageAppointmentModule,
+		TranslateModule.forChild({
+			loader: {
+				provide: TranslateLoader,
+				useFactory: HttpLoaderFactory,
+				deps: [HttpClient]
+			}
+		})
+	],
+	declarations: [EditAppointmentComponent],
+	entryComponents: [EditAppointmentComponent],
+	providers: [EmployeeAppointmentService]
+})
+export class EditAppointmentModule {}

--- a/apps/gauzy/src/app/share/public-appointments/edit-appointment/edit-appointment.routing.module.ts
+++ b/apps/gauzy/src/app/share/public-appointments/edit-appointment/edit-appointment.routing.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { EditAppointmentComponent } from './edit-appointment.component';
+const routes: Routes = [
+	{
+		path: '',
+		component: EditAppointmentComponent
+	}
+];
+
+@NgModule({
+	imports: [RouterModule.forChild(routes)],
+	exports: [RouterModule]
+})
+export class EditAppointmentRoutingModule {}

--- a/apps/gauzy/src/app/share/share-routing.module.ts
+++ b/apps/gauzy/src/app/share/share-routing.module.ts
@@ -22,6 +22,13 @@ const routes: Routes = [
 					)
 			},
 			{
+				path: 'employee/edit-appointment',
+				loadChildren: () =>
+					import(
+						'./public-appointments/edit-appointment/edit-appointment.module'
+					).then((m) => m.EditAppointmentModule)
+			},
+			{
 				path: 'employee/:id',
 				loadChildren: () =>
 					import(

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -1935,6 +1935,7 @@
 		"DETAILS": "Booking Details",
 		"PARTICIPANTS": "Participant Emails",
 		"HOST": "Host",
+		"RESCHEDULE": "Reschedule Appointment",
 		"CANCEL": "Cancel Appointment",
 		"EXPIRED_OR_CANCELLED": "**This appointment has expired or has been cancelled.",
 		"EMAIL_SENT": "**An email has been sent to the host as well as to all the participants for this meeting."


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

This PR adds functionality to edit public appointments. The reschedule link shown on the confirm appointment page will be sent over email to the end user so that they can choose to reschedule later. The appointment link is encoded using JWT token.

#WIP: Modify time for public appointment edit based on available time slots - Thinking of showing a full calendar with available slots on the appointment date and the actual appointment in red. The user can click on appointment and select time from one of the free slots but the event duration will be same as that of the original appointment.

![Screen-Recording-2020-07-10-at-1](https://user-images.githubusercontent.com/16370987/87179025-b48de780-c2fb-11ea-8174-e6f6a343c319.gif)

---
