### PR TITLE
feat: added status to expenses

### DIFF
--- a/apps/api/src/app/expense/commands/handlers/expense.create.handler.ts
+++ b/apps/api/src/app/expense/commands/handlers/expense.create.handler.ts
@@ -45,6 +45,7 @@ export class ExpenseCreateHandler
 		expense.receipt = input.receipt;
 		expense.splitExpense = input.splitExpense;
 		expense.tags = input.tags;
+		expense.status = input.status;
 
 		if (!expense.currency) {
 			expense.currency = organization.currency;

--- a/apps/api/src/app/expense/expense.entity.ts
+++ b/apps/api/src/app/expense/expense.entity.ts
@@ -175,6 +175,11 @@ export class Expense extends TenantBase implements IExpense {
 	@Column({ nullable: true })
 	reference?: string;
 
+	@ApiPropertyOptional({ type: String })
+	@IsOptional()
+	@Column({ nullable: true })
+	status?: string;
+
 	//IN SOME CASES THE EXPENSES ARE CRASHING BECAUZE ITS TRYING TO ADD EXPENSEID AND THERE IS NO SUCH THING
 
 	// IF THIS HAPPENS AGAIN ADD THIS

--- a/apps/gauzy/src/app/@shared/expenses/expenses-mutation/expenses-mutation.component.html
+++ b/apps/gauzy/src/app/@shared/expenses/expenses-mutation/expenses-mutation.component.html
@@ -40,6 +40,7 @@
 				<nb-radio
 					*ngFor="let expenseType of expenseTypes"
 					[value]="expenseType"
+					(valueChange)="changeExpenseType($event)"
 					>{{ expenseType }}
 				</nb-radio>
 			</nb-radio-group>
@@ -202,7 +203,7 @@
 				</div>
 			</div>
 			<div class="row">
-				<div class="col-sm-12">
+				<div class="col-sm-6">
 					<div class="form-group">
 						<ga-tags-color-input
 							[selectedTags]="tags"
@@ -210,6 +211,32 @@
 							[isOrgLevel]="true"
 						>
 						</ga-tags-color-input>
+					</div>
+				</div>
+				<div class="col-sm-6">
+					<div class="form-group">
+						<label class="label" for="status">
+							{{ 'FORM.LABELS.STATUS' | translate }}
+						</label>
+						<div>
+							<nb-select
+								id="status"
+								placeholder="{{
+									'FORM.PLACEHOLDERS.SELECT_STATUS'
+										| translate
+								}}"
+								fullWidth
+								[disabled]="disableStatuses"
+								formControlName="status"
+							>
+								<nb-option
+									*ngFor="let status of expenseStatuses"
+									[value]="status"
+								>
+									{{ status }}
+								</nb-option>
+							</nb-select>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/apps/gauzy/src/app/@shared/expenses/expenses-mutation/expenses-mutation.component.ts
+++ b/apps/gauzy/src/app/@shared/expenses/expenses-mutation/expenses-mutation.component.ts
@@ -15,7 +15,8 @@ import {
 	IOrganizationVendor,
 	Tag,
 	OrganizationContact,
-	OrganizationProjects
+	OrganizationProjects,
+	ExpenseStatusesEnum
 } from '@gauzy/models';
 import { OrganizationsService } from '../../../@core/services/organizations.service';
 import { Store } from '../../../@core/services/store.service';
@@ -55,6 +56,7 @@ export class ExpensesMutationComponent extends TranslationBaseComponent
 	expenseTypes = Object.values(ExpenseTypesEnum);
 	currencies = Object.values(CurrenciesEnum);
 	taxTypes = Object.values(TaxTypesEnum);
+	expenseStatuses = Object.values(ExpenseStatusesEnum);
 	expenseCategories: IOrganizationExpenseCategory[];
 	vendors: IOrganizationVendor[];
 	clients: { clientName: string; clientId: string }[] = [];
@@ -73,6 +75,7 @@ export class ExpensesMutationComponent extends TranslationBaseComponent
 	amount: AbstractControl;
 	notes: AbstractControl;
 	showTooltip = false;
