### PR TITLE
feat: #1761 remove success logging from seed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ Thumbs.db
 
 .env
 /.deploy/nginx/log
+
+# Typeorm Logs
+ormlogs.log

--- a/apps/api/src/app/core/seeds/SeedDataService.ts
+++ b/apps/api/src/app/core/seeds/SeedDataService.ts
@@ -529,6 +529,15 @@ export class SeedDataService {
 
 	constructor() {}
 
+	/**
+	 * This config is applied only for `yarn seed:*` type calls because
+	 * that is when connection is created by this service itself.
+	 */
+	overrideDbConfig = {
+		logging: true,
+		logger: 'file' //Removes console logging, instead logs all queries in a file ormlogs.log
+	};
+
 	private async cleanUpPreviousRuns() {
 		this.log(chalk.green(`CLEANING UP FROM PREVIOUS RUNS...`));
 
@@ -564,6 +573,7 @@ export class SeedDataService {
 
 				this.connection = await createConnection({
 					...env.database,
+					...this.overrideDbConfig,
 					entities: allEntities
 				} as ConnectionOptions);
 			} catch (error) {


### PR DESCRIPTION
-   [x] Have you followed the [contributing guidelines](https://github.com/ever-co/gauzy/blob/master/.github/CONTRIBUTING.md)?
-   [x] Have you explained what your changes do, and why they add value?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

---

When we run `yarn seed` or `yarn seed:all` then all success queries are logged into a file. Failures through and exception so they. get logged on the console.

Console:
<img width="1431" alt="Screenshot 2020-08-16 at 5 19 16 PM" src="https://user-images.githubusercontent.com/6750734/90333567-aad75e00-dfe4-11ea-996c-cc85ecadfc4b.png">
 
Log File `gauzy/ormlogs.log`:
<img width="1675" alt="Screenshot 2020-08-16 at 5 20 48 PM" src="https://user-images.githubusercontent.com/6750734/90333602-da866600-dfe4-11ea-9543-6b0a948d033c.png">

This will have no effect on `yarn start:api` since in that case the connection is not created from SeedDataService.