### PR TITLE
feat: added save and send functinality

### DIFF
--- a/apps/api/src/app/invoice/invoice.entity.ts
+++ b/apps/api/src/app/invoice/invoice.entity.ts
@@ -92,10 +92,11 @@ export class Invoice extends Base implements IInvoice {
 	@Column({ nullable: true, type: 'numeric' })
 	totalValue?: number;
 
-	@ApiPropertyOptional({ type: Boolean })
-	@IsBoolean()
-	@Column({ nullable: true })
-	sentStatus?: boolean;
+	@ApiPropertyOptional({ type: String })
+	@IsString()
+	@IsOptional()
+	@Column()
+	status?: string;
 
 	@ApiPropertyOptional({ type: Boolean })
 	@IsBoolean()

--- a/apps/gauzy/src/app/pages/invoices/invoice-add/invoice-add.component.html
+++ b/apps/gauzy/src/app/pages/invoices/invoice-add/invoice-add.component.html
@@ -590,12 +590,31 @@
 			{{ 'BUTTONS.CANCEL' | translate }}
 		</button>
 		<button
-			(click)="addInvoice()"
+			class="mr-3"
+			(click)="addInvoice('Draft')"
 			status="success"
 			[disabled]="disableSaveButton || form.invalid"
 			nbButton
 		>
-			{{ 'BUTTONS.SAVE' | translate }}
+			{{ 'BUTTONS.SAVE_AS_DRAFT' | translate }}
+		</button>
+		<button
+			class="mr-3"
+			(click)="sendToClient()"
+			status="success"
+			[disabled]="disableSaveButton || form.invalid"
+			nbButton
+		>
+			{{ 'BUTTONS.SAVE_AND_SEND_CLIENT' | translate }}
+		</button>
+		<button
+			class="mr-3"
+			(click)="sendViaEmail()"
+			status="success"
+			[disabled]="disableSaveButton || form.invalid"
+			nbButton
+		>
+			{{ 'BUTTONS.SAVE_AND_SEND_EMAIL' | translate }}
 		</button>
 	</nb-card-footer>
 </nb-card>

--- a/apps/gauzy/src/app/pages/invoices/invoice-edit/invoice-edit.component.html
+++ b/apps/gauzy/src/app/pages/invoices/invoice-edit/invoice-edit.component.html
@@ -347,13 +347,31 @@
 			{{ 'BUTTONS.CANCEL' | translate }}
 		</button>
 		<button
+			class="mr-3"
+			(click)="updateInvoice('Draft')"
 			status="success"
-			(click)="updateInvoice()"
-			*ngIf="hasInvoiceEditPermission"
 			[disabled]="form.invalid"
 			nbButton
 		>
-			{{ 'BUTTONS.SAVE' | translate }}
+			{{ 'BUTTONS.SAVE_AS_DRAFT' | translate }}
+		</button>
+		<button
+			class="mr-3"
+			(click)="sendToClient()"
+			status="success"
+			[disabled]="form.invalid"
+			nbButton
+		>
+			{{ 'BUTTONS.SAVE_AND_SEND_CLIENT' | translate }}
+		</button>
+		<button
+			class="mr-3"
+			(click)="sendViaEmail()"
+			status="success"
+			[disabled]="form.invalid"
+			nbButton
+		>
+			{{ 'BUTTONS.SAVE_AND_SEND_EMAIL' | translate }}
 		</button>
 	</nb-card-footer>
 </nb-card>

--- a/apps/gauzy/src/app/pages/invoices/invoice-edit/invoice-edit.component.ts
+++ b/apps/gauzy/src/app/pages/invoices/invoice-edit/invoice-edit.component.ts
@@ -27,7 +27,7 @@ import { OrganizationProjectsService } from '../../../@core/services/organizatio
 import { LocalDataSource } from 'ng2-smart-table';
 import { InvoiceItemService } from '../../../@core/services/invoice-item.service';
 import { Router, ActivatedRoute } from '@angular/router';
-import { NbToastrService } from '@nebular/theme';
+import { NbToastrService, NbDialogService } from '@nebular/theme';
 import { InvoicesService } from '../../../@core/services/invoices.service';
 import { InvoiceEmployeesSelectorComponent } from '../table-components/invoice-employees-selector.component';
 import { InvoiceProjectsSelectorComponent } from '../table-components/invoice-project-selector.component';
@@ -37,6 +37,7 @@ import { InvoiceProductsSelectorComponent } from '../table-components/invoice-pr
 import { ProductService } from '../../../@core/services/product.service';
 import { TasksStoreService } from '../../../@core/services/tasks-store.service';
 import { InvoiceApplyTaxDiscountComponent } from '../table-components/invoice-apply-tax-discount.component';
+import { InvoiceEmailMutationComponent } from '../invoice-email/invoice-email-mutation.component';
 
 @Component({
 	selector: 'ga-invoice-edit',
@@ -59,7 +60,8 @@ export class InvoiceEditComponent extends TranslationBaseComponent
 		private employeeService: EmployeesService,
 		private projectService: OrganizationProjectsService,
 		private productService: ProductService,
-		private tasksStore: TasksStoreService
+		private tasksStore: TasksStoreService,
+		private dialogService: NbDialogService
 	) {
 		super(translate);
 		this.observableTasks = this.tasksStore.tasks$;
@@ -183,6 +185,10 @@ export class InvoiceEditComponent extends TranslationBaseComponent
 
 	loadSmartTable() {
 		this.settingsSmartTable = {
+			pager: {
+				display: true,
+				perPage: 5
+			},
 			add: {
 				addButtonContent: '<i class="nb-plus"></i>',
 				createButtonContent: '<i class="nb-checkmark"></i>',
@@ -459,7 +465,7 @@ export class InvoiceEditComponent extends TranslationBaseComponent
 			});
 	}
 
-	async updateInvoice() {
+	async updateInvoice(status: string, sendTo?: string) {
 		const tableData = await this.smartTableSource.getAll();
 		if (tableData.length) {
 			const invoiceData = this.form.value;
@@ -506,7 +512,9 @@ export class InvoiceEditComponent extends TranslationBaseComponent
 				invoiceType: this.invoice.invoiceType,
 				clientId: invoiceData.client.id,
 				organizationId: this.organization.id,
-				tags: this.tags
+				tags: this.tags,
+				status: status,
+				sentTo: sendTo
 			});
 
 			for (const invoiceItem of tableData) {
@@ -563,6 +571,131 @@ export class InvoiceEditComponent extends TranslationBaseComponent
 					this.getTranslation('TOASTR.TITLE.SUCCESS')
 				);
 				this.router.navigate(['/pages/accounting/invoices']);
+			}
+		} else {
+			this.toastrService.danger(
+				this.getTranslation('INVOICES_PAGE.INVOICE_ITEM.NO_ITEMS'),
+				this.getTranslation('TOASTR.TITLE.WARNING')
+			);
+		}
+	}
+
+	async sendToClient() {
+		if (this.form.value.client.contactOrganizationId) {
+			await this.updateInvoice(
+				'Sent',
+				this.form.value.client.contactOrganizationId
+			);
+		} else {
+			this.toastrService.danger(
+				this.getTranslation('INVOICES_PAGE.SEND.NOT_LINKED'),
+				this.getTranslation('TOASTR.TITLE.WARNING')
+			);
+		}
+	}
+
+	async sendViaEmail() {
+		const tableData = await this.smartTableSource.getAll();
+		if (tableData.length) {
+			const invoiceData = this.form.value;
+			if (
+				!invoiceData.invoiceDate ||
+				!invoiceData.dueDate ||
+				this.compareDate(invoiceData.invoiceDate, invoiceData.dueDate)
+			) {
+				this.toastrService.danger(
+					this.getTranslation('INVOICES_PAGE.INVALID_DATES'),
+					this.getTranslation('TOASTR.TITLE.WARNING')
+				);
+				return;
+			}
+
+			const invoiceExists = await this.invoicesService.getAll([], {
+				invoiceNumber: invoiceData.invoiceNumber
+			});
+
+			if (
+				invoiceExists.items.length &&
+				+invoiceExists.items[0].invoiceNumber !==
+					+this.invoice.invoiceNumber
+			) {
+				this.toastrService.danger(
+					this.getTranslation(
+						'INVOICES_PAGE.INVOICE_NUMBER_DUPLICATE'
+					),
+					this.getTranslation('TOASTR.TITLE.WARNING')
+				);
+				return;
+			}
+
+			const invoice = {
+				invoiceNumber: invoiceData.invoiceNumber,
+				invoiceDate: invoiceData.invoiceDate,
+				dueDate: invoiceData.dueDate,
+				currency: this.currency.value,
+				discountValue: invoiceData.discountValue,
+				discountType: invoiceData.discountType,
+				tax: invoiceData.tax,
+				tax2: invoiceData.tax2,
+				taxType: invoiceData.taxType,
+				tax2Type: invoiceData.tax2Type,
+				terms: invoiceData.terms,
+				paid: false,
+				totalValue: +this.total.toFixed(2),
+				toClient: invoiceData.client,
+				clientId: invoiceData.client.id,
+				fromOrganization: this.organization,
+				organizationId: this.organization.id,
+				invoiceType: this.invoice.invoiceType,
+				tags: this.tags,
+				isEstimate: this.isEstimate,
+				invoiceItems: []
+			};
+
+			const invoiceItems = [];
+
+			for (const invoiceItem of tableData) {
+				const itemToAdd = {
+					description: invoiceItem.description,
+					price: invoiceItem.price,
+					quantity: invoiceItem.quantity,
+					totalValue: invoiceItem.totalValue,
+					applyTax: invoiceItem.applyTax,
+					applyDiscount: invoiceItem.applyDiscount
+				};
+				switch (this.invoice.invoiceType) {
+					case InvoiceTypeEnum.BY_EMPLOYEE_HOURS:
+						itemToAdd['employeeId'] = invoiceItem.selectedItem;
+						break;
+					case InvoiceTypeEnum.BY_PROJECT_HOURS:
+						itemToAdd['projectId'] = invoiceItem.selectedItem;
+						break;
+					case InvoiceTypeEnum.BY_TASK_HOURS:
+						itemToAdd['taskId'] = invoiceItem.selectedItem;
+						break;
+					case InvoiceTypeEnum.BY_PRODUCTS:
+						itemToAdd['productId'] = invoiceItem.selectedItem;
+						break;
+					default:
+						break;
+				}
+				invoiceItems.push(itemToAdd);
+			}
+
+			invoice.invoiceItems = invoiceItems;
+
+			const result = await this.dialogService
+				.open(InvoiceEmailMutationComponent, {
+					context: {
+						invoice: invoice,
+						isEstimate: this.isEstimate
+					}
+				})
+				.onClose.pipe(first())
+				.toPromise();
+
+			if (result) {
+				await this.updateInvoice('Sent');
 			}
 		} else {
 			this.toastrService.danger(

--- a/apps/gauzy/src/app/pages/invoices/invoice-email/invoice-email-mutation.component.ts
+++ b/apps/gauzy/src/app/pages/invoices/invoice-email/invoice-email-mutation.component.ts
@@ -1,7 +1,11 @@
 import { Component } from '@angular/core';
 import { TranslationBaseComponent } from '../../../@shared/language-base/translation-base.component';
 import { OnInit } from '@angular/core';
-import { Invoice, InvoiceTypeEnum } from '@gauzy/models';
+import {
+	Invoice,
+	InvoiceTypeEnum,
+	InvoiceStatusTypesEnum
+} from '@gauzy/models';
 import { TranslateService } from '@ngx-translate/core';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { NbDialogRef, NbToastrService } from '@nebular/theme';
@@ -88,15 +92,17 @@ export class InvoiceEmailMutationComponent extends TranslationBaseComponent
 			);
 		});
 
-		await this.invoiceService.update(this.invoice.id, {
-			sentStatus: true
-		});
+		if (this.invoice.id) {
+			await this.invoiceService.update(this.invoice.id, {
+				status: InvoiceStatusTypesEnum.SENT
+			});
+		}
 
 		this.toastrService.primary(
 			this.getTranslation('INVOICES_PAGE.EMAIL.EMAIL_SENT'),
 			this.getTranslation('TOASTR.TITLE.SUCCESS')
 		);
-		this.dialogRef.close();
+		this.dialogRef.close('ok');
 	}
 
 	cancel() {

--- a/apps/gauzy/src/app/pages/invoices/invoice-send/invoice-send-mutation.component.ts
+++ b/apps/gauzy/src/app/pages/invoices/invoice-send/invoice-send-mutation.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { NbDialogRef, NbToastrService } from '@nebular/theme';
 import { TranslateService } from '@ngx-translate/core';
 import { TranslationBaseComponent } from '../../../@shared/language-base/translation-base.component';
-import { Invoice, Tag } from '@gauzy/models';
+import { Invoice, Tag, InvoiceStatusTypesEnum } from '@gauzy/models';
 import { InvoicesService } from '../../../@core/services/invoices.service';
 
 @Component({
@@ -37,8 +37,8 @@ export class InvoiceSendMutationComponent extends TranslationBaseComponent
 
 	async send() {
 		await this.invoicesService.update(this.invoice.id, {
-			sentTo: this.invoice.clientId,
-			sentStatus: true
+			sentTo: this.invoice.toClient.contactOrganizationId,
+			status: InvoiceStatusTypesEnum.SENT
 		});
 		this.dialogRef.close();
 

--- a/apps/gauzy/src/app/pages/invoices/invoice-view/inner-component/invoice-view-inner.component.ts
+++ b/apps/gauzy/src/app/pages/invoices/invoice-view/inner-component/invoice-view-inner.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit, OnDestroy, Input } from '@angular/core';
 import { TranslationBaseComponent } from '../../../../@shared/language-base/translation-base.component';
 import { TranslateService } from '@ngx-translate/core';
 import { Invoice, Employee, InvoiceTypeEnum } from '@gauzy/models';
-
 import { EmployeesService } from '../../../../@core/services/employees.service';
 import { Subject } from 'rxjs';
 import { OrganizationProjectsService } from '../../../../@core/services/organization-projects.service';
@@ -50,6 +49,9 @@ export class InvoiceViewInnerComponent extends TranslationBaseComponent
 		this.settingsSmartTable = {
 			actions: false,
 			hideSubHeader: true,
+			pager: {
+				display: false
+			},
 			columns: {
 				name: {
 					title: this.getTranslation('INVOICES_PAGE.NAME'),

--- a/apps/gauzy/src/app/pages/invoices/invoices.component.html
+++ b/apps/gauzy/src/app/pages/invoices/invoices.component.html
@@ -8,6 +8,17 @@
 				{{ 'INVOICES_PAGE.ESTIMATES.HEADER' | translate }}
 			</h4>
 		</div>
+		<nb-select
+			class="invoice-status"
+			[disabled]="disableButton"
+			placeholder="Set Invoice Status"
+			[(selected)]="status"
+			(selectedChange)="selectStatus($event)"
+		>
+			<nb-option *ngFor="let status of statusTypes" [value]="status">
+				{{ status }}
+			</nb-option>
+		</nb-select>
 		<div>
 			<ga-layout-selector
 				componentName="{{ viewComponentName }}"

--- a/apps/gauzy/src/app/pages/invoices/invoices.component.scss
+++ b/apps/gauzy/src/app/pages/invoices/invoices.component.scss
@@ -4,3 +4,7 @@
   align-items: center;
   justify-content: space-between;
 }
+
+.invoice-status {
+  margin-left: 70%;
+}

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -53,6 +53,9 @@
 		"EMAIL": "Email",
 		"CONVERT_TO_INVOICE": "Convert to invoice",
 		"PUBLIC_APPOINTMENT_BOOK": "Book Public Appointment",
+		"SAVE_AS_DRAFT": "Save as Draft",
+		"SAVE_AND_SEND_CLIENT": "Save and send to client in gauzy",
+		"SAVE_AND_SEND_EMAIL": "Save and send via email",
 		"SPRINT": {
 			"CREATE": "Create Sprint",
 			"EDIT": "Edit",
@@ -1462,6 +1465,7 @@
 		"APPLY_DISCOUNT": "Apply Discount",
 		"APPLIED": "Applied",
 		"NOT_APPLIED": "Not Applied",
+		"STATUS": "Status",
 		"INVOICE_TYPE": {
 			"INVOICE_TYPE": "Invoice Type",
 			"ESTIMATE_TYPE": "Estimate Type",

--- a/libs/models/src/lib/invoice.model.ts
+++ b/libs/models/src/lib/invoice.model.ts
@@ -28,7 +28,7 @@ export interface Invoice extends IBaseEntityModel {
 	sentTo?: string;
 	tags?: Tag[];
 	isEstimate?: boolean;
-	sentStatus?: boolean;
+	status?: string;
 	payments?: Payment[];
 	isAccepted?: boolean;
 }
@@ -52,7 +52,7 @@ export interface InvoiceUpdateInput {
 	invoiceType?: string;
 	sentTo?: string;
 	tags?: Tag[];
-	sentStatus?: boolean;
+	status?: string;
 	isAccepted?: boolean;
 	isEstimate?: boolean;
 }
@@ -78,4 +78,12 @@ export enum InvoiceTypeEnum {
 export enum DiscountTaxTypeEnum {
 	PERCENT = 'Percent',
 	FLAT_VALUE = 'Flat'
+}
+
+export enum InvoiceStatusTypesEnum {
+	DRAFT = 'Draft',
+	SENT = 'Sent',
+	VIEWED = 'Viewed',
+	PAID = 'Paid',
+	VOID = 'Void'
 }


### PR DESCRIPTION
When adding/editing invoices the user can now choose to save and immediately send the invoice (either via email or the client in gauzy).
Invoices can now have one of multiple statuses. The status can be changed by the user manually.
When there are more than 5 invoice items (in the add/edit page) and more than 10 invoices (in the invoices page) they will be separated into pages.

Video: https://www.loom.com/share/c3547726270a40bd8e576e2e0fb305dc