### PR TITLE
fix: #1581 load translation on app start

### DIFF
--- a/apps/gauzy/src/app/@core/services/store.service.ts
+++ b/apps/gauzy/src/app/@core/services/store.service.ts
@@ -6,7 +6,8 @@ import {
 	User,
 	LanguagesEnum,
 	OrganizationPermissionsEnum,
-	OrganizationProjects
+	OrganizationProjects,
+	Language
 } from '@gauzy/models';
 import { SelectedEmployee } from '../../@theme/components/header/selectors/employee/employee.component';
 import { ProposalViewModel } from '../../pages/proposals/proposals.component';
@@ -29,6 +30,7 @@ export interface AppState {
 	selectedProposal: ProposalViewModel;
 	selectedProject: OrganizationProjects;
 	selectedDate: Date;
+	systemLanguages: Language[];
 }
 
 export interface PersistState {
@@ -124,6 +126,7 @@ export class Store {
 	componentLayoutMap$ = this.persistQuery
 		.select((state) => state.componentLayout)
 		.pipe(map((componentLayout) => new Map(componentLayout)));
+	systemLanguages$ = this.appQuery.select((state) => state.systemLanguages);
 
 	subject = new Subject<ComponentEnum>();
 
@@ -194,6 +197,17 @@ export class Store {
 		this.appStore.update({
 			selectedProject: project
 		});
+	}
+
+	set systemLanguages(languages: Language[]) {
+		this.appStore.update({
+			systemLanguages: languages
+		});
+	}
+
+	get systemLanguages(): Language[] {
+		const { systemLanguages } = this.appQuery.getValue();
+		return systemLanguages;
 	}
 
 	get token(): string | null {

--- a/apps/gauzy/src/app/@theme/layouts/one-column/one-column.layout.html
+++ b/apps/gauzy/src/app/@theme/layouts/one-column/one-column.layout.html
@@ -22,7 +22,7 @@
 		</div>
 	</nb-sidebar>
 
-	<nb-layout-column>
+	<nb-layout-column *ngIf="!loading">
 		<ng-content select="router-outlet"></ng-content>
 	</nb-layout-column>
 

--- a/apps/gauzy/src/app/@theme/layouts/one-column/one-column.layout.ts
+++ b/apps/gauzy/src/app/@theme/layouts/one-column/one-column.layout.ts
@@ -46,6 +46,7 @@ export class OneColumnLayoutComponent implements OnInit, AfterViewInit {
 	user: any;
 	showOrganizationsSelector = false;
 	showEmployeesSelector = false;
+	loading = true;
 
 	userMenu = [
 		{ title: 'Profile', link: '/pages/auth/profile' },
@@ -127,5 +128,7 @@ export class OneColumnLayoutComponent implements OnInit, AfterViewInit {
 				this.store.selectedEmployee = NO_EMPLOYEE_SELECTED;
 			}
 		}
+
+		this.loading = false;
 	}
 }

--- a/apps/gauzy/src/app/app.component.ts
+++ b/apps/gauzy/src/app/app.component.ts
@@ -5,25 +5,39 @@
  */
 import { Component, OnInit } from '@angular/core';
 import { AnalyticsService } from './@core/utils/analytics.service';
-import { Cloudinary } from '@cloudinary/angular-5.x';
-import { HttpClient } from '@angular/common/http';
 import { Store } from './@core/services/store.service';
-import { Router } from '@angular/router';
+import { TranslateService } from '@ngx-translate/core';
+import { LanguagesEnum } from '@gauzy/models';
+import { LanguagesService } from './@core/services/languages.service';
 
 @Component({
 	selector: 'ga-app',
-	template: '<router-outlet></router-outlet>'
+	template: '<router-outlet *ngIf="!loading"></router-outlet>'
 })
 export class AppComponent implements OnInit {
 	constructor(
 		private analytics: AnalyticsService,
-		private _cloudinary: Cloudinary,
-		private readonly httpClient: HttpClient,
 		private store: Store,
-		private router: Router
+		private languagesService: LanguagesService,
+		public translate: TranslateService
 	) {}
+
+	loading = true;
 
 	async ngOnInit() {
 		this.analytics.trackPageViews();
+		this.translate.onLangChange.subscribe(() => {
+			this.loading = false;
+		});
+		this.loadLanguages();
+	}
+
+	private async loadLanguages() {
+		const res = await this.languagesService.getSystemLanguages();
+		this.store.systemLanguages = res.items;
+		this.translate.setDefaultLang(LanguagesEnum.ENGLISH);
+		this.translate.use(
+			this.translate.getBrowserLang() || LanguagesEnum.ENGLISH
+		);
 	}
 }

--- a/apps/gauzy/src/app/pages/pages.component.ts
+++ b/apps/gauzy/src/app/pages/pages.component.ts
@@ -654,7 +654,7 @@ export class PagesComponent implements OnInit, OnDestroy {
 	constructor(
 		private authService: AuthService,
 		private employeeService: EmployeesService,
-		private translate: TranslateService,
+		public translate: TranslateService,
 		private store: Store,
 		private selectorService: SelectorService,
 		private router: Router
@@ -693,10 +693,7 @@ export class PagesComponent implements OnInit, OnDestroy {
 			});
 	}
 
-	loadItems(
-		withOrganizationShortcuts: boolean,
-		forceTranslate: boolean = false
-	) {
+	loadItems(withOrganizationShortcuts: boolean) {
 		this.menu.forEach((item) => {
 			this.refreshMenuItem(item, withOrganizationShortcuts);
 		});
@@ -754,8 +751,7 @@ export class PagesComponent implements OnInit, OnDestroy {
 			.subscribe(() => {
 				this.loadItems(
 					this.selectorService.showSelectors(this.router.url)
-						.showOrganizationShortcuts,
-					true
+						.showOrganizationShortcuts
 				);
 			});
 	}


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

https://www.loom.com/share/53a2efb2aaf345ccbd41ca7f09ace65c

So this is an interesting issue, we were currently loading languages inside the theme-settings component which is the right sidebar as shown in the video. Until this was loaded other components were already loaded and so components with pipes i.e. ` XYZ | translate` was still working because it was re-rendering them but components that used function the this.getTranslate() on Init were failing.

This was also the reason we first see the keys for a second and then the translated values. These small changes should fix the issues, but we are still loading the user's preferred language in the theme-settings but it has no visible effect so I  guess this should be good, if we face more issues then we'll move the users preferred language to a wrapper component as well.

@evereq 