+	disableStatuses = false;
 
 	constructor(
 		public dialogRef: NbDialogRef<ExpensesMutationComponent>,
@@ -97,6 +100,7 @@ export class ExpensesMutationComponent extends TranslationBaseComponent
 		this.loadProjects();
 		this._initializeForm();
 		this.form.get('currency').disable();
+		this.changeExpenseType(this.form.value.typeOfExpense);
 	}
 
 	get currency() {
@@ -148,6 +152,10 @@ export class ExpensesMutationComponent extends TranslationBaseComponent
 
 		if (this.employeeSelector.selectedEmployee === ALL_EMPLOYEES_SELECTED)
 			this.form.value.splitExpense = true;
+
+		if (this.form.value.typeOfExpense !== 'Billable to Client') {
+			this.form.value.status = 'Not Billable';
+		}
 
 		this.dialogRef.close(
 			Object.assign(
@@ -269,7 +277,8 @@ export class ExpensesMutationComponent extends TranslationBaseComponent
 				rateValue: [this.expense.rateValue],
 				receipt: [this.expense.receipt],
 				splitExpense: [this.expense.splitExpense],
-				tags: [this.expense.tags]
+				tags: [this.expense.tags],
+				status: [this.expense.status]
 			});
 		} else {
 			this.form = this.fb.group({
@@ -291,7 +300,8 @@ export class ExpensesMutationComponent extends TranslationBaseComponent
 				rateValue: [0],
 				receipt: [this.defaultImage],
 				splitExpense: [false],
-				tags: []
+				tags: [],
+				status: []
 			});
 
 			this._loadDefaultCurrency();
@@ -396,6 +406,14 @@ export class ExpensesMutationComponent extends TranslationBaseComponent
 
 	onEmployeeChange(selectedEmployee: SelectedEmployee) {
 		this.showTooltip = selectedEmployee === ALL_EMPLOYEES_SELECTED;
+	}
+
+	changeExpenseType($event) {
+		if ($event !== 'Billable to Client') {
+			this.disableStatuses = true;
+		} else {
+			this.disableStatuses = false;
+		}
 	}
 
 	ngOnDestroy() {

--- a/apps/gauzy/src/app/pages/expenses/expenses.component.ts
+++ b/apps/gauzy/src/app/pages/expenses/expenses.component.ts
@@ -55,6 +55,7 @@ export interface ExpenseViewModel {
 	receipt: string;
 	splitExpense: boolean;
 	tags: Tag[];
+	status: string;
 }
 
 @Component({
@@ -116,6 +117,10 @@ export class ExpensesComponent extends TranslationBaseComponent
 				},
 				purpose: {
 					title: 'Purpose',
+					type: 'string'
+				},
+				status: {
+					title: this.getTranslation('SM_TABLE.STATUS'),
 					type: 'string'
 				}
 			}
@@ -251,7 +256,8 @@ export class ExpensesComponent extends TranslationBaseComponent
 			rateValue: formData.rateValue,
 			receipt: formData.receipt,
 			splitExpense: formData.splitExpense,
-			tags: formData.tags
+			tags: formData.tags,
+			status: formData.status
 		};
 	}
 
@@ -493,7 +499,8 @@ export class ExpensesComponent extends TranslationBaseComponent
 					rateValue: i.rateValue,
 					receipt: i.receipt,
 					splitExpense: i.splitExpense,
-					tags: i.tags
+					tags: i.tags,
+					status: i.status
 				};
 			});
 			this.expenses = items;

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -231,7 +231,8 @@
 			"ADD_REMOVE_MEMBERS": "Add or Remove Members",
 			"SHORT_DESCRIPTION": "Short Description",
 			"ENABLE_EMPLOYEE_FEATURES": "Enable Employee Features",
-			"REVOKE_EMPLOYEE_FEATURES": "Revoke Employee Features"
+			"REVOKE_EMPLOYEE_FEATURES": "Revoke Employee Features",
+			"STATUS": "Status"
 		},
 		"PLACEHOLDERS": {
 			"NAME": "Name",
@@ -315,6 +316,7 @@
 			"FEEDBACK_DESCRIPTION": "Feedback description",
 			"PREFERRED_LANGUAGE": "Preferred Language",
 			"OWNER": "Owner",
+			"SELECT_STATUS": "Select Status",
 			"ADD_EDUCATION": {
 				"SCHOOL_NAME": "School name",
 				"DEGREE": "Degree/Diploma",

--- a/libs/models/src/lib/expense.model.ts
+++ b/libs/models/src/lib/expense.model.ts
@@ -30,6 +30,7 @@ export interface Expense extends IBaseEntityModel {
 	receipt?: string;
 	splitExpense?: boolean;
 	tags?: Tag[];
+	status?: string;
 }
 
 export interface ExpenseCreateInput {
@@ -54,6 +55,7 @@ export interface ExpenseCreateInput {
 	splitExpense?: boolean;
 	reference?: string;
 	tags?: Tag[];
+	status?: string;
 }
 
 export interface ExpenseFindInput extends IBaseEntityModel {
@@ -79,6 +81,7 @@ export interface ExpenseFindInput extends IBaseEntityModel {
 	receipt?: string;
 	splitExpense?: boolean;
 	tags?: Tag[];
+	status?: string;
 }
 
 export interface ExpenseUpdateInput {
@@ -103,6 +106,7 @@ export interface ExpenseUpdateInput {
 	receipt?: string;
 	splitExpense?: boolean;
 	tags?: Tag[];
+	status?: string;
 }
 
 export interface SplitExpenseOutput extends Expense {
@@ -125,4 +129,10 @@ export enum ExpenseTypesEnum {
 export enum TaxTypesEnum {
 	PERCENTAGE = 'Percentage',
 	VALUE = 'Value'
+}
+
+export enum ExpenseStatusesEnum {
+	INVOICED = 'Invoiced',
+	UNINVOICED = 'Uninvoiced',
+	PAID = 'Paid'
 }


### PR DESCRIPTION
When creating an expense if the expense type is set to 'Billable to Client' the user can add a status to the expense.
If the expense type is different the status is set to 'Not Billable'.

Video: https://www.loom.com/share/75664ff84815454ca256c455c6c19ade