### PR TITLE
Automate tagging when pushed to master

### DIFF
--- a/.github/workflows/desktop-app.yml
+++ b/.github/workflows/desktop-app.yml
@@ -2,8 +2,7 @@ name: Desktop App Build
 
 on: 
   push:
-    branches: [ develop ]
-  pull_request:
+    branches: [ master ]
 
 jobs:
   release-linux:
@@ -33,6 +32,11 @@ jobs:
 
       - name: Bootstrap Yarn
         run: "yarn bootstrap"
+
+      - name: Bump version and push tag
+        uses: mathieudutour/github-tag-action@v4.5
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Desktop App
         run: "yarn build:desktop:linux"


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---
A `tag` should be automatically created/bumped when a commit is pushed/merged to `master` and `electron-builder` should be able to use this tag to publish the Desktop App artifacts to GitHub Releases.