### PR TITLE
feat(appointment_scheduling): finish schedules & seed event types

### DIFF
--- a/apps/api/src/app/core/seeds/SeedDataService.ts
+++ b/apps/api/src/app/core/seeds/SeedDataService.ts
@@ -290,6 +290,10 @@ import { GoalGeneralSetting } from '../../goal-general-setting/goal-general-sett
 import { EstimateEmail } from '../../estimate-email/estimate-email.entity';
 import { HelpCenterAuthor } from '../../help-center-author/help-center-author.entity';
 import { IntegrationMap } from '../../integration-map/integration-map.entity';
+import {
+	createDefaultEventTypes,
+	createRandomEventType
+} from '../../event-types/event-type.seed';
 
 const allEntities = [
 	AvailabilitySlots,
@@ -797,6 +801,9 @@ export class SeedDataService {
 		);
 		await this.tryExecute(
 			createDefaultInvoice(this.connection, this.organizations, 50)
+		);
+		await this.tryExecute(
+			createDefaultEventTypes(this.connection, this.organizations)
 		);
 	}
 
@@ -1331,6 +1338,15 @@ export class SeedDataService {
 				this.connection,
 				tenants,
 				tenantCandidatesMap
+			)
+		);
+
+		await this.tryExecute(
+			createRandomEventType(
+				this.connection,
+				tenants,
+				tenantEmployeeMap,
+				tenantOrganizationsMap
 			)
 		);
 	}

--- a/apps/api/src/app/event-types/event-type.seed.ts
+++ b/apps/api/src/app/event-types/event-type.seed.ts
@@ -54,3 +54,53 @@ export const createRandomEventType = async (
 
 	await connection.manager.save(eventTypes);
 };
+
+export const createDefaultEventTypes = async (
+	connection: Connection,
+	orgs: Organization[]
+): Promise<void> => {
+	const eventTypes: EventType[] = [];
+
+	orgs.forEach((org) => {
+		const eventType = new EventType();
+		eventType.title = '15 Minutes Event';
+		eventType.description = 'This is a default event type.';
+		eventType.duration = 15;
+		eventType.durationUnit = 'Minute(s)';
+		eventType.isActive = true;
+		eventType.organization = org;
+		eventTypes.push(eventType);
+
+		const eventTypeOne = new EventType();
+		eventTypeOne.title = '30 Minutes Event';
+		eventTypeOne.description = 'This is a default event type.';
+		eventTypeOne.duration = 30;
+		eventTypeOne.durationUnit = 'Minute(s)';
+		eventTypeOne.isActive = true;
+		eventTypeOne.organization = org;
+		eventTypes.push(eventTypeOne);
+
+		const eventTypeTwo = new EventType();
+		eventTypeTwo.title = '60 Minutes Event';
+		eventTypeTwo.description = 'This is a default event type.';
+		eventTypeTwo.duration = 60;
+		eventTypeTwo.durationUnit = 'Minute(s)';
+		eventTypeTwo.isActive = true;
+		eventTypeTwo.organization = org;
+		eventTypes.push(eventTypeTwo);
+	});
+
+	await insertEventTypes(connection, eventTypes);
+};
+
+const insertEventTypes = async (
+	connection: Connection,
+	eventTypes: EventType[]
+): Promise<void> => {
+	await connection
+		.createQueryBuilder()
+		.insert()
+		.into(EventType)
+		.values(eventTypes)
+		.execute();
+};


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

This PR completes integration of Time off feature with Schedules page. So now, schedules page is all ready. Also, added default seed for event types such that if an employee does not have any event types then it will show the organization level event types

![Screen-Recording-2020-08-02-at-1](https://user-images.githubusercontent.com/16370987/89118772-fdcdf300-d4c5-11ea-990f-b76f14525eb0.gif)

---
