### PR TITLE
Feat/#868 fix candidate bug

### DIFF
--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-interview/edit-candidate-interview.component.html
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-interview/edit-candidate-interview.component.html
@@ -1,20 +1,39 @@
 <nb-card>
 	<nb-card-header>
-		<button nbButton status="success" (click)="add()">
-			<nb-icon class="mr-1" icon="plus-outline"></nb-icon
-			>{{ 'BUTTONS.ADD' | translate }}
-		</button>
+		<div class="header">
+			<button nbButton status="success" (click)="add()">
+				<nb-icon class="mr-1" icon="plus-outline"></nb-icon
+				>{{ 'BUTTONS.ADD' | translate }}
+			</button>
+			<div class="right-block">
+				<div class="checkboxes" *ngIf="showCheckboxes">
+					<nb-checkbox
+						(checkedChange)="changePast($event)"
+						status="warning"
+						[checked]="onlyPast"
+						>{{ 'FORM.CHECKBOXES.ONLY_PAST' | translate }}
+					</nb-checkbox>
+					<nb-checkbox
+						(checkedChange)="changeFuture($event)"
+						status="warning"
+						[checked]="onlyFuture"
+						class="mr-3 ml-3"
+						>{{ 'FORM.CHECKBOXES.ONLY_FUTURE' | translate }}
+					</nb-checkbox>
+				</div>
+				<ga-layout-selector
+					componentName="{{ viewComponentName }}"
+				></ga-layout-selector>
+			</div>
+		</div>
 	</nb-card-header>
-	<nb-card-body *ngIf="showPastCheckbox">
-		<nb-checkbox
-			(checkedChange)="changeHidePastInterviews($event)"
-			status="primary"
-			class="float-right py-auto"
-			>{{
-				'CANDIDATES_PAGE.EDIT_CANDIDATE.INTERVIEW.HIDE_PAST' | translate
-			}}</nb-checkbox
+	<nb-card-body>
+		<div
+			*ngIf="
+				interviewList?.length > 0 && dataLayoutStyle === 'CARDS_GRID'
+			"
+			class="cards"
 		>
-		<div *ngIf="interviewList?.length > 0" class="cards">
 			<div
 				[nbSpinner]="loading"
 				nbSpinnerSize="giant"
@@ -98,5 +117,14 @@
 				</nb-card>
 			</div>
 		</div>
