### PR TITLE
feat(appointment_scheduling): finish pick employee based on availability

### DIFF
--- a/apps/gauzy/src/app/pages/employees/appointment/appointment.component.ts
+++ b/apps/gauzy/src/app/pages/employees/appointment/appointment.component.ts
@@ -232,7 +232,10 @@ export class AppointmentComponent extends TranslationBaseComponent
 		const data = await this.timeOffService
 			.getAllTimeOffRecords(['employees', 'employees.user'], {
 				organizationId: this._selectedOrganizationId,
-				employeeId: this._selectedEmployeeId || ''
+				employeeId:
+					this._selectedEmployeeId ||
+					(this.employee && this.employee.id) ||
+					''
 			})
 			.pipe(first())
 			.toPromise();

--- a/apps/gauzy/src/app/pages/employees/appointment/manage-appointment/manage-appointment.component.ts
+++ b/apps/gauzy/src/app/pages/employees/appointment/manage-appointment/manage-appointment.component.ts
@@ -283,8 +283,30 @@ export class ManageAppointmentComponent extends TranslationBaseComponent
 				}
 			})
 		).items;
+
+		this.employees = this.employees.filter(
+			(e) =>
+				e.id !==
+				(this.employee
+					? this.employee.id
+					: this.store.selectedEmployee
+					? this.store.selectedEmployee.id
+					: null)
+		);
+
 		this.employees.map((e) => {
-			this.employeeAvailability[e.id] = slots.filter(
+			const dateSpecificSlots: IAvailabilitySlots[] = [];
+			const recurringSlots: IAvailabilitySlots[] = [];
+
+			slots.forEach((s) => {
+				if (s.employeeId === e.id && s.type === 'Recurring') {
+					recurringSlots.push(s);
+				} else if (s.employeeId === e.id) {
+					dateSpecificSlots.push(s);
+				}
+			});
+
+			this.employeeAvailability[e.id] = dateSpecificSlots.filter(
 				(s) =>
 					s.employeeId === e.id &&
 					moment(this.selectedRange.start).isBetween(
@@ -294,6 +316,15 @@ export class ManageAppointmentComponent extends TranslationBaseComponent
 						'[]'
 					)
 			);
+
+			if (this.employeeAvailability[e.id].length === 0) {
+				const appointmentDay = moment(this.selectedRange.start).format(
+					'dddd'
+				);
+				this.employeeAvailability[e.id] = recurringSlots.filter(
+					(s) => moment(s.startTime).format('dddd') === appointmentDay
+				);
+			}
 		});
 	}
 


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

This PR adds case for consideration of recurring availability for picking employees on booking appointment page. Also fixed an issue with public appointment page not considering time off feature correctly
---