+		<ng2-smart-table
+			*ngIf="dataLayoutStyle === 'TABLE'"
+			class="interviews-table"
+			style="cursor: pointer;"
+			[settings]="settingsSmartTable"
+			[source]="sourceSmartTable"
+			#interviewsTable
+		>
+		</ng2-smart-table>
 	</nb-card-body>
 </nb-card>

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-interview/edit-candidate-interview.component.scss
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-interview/edit-candidate-interview.component.scss
@@ -1,7 +1,6 @@
 .interviews-line {
   margin: 0.2rem 0 0.2rem 0.2rem;
   display: flex;
-  flex-direction: row;
   justify-content: space-between;
   align-items: center;
   width: 100%;
@@ -9,9 +8,26 @@
 
 .interviews-card {
   display: flex;
-  flex-direction: row;
   justify-content: space-between;
   align-items: center;
+}
+
+.right-block {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.checkboxes {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .cards {

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-interview/edit-candidate-interview.component.ts
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-interview/edit-candidate-interview.component.ts
@@ -366,12 +366,11 @@ export class EditCandidateInterviewComponent extends TranslationBaseComponent
 	}
 	filterInterviewByTime(list: ICandidateInterview[], isPast: boolean) {
 		const now = new Date().getTime();
-		let res: ICandidateInterview[] = [];
-		return (res = list.filter((item) =>
+		return list.filter((item) =>
 			isPast
 				? new Date(item.startTime).getTime() < now
 				: new Date(item.startTime).getTime() > now
-		));
+		);
 	}
 
 	async removeInterview(id: string) {

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-interview/edit-candidate-interview.component.ts
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-interview/edit-candidate-interview.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
 import { NbDialogService, NbToastrService } from '@nebular/theme';
 import { TranslateService } from '@ngx-translate/core';
 import { TranslationBaseComponent } from 'apps/gauzy/src/app/@shared/language-base/translation-base.component';
@@ -11,11 +11,23 @@ import { FormGroup } from '@angular/forms';
 import {
 	Candidate,
 	ICandidateInterview,
-	ICandidateInterviewers
+	ICandidateInterviewers,
+	ComponentLayoutStyleEnum,
+	Employee,
+	ICandidateFeedback
 } from '@gauzy/models';
 import { EmployeesService } from 'apps/gauzy/src/app/@core/services';
 import { CandidateInterviewFeedbackComponent } from 'apps/gauzy/src/app/@shared/candidate/candidate-interview-feedback/candidate-interview-feedback.component';
 import { DeleteInterviewComponent } from 'apps/gauzy/src/app/@shared/candidate/candidate-confirmation/delete-interview/delete-interview.component';
+import { ComponentEnum } from 'apps/gauzy/src/app/@core/constants/layout.constants';
+import { LocalDataSource } from 'ng2-smart-table';
+import { Store } from 'apps/gauzy/src/app/@core/services/store.service';
+import { InterviewActionsTableComponent } from '../../../manage-candidate-interviews/interview-panel/table-components/actions/actions.component';
+import { InterviewDateTableComponent } from '../../../manage-candidate-interviews/interview-panel/table-components/date/date.component';
+import { InterviewStarRatingComponent } from '../../../manage-candidate-interviews/interview-panel/table-components/rating/rating.component';
+import { InterviewersTableComponent } from '../../../manage-candidate-interviews/interview-panel/table-components/interviewers/interviewers.component';
+import { InterviewCriterionsTableComponent } from '../../../manage-candidate-interviews/interview-panel/table-components/criterions/criterions.component';
+import { CandidateFeedbacksService } from 'apps/gauzy/src/app/@core/services/candidate-feedbacks.service';
 
 @Component({
 	selector: 'ga-edit-candidate-interview',
@@ -31,18 +43,32 @@ export class EditCandidateInterviewComponent extends TranslationBaseComponent
 	interviewers: ICandidateInterviewers[];
 	interviewersNumber: number;
 	form: FormGroup;
-	showPastCheckbox: boolean;
+	showCheckboxes: boolean = true;
 	loading: boolean;
+	onlyPast = false;
+	onlyFuture = false;
+	@ViewChild('interviewsTable') interviewsTable;
+	settingsSmartTable: object;
+	sourceSmartTable = new LocalDataSource();
+	viewComponentName: ComponentEnum;
+	dataLayoutStyle = ComponentLayoutStyleEnum.TABLE;
+	tableInterviewList = [];
+	employeeList: Employee[];
+	allInterviews: ICandidateInterview[];
+	allFeedbacks: ICandidateFeedback[];
 	constructor(
 		private dialogService: NbDialogService,
 		translate: TranslateService,
-		protected employeesService: EmployeesService,
+		private employeesService: EmployeesService,
+		private candidateFeedbacksService: CandidateFeedbacksService,
 		private readonly candidateInterviewService: CandidateInterviewService,
 		readonly translateService: TranslateService,
 		private candidateStore: CandidateStore,
+		private store: Store,
 		private toastrService: NbToastrService
 	) {
 		super(translate);
+		this.setView();
 	}
 	ngOnInit() {
 		this.candidateStore.selectedCandidate$
@@ -51,11 +77,111 @@ export class EditCandidateInterviewComponent extends TranslationBaseComponent
 				if (candidate) {
 					this.candidateId = candidate.id;
 					this.loadInterview();
+					this.loadSmartTable();
+					this._applyTranslationOnSmartTable();
 				}
 				this.selectedCandidate = candidate;
 			});
 	}
-
+	setView() {
+		this.viewComponentName = ComponentEnum.VENDORS;
+		this.store
+			.componentLayout$(this.viewComponentName)
+			.pipe(takeUntil(this._ngDestroy$))
+			.subscribe((componentLayout) => {
+				this.dataLayoutStyle = componentLayout;
+			});
+	}
+	async loadSmartTable() {
+		this.settingsSmartTable = {
+			actions: false,
+			columns: {
+				title: {
+					title: this.getTranslation(
+						'CANDIDATES_PAGE.MANAGE_INTERVIEWS.TITLE'
+					),
+					type: 'string'
+				},
+				date: {
+					title: this.getTranslation(
+						'CANDIDATES_PAGE.MANAGE_INTERVIEWS.DATE'
+					),
+					type: 'custom',
+					width: '120px',
+					renderComponent: InterviewDateTableComponent,
+					filter: false,
+					class: 'text-center'
+				},
+				rating: {
+					title: this.getTranslation(
+						'CANDIDATES_PAGE.MANAGE_INTERVIEWS.RATING'
+					),
+					type: 'custom',
+					width: '136px',
+					renderComponent: InterviewStarRatingComponent,
+					filter: false
+				},
+				employees: {
+					title: this.getTranslation(
+						'CANDIDATES_PAGE.MANAGE_INTERVIEWS.INTERVIEWERS'
+					),
+					type: 'custom',
+					width: '155px',
+					renderComponent: InterviewersTableComponent,
+					filter: false
+				},
+				criterions: {
+					title: this.getTranslation(
+						'CANDIDATES_PAGE.MANAGE_INTERVIEWS.CRITERIONS'
+					),
+					type: 'custom',
+					renderComponent: InterviewCriterionsTableComponent,
+					filter: false
+				},
+				location: {
+					title: this.getTranslation(
+						'CANDIDATES_PAGE.MANAGE_INTERVIEWS.LOCATION'
+					),
+					type: 'string'
+				},
+				note: {
+					title: this.getTranslation(
+						'CANDIDATES_PAGE.MANAGE_INTERVIEWS.NOTES'
+					),
+					type: 'string',
+					filter: false
+				},
+				actions: {
+					title: this.getTranslation(
+						'CANDIDATES_PAGE.MANAGE_INTERVIEWS.ACTIONS'
+					),
+					width: '150px',
+					type: 'custom',
+					renderComponent: InterviewActionsTableComponent,
+					filter: false,
+					onComponentInitFunction: (instance) => {
+						instance.updateResult.subscribe((params) => {
+							switch (params.type) {
+								case 'feedback':
+									this.addInterviewFeedback(params.data.id);
+									break;
+								case 'edit':
+									this.editInterview(params.data.id);
+									break;
+								case 'remove':
+									this.removeInterview(params.data.id);
+									break;
+							}
+						});
+					}
+				}
+			},
+			pager: {
+				display: true,
+				perPage: 8
+			}
+		};
+	}
 	async add() {
 		const dialog = this.dialogService.open(
 			CandidateInterviewMutationComponent,
@@ -78,16 +204,86 @@ export class EditCandidateInterviewComponent extends TranslationBaseComponent
 
 	private async loadInterview() {
 		this.loading = true;
-		const res = await this.candidateInterviewService.getAll(
-			['personalQualities', 'interviewers', 'technologies', 'feedbacks'],
+		const res = await this.candidateFeedbacksService.getAll([
+			'interviewer'
+		]);
+		if (res) {
+			this.allFeedbacks = res.items;
+		}
+		const { items } = await this.employeesService
+			.getAll(['user'])
+			.pipe(first())
+			.toPromise();
+		this.employeeList = items;
+		const interviews = await this.candidateInterviewService.getAll(
+			[
+				'feedbacks',
+				'interviewers',
+				'technologies',
+				'personalQualities',
+				'candidate'
+			],
 			{ candidateId: this.candidateId }
 		);
-		if (res) {
-			this.interviewList = res.items;
-			this.showPastCheckbox =
-				this.interviewList.length > 0 ? true : false;
-			this.loadEmployee();
+		if (interviews) {
+			this.interviewList = interviews.items;
+			this.allInterviews = interviews.items;
+			this.tableInterviewList = [];
+			this.interviewList.forEach((interview) => {
+				const employees = [];
+				interview.interviewers.forEach(
+					(interviewer: ICandidateInterviewers) => {
+						this.employeeList.forEach((employee: Employee) => {
+							if (interviewer.employeeId === employee.id) {
+								interviewer.employeeImageUrl =
+									employee.user.imageUrl;
+								interviewer.employeeName = employee.user.name;
+								employees.push(employee);
+							}
+						});
+					}
+				);
+				this.tableInterviewList.push({
+					...interview,
+					fullName: this.selectedCandidate.user.name,
+					imageUrl: this.selectedCandidate.user.imageUrl,
+					showArchive: false,
+					employees: employees,
+					allFeedbacks: this.allFeedbacks
+				});
+
+				if (interview.feedbacks.length > 0) {
+					const rate: number[] = [];
+					interview.feedbacks.forEach((fb) => {
+						rate.push(Number(fb.rating));
+					});
+					const fbSum = rate.reduce((sum, current) => {
+						return sum + current;
+					});
+					interview.rating = fbSum / interview.feedbacks.length;
+				} else {
+					interview.rating = 0;
+				}
+			});
 		}
+		this.interviewList = this.onlyPast
+			? this.filterInterviewByTime(this.interviewList, true)
+			: this.interviewList;
+
+		this.interviewList = this.onlyFuture
+			? this.filterInterviewByTime(this.interviewList, false)
+			: this.interviewList;
+
+		this.tableInterviewList = this.onlyPast
+			? this.filterInterviewByTime(this.tableInterviewList, true)
+			: this.tableInterviewList;
+
+		this.tableInterviewList = this.onlyFuture
+			? this.filterInterviewByTime(this.tableInterviewList, false)
+			: this.tableInterviewList;
+
+		this.sourceSmartTable.load(this.tableInterviewList);
+		this.loading = false;
 	}
 
 	async addInterviewFeedback(id: string) {
@@ -146,25 +342,6 @@ export class EditCandidateInterviewComponent extends TranslationBaseComponent
 		}
 	}
 
-	async loadEmployee() {
-		const { items } = await this.employeesService
-			.getAll(['user'])
-			.pipe(first())
-			.toPromise();
-		const employeeList = items;
-		for (const interview of this.interviewList) {
-			const employees = [];
-			interview.interviewers.forEach((interviewer) => {
-				employeeList.forEach((employee) => {
-					if (interviewer.employeeId === employee.id) {
-						employees.push(employee);
-					}
-				});
-			});
-			interview.employees = employees;
-			this.loading = false;
-		}
-	}
 	isPastInterview(interview: ICandidateInterview) {
 		const now = new Date().getTime();
 		if (new Date(interview.startTime).getTime() > now) {
@@ -173,18 +350,28 @@ export class EditCandidateInterviewComponent extends TranslationBaseComponent
 			return true;
 		}
 	}
-	changeHidePastInterviews(checked: boolean) {
-		const res = [];
-		if (checked) {
-			for (const item of this.interviewList) {
-				if (!this.isPastInterview(item)) {
-					res.push(item);
-				}
-			}
-			this.interviewList = res;
-		} else {
-			this.loadInterview();
+	changePast(checked: boolean) {
+		this.onlyPast = checked;
+		if (this.onlyFuture) {
+			this.onlyFuture = false;
 		}
+		this.loadInterview();
+	}
+	changeFuture(checked: boolean) {
+		this.onlyFuture = checked;
+		if (this.onlyPast) {
+			this.onlyPast = false;
+		}
+		this.loadInterview();
+	}
+	filterInterviewByTime(list: ICandidateInterview[], isPast: boolean) {
+		const now = new Date().getTime();
+		let res: ICandidateInterview[] = [];
+		return (res = list.filter((item) =>
+			isPast
+				? new Date(item.startTime).getTime() < now
+				: new Date(item.startTime).getTime() > now
+		));
 	}
 
 	async removeInterview(id: string) {
@@ -208,6 +395,11 @@ export class EditCandidateInterviewComponent extends TranslationBaseComponent
 			this.getTranslation('TOASTR.TITLE.SUCCESS'),
 			this.getTranslation(`TOASTR.MESSAGE.CANDIDATE_EDIT_${text}`)
 		);
+	}
+	_applyTranslationOnSmartTable() {
+		this.translateService.onLangChange.subscribe(() => {
+			this.loadSmartTable();
+		});
 	}
 	ngOnDestroy() {
 		this._ngDestroy$.next();

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-profile.component.html
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-profile.component.html
@@ -36,7 +36,7 @@
 		</div>
 		<div class="notification" (click)="interviewInfo()">
 			<nb-icon class="bell" icon="bell-outline"></nb-icon>
-			<div *ngIf="interviewList?.length > 0" class="exist"></div>
+			<div *ngIf="futureInterviews?.length > 0" class="exist"></div>
 		</div>
 	</nb-card-header>
 	<nb-card-body class="tabset">

--- a/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-profile.component.ts
+++ b/apps/gauzy/src/app/pages/candidates/edit-candidate/edit-candidate-profile/edit-candidate-profile.component.ts
@@ -36,6 +36,7 @@ export class EditCandidateProfileComponent extends TranslationBaseComponent
 	candidateName = 'Candidate';
 	tabs: any[];
 	interviewList: ICandidateInterview[];
+	futureInterviews: ICandidateInterview[];
 
 	constructor(
 		private route: ActivatedRoute,
@@ -102,13 +103,17 @@ export class EditCandidateProfileComponent extends TranslationBaseComponent
 
 		if (interviews) {
 			this.interviewList = interviews.items;
+			const now = new Date().getTime();
+			this.futureInterviews = this.interviewList.filter(
+				(item) => new Date(item.startTime).getTime() > now
+			);
 		}
 	}
 	async interviewInfo() {
-		if (this.interviewList.length > 0) {
+		if (this.futureInterviews.length > 0) {
 			this.dialogService.open(CandidateInterviewInfoComponent, {
 				context: {
-					interviewList: this.interviewList,
+					interviewList: this.futureInterviews,
 					selectedCandidate: this.selectedCandidate,
 					isSlider: true
 				}

--- a/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/interview-panel/interview-panel.component.html
+++ b/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/interview-panel/interview-panel.component.html
@@ -229,6 +229,11 @@
 							icon="message-square-outline"
 						></nb-icon
 						>{{ 'BUTTONS.LEAVE_FEEDBACK' | translate }}
+						<span *ngIf="isPastInterview(interview)" class="ml-1">
+							({{ interview.feedbacks.length }}/{{
+								interview.interviewers.length
+							}})
+						</span>
 					</button>
 				</div>
 			</nb-card-body>

--- a/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/interview-panel/interview-panel.component.html
+++ b/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/interview-panel/interview-panel.component.html
@@ -12,13 +12,25 @@
 
 		<div class="btn">
 			<nb-checkbox
+				(checkedChange)="changePast($event)"
+				status="warning"
+				class="mr-3"
+				[checked]="onlyPast"
+				>{{ 'FORM.CHECKBOXES.ONLY_PAST' | translate }}
+			</nb-checkbox>
+			<nb-checkbox
+				(checkedChange)="changeFuture($event)"
+				status="warning"
+				[checked]="onlyFuture"
+				class="mr-3"
+				>{{ 'FORM.CHECKBOXES.ONLY_FUTURE' | translate }}
+			</nb-checkbox>
+			<nb-checkbox
 				(checkedChange)="changeIncludeArchived($event)"
 				status="warning"
 				class="mr-3"
-				>{{
-					'FORM.CHECKBOXES.INCLUDE_ARCHIVED' | translate
-				}}</nb-checkbox
-			>
+				>{{ 'FORM.CHECKBOXES.INCLUDE_ARCHIVED' | translate }}
+			</nb-checkbox>
 			<ga-layout-selector
 				componentName="{{ viewComponentName }}"
 			></ga-layout-selector>

--- a/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/interview-panel/interview-panel.component.ts
+++ b/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/interview-panel/interview-panel.component.ts
@@ -216,12 +216,11 @@ export class InterviewPanelComponent extends TranslationBaseComponent
 	}
 	filterInterviewByTime(list: ICandidateInterview[], isPast: boolean) {
 		const now = new Date().getTime();
-		let res: ICandidateInterview[] = [];
-		return (res = list.filter((item) =>
+		return list.filter((item) =>
 			isPast
 				? new Date(item.startTime).getTime() < now
 				: new Date(item.startTime).getTime() > now
-		));
+		);
 	}
 
 	includeArchivedCheck(

--- a/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/interview-panel/table-components/actions/actions.component.ts
+++ b/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/interview-panel/table-components/actions/actions.component.ts
@@ -24,7 +24,10 @@ import { TranslateService } from '@ngx-translate/core';
 				>
 					{{ 'CANDIDATES_PAGE.MANAGE_INTERVIEWS.PAST' | translate }}
 				</div>
-				<div class="badge badge-warning" *ngIf="rowData.isArchived">
+				<div
+					class="badge badge-warning"
+					*ngIf="rowData.isArchived && rowData.showArchive"
+				>
 					{{ 'CANDIDATES_PAGE.ARCHIVED' | translate }}
 				</div>
 			</div>
@@ -77,6 +80,7 @@ import { TranslateService } from '@ngx-translate/core';
 					nbTooltip="{{
 						'CANDIDATES_PAGE.MANAGE_INTERVIEWS.ARCHIVE' | translate
 					}}"
+					*ngIf="rowData.showArchive"
 					nbTooltipPlacement="top"
 					icon="archive-outline"
 					class="icons ml-2"

--- a/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/interview-panel/table-components/actions/actions.component.ts
+++ b/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/interview-panel/table-components/actions/actions.component.ts
@@ -36,18 +36,27 @@ import { TranslateService } from '@ngx-translate/core';
 			</span>
 			<div class="btn">
 				<nb-icon
+					*ngIf="isPastInterview(rowData)"
 					(click)="addFeedback()"
 					nbTooltip="{{
 						'CANDIDATES_PAGE.MANAGE_INTERVIEWS.ADD_FEEDBACK'
 							| translate
-					}}"
+					}} 
+					({{ rowData.feedbacks.length }}/{{ rowData.interviewers.length }})"
 					nbTooltipPlacement="top"
 					icon="message-square-outline"
-					class="icons"
-					[ngClass]="{
-						enabled: isPastInterview(rowData),
-						disabled: !isPastInterview(rowData)
-					}"
+					class="icons enabled"
+				></nb-icon>
+				<nb-icon
+					*ngIf="!isPastInterview(rowData)"
+					(click)="addFeedback()"
+					nbTooltip="{{
+						'CANDIDATES_PAGE.MANAGE_INTERVIEWS.ADD_FEEDBACK'
+							| translate
+					}} "
+					nbTooltipPlacement="top"
+					icon="message-square-outline"
+					class="icons disabled"
 				></nb-icon>
 				<nb-icon
 					(click)="editInterview()"
@@ -126,9 +135,9 @@ import { TranslateService } from '@ngx-translate/core';
 			}
 			.enabled {
 				color: #222b45 !important;
-				&:focus {
-					transform: translateY(2px);
-				}
+			}
+			.icons:active {
+				transform: translateY(2px);
 			}
 			.disabled {
 				color: rgba(143, 155, 179, 0.48) !important;

--- a/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/interview-panel/table-components/interviewers/interviewers.component.ts
+++ b/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/interview-panel/table-components/interviewers/interviewers.component.ts
@@ -1,5 +1,11 @@
 import { Component, Input } from '@angular/core';
 import { ICandidateFeedback } from '@gauzy/models';
+import {
+	SelectedEmployee,
+	ALL_EMPLOYEES_SELECTED
+} from 'apps/gauzy/src/app/@theme/components/header/selectors/employee/employee.component';
+import { Store } from 'apps/gauzy/src/app/@core/services/store.service';
+import { Router } from '@angular/router';
 
 @Component({
 	selector: 'ga-interview-interviewers',
@@ -10,14 +16,23 @@ import { ICandidateFeedback } from '@gauzy/models';
 				nbTooltip=" {{ employee?.user?.name }}"
 				nbTooltipPlacement="top"
 			>
-				<img
-					class="image-employee"
-					[src]="employee?.user?.imageUrl"
-					alt="employee Avatar"
-					[ngClass]="{
-						active: isInterviewerActive(rowData.id, employee.id)
-					}"
-				/>
+				<a
+					*ngIf="employee.user"
+					(click)="
+						selectEmployee(
+							employee,
+							employee.user.firstName,
+							employee.user.lastName,
+							employee.user.imageUrl
+						)
+					"
+				>
+					<img
+						class="image-employee"
+						[src]="employee?.user?.imageUrl"
+						alt="employee Avatar"
+					/>
+				</a>
 			</span>
 		</div>
 	`,
@@ -35,12 +50,6 @@ import { ICandidateFeedback } from '@gauzy/models';
 				max-height: 30px;
 				border-radius: 50%;
 				margin: 0.25rem;
-				&:hover {
-					opacity: 1 !important;
-				}
-			}
-			.active {
-				opacity: 0.7 !important;
 			}
 		`
 	]
@@ -48,13 +57,21 @@ import { ICandidateFeedback } from '@gauzy/models';
 export class InterviewersTableComponent {
 	@Input()
 	rowData: any;
+	constructor(private store: Store, private readonly router: Router) {}
+	selectEmployee(
+		employee: SelectedEmployee,
+		firstName: string,
+		lastName: string,
+		imageUrl: string
+	) {
+		this.store.selectedEmployee = employee || ALL_EMPLOYEES_SELECTED;
+		this.store.selectedEmployee.firstName = firstName;
+		this.store.selectedEmployee.lastName = lastName;
+		this.store.selectedEmployee.imageUrl = imageUrl;
+		this.navigateToEmployeeStatistics(employee.id);
+	}
 
-	isInterviewerActive(interviewId: string, employeeId: string) {
-		return this.rowData.allFeedbacks.find(
-			(el: ICandidateFeedback) =>
-				el.interviewId === interviewId &&
-				el.interviewer &&
-				employeeId === el.interviewer.employeeId
-		);
+	navigateToEmployeeStatistics(id: string) {
+		this.router.navigate([`/pages/employees/edit/${id}/account`]);
 	}
 }

--- a/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/interview-panel/table-components/interviewers/interviewers.component.ts
+++ b/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/interview-panel/table-components/interviewers/interviewers.component.ts
@@ -67,7 +67,9 @@ export class InterviewersTableComponent {
 		this.store.selectedEmployee.firstName = firstName;
 		this.store.selectedEmployee.lastName = lastName;
 		this.store.selectedEmployee.imageUrl = imageUrl;
-		this.navigateToEmployeeStatistics(employee.id);
+		if (employee) {
+			this.navigateToEmployeeStatistics(employee.id);
+		}
 	}
 
 	navigateToEmployeeStatistics(id: string) {

--- a/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/interview-panel/table-components/interviewers/interviewers.component.ts
+++ b/apps/gauzy/src/app/pages/candidates/manage-candidate-interviews/interview-panel/table-components/interviewers/interviewers.component.ts
@@ -1,5 +1,4 @@
 import { Component, Input } from '@angular/core';
-import { ICandidateFeedback } from '@gauzy/models';
 import {
 	SelectedEmployee,
 	ALL_EMPLOYEES_SELECTED
@@ -10,7 +9,7 @@ import { Router } from '@angular/router';
 @Component({
 	selector: 'ga-interview-interviewers',
 	template: `
-		<div class="employee" *ngIf="rowData.employees.length > 0">
+		<div class="employee" *ngIf="rowData.employees?.length > 0">
 			<span
 				*ngFor="let employee of rowData.employees"
 				nbTooltip=" {{ employee?.user?.name }}"

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -382,7 +382,9 @@
 		},
 		"CHECKBOXES": {
 			"INCLUDE_DELETED": "Include Deleted",
-			"INCLUDE_ARCHIVED": "Include Archived"
+			"INCLUDE_ARCHIVED": "Include Archived",
+			"ONLY_PAST": "Only Past",
+			"ONLY_FUTURE": "Only Future"
 		},
 		"NOTIFICATIONS": {
 			"STARTED_WORK_ON": "It's required to enter the date when the employee started work to generate employee payroll, enable the employee to participate in split expenses, see employee statistics"


### PR DESCRIPTION
- in the candidate’s profile, the icon with a reminder of scheduled interviews now only shows future interviews
- on the interview page in the button for adding feedback displays the ratio of already received feedback to the number of interviewers, also added checkboxes to show only past / future interviews
- added table view for interviews in candidate profile

https://www.loom.com/share/0ee09edea94a4badabbcd56a493a6ff8