### PR TITLE
Feature:#2639-email-history-improvements

### DIFF
--- a/apps/api/src/app/email/email.controller.ts
+++ b/apps/api/src/app/email/email.controller.ts
@@ -1,4 +1,14 @@
-import { Controller, HttpStatus, Get, Query, UseGuards } from '@nestjs/common';
+import {
+	Controller,
+	HttpStatus,
+	Get,
+	Query,
+	UseGuards,
+	Body,
+	Param,
+	Put,
+	HttpCode
+} from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { CrudController } from '../core/crud/crud.controller';
@@ -30,11 +40,15 @@ export class EmailController extends CrudController<Email> {
 	async findAllEmails(
 		@Query('data', ParseJsonPipe) data: any
 	): Promise<IPagination<Email>> {
-		const { relations, findInput } = data;
+		const { relations, findInput, take } = data;
 
 		const response = await this.emailService.findAll({
 			where: findInput,
-			relations
+			relations,
+			order: {
+				createdAt: 'DESC'
+			},
+			take: take
 		});
 
 		response.items.forEach((email) => {
@@ -43,5 +57,25 @@ export class EmailController extends CrudController<Email> {
 		});
 
 		return response;
+	}
+
+	@ApiOperation({ summary: 'Update an existing record' })
+	@ApiResponse({
+		status: HttpStatus.CREATED,
+		description: 'The record has been successfully edited.'
+	})
+	@ApiResponse({
+		status: HttpStatus.NOT_FOUND,
+		description: 'Record not found'
+	})
+	@ApiResponse({
+		status: HttpStatus.BAD_REQUEST,
+		description:
+			'Invalid input, The response body may contain clues as to what went wrong'
+	})
+	@HttpCode(HttpStatus.ACCEPTED)
+	@Put(':id')
+	async update(@Param('id') id: string, @Body() entity: Email): Promise<any> {
+		return this.emailService.update(id, entity);
 	}
 }

--- a/apps/api/src/app/email/email.entity.ts
+++ b/apps/api/src/app/email/email.entity.ts
@@ -1,6 +1,6 @@
 import { IEmail, IEmailTemplate, IUser } from '@gauzy/models';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsBoolean, IsNotEmpty, IsString } from 'class-validator';
 import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
 import { EmailTemplate } from '../email-template/email-template.entity';
 import { User } from '../user/user.entity';
@@ -40,6 +40,11 @@ export class Email extends TenantOrganizationBase implements IEmail {
 	@IsNotEmpty()
 	@Column()
 	email: string;
+
+	@ApiPropertyOptional({ type: Boolean })
+	@IsBoolean()
+	@Column({ nullable: true })
+	isArchived?: boolean;
 
 	@ApiProperty({ type: User })
 	@ManyToOne((type) => User, {

--- a/apps/gauzy/src/app/@core/services/email.service.ts
+++ b/apps/gauzy/src/app/@core/services/email.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { IEmail, IEmailFindInput } from '@gauzy/models';
+import { IEmail, IEmailFindInput, IEmailUpdateInput } from '@gauzy/models';
 import { first } from 'rxjs/operators';
 
 @Injectable({
@@ -11,14 +11,22 @@ export class EmailService {
 
 	getAll(
 		relations?: string[],
-		findInput?: IEmailFindInput
+		findInput?: IEmailFindInput,
+		take?: number
 	): Promise<{ items: IEmail[]; total: number }> {
-		const data = JSON.stringify({ relations, findInput });
+		const data = JSON.stringify({ relations, findInput, take });
 
 		return this.http
 			.get<{ items: IEmail[]; total: number }>(`/api/email`, {
 				params: { data }
 			})
+			.pipe(first())
+			.toPromise();
+	}
+
+	update(id: string, updateInput: IEmailUpdateInput): Promise<any> {
+		return this.http
+			.put<IEmail>(`api/email/${id}`, updateInput)
 			.pipe(first())
 			.toPromise();
 	}

--- a/apps/gauzy/src/app/pages/settings/email-history/email-history.component.html
+++ b/apps/gauzy/src/app/pages/settings/email-history/email-history.component.html
@@ -1,5 +1,8 @@
 <nb-card>
 	<nb-card-header>
+		<h4 class="email-history-header">
+			{{ 'SETTINGS.EMAIL_HISTORY.HEADER' | translate }}
+		</h4>
 		<div class="filter">
 			<button
 				(click)="openFiltersDialog()"
@@ -7,8 +10,7 @@
 				status="primary"
 				size="small"
 			>
-				<nb-icon icon="plus-outline"></nb-icon>
-				Add Filter
+				{{ 'BUTTONS.FILTER' | translate }}
 				<span>
 					<nb-badge
 						*ngIf="this.filteredCount"
@@ -24,62 +26,93 @@
 	</nb-card-header>
 	<nb-card-body>
 		<div class="content-container">
-			<nb-list [nbSpinner]="loading">
+			<nb-list
+				[nbSpinner]="loading"
+				nbInfiniteList
+				[threshold]="20"
+				(bottomThreshold)="loadNext()"
+			>
 				<nb-list-item
 					(click)="selectEmail(email)"
 					*ngFor="let email of emails"
 				>
 					<div class="email-list-item">
-						<span
-							>From:
+						<div class="image-container">
+							<img
+								class="email-history-avatar"
+								[src]="getUrl(email.email)"
+							/>
+						</div>
+						<span>
+							{{ 'SETTINGS.EMAIL_HISTORY.FROM' | translate }}
 							<b>{{
 								email.user ? email.user.email : 'System'
-							}}</b></span
-						>
-						<span [title]="email.email"
-							>To: <b>{{ email.email }}</b></span
-						>
+							}}</b>
+						</span>
+						<span [title]="email.email">
+							{{ 'SETTINGS.EMAIL_HISTORY.TO' | translate }}
+							<b>{{ email.email }}</b>
+						</span>
+						<span [title]="email.email">
+							{{ 'SETTINGS.EMAIL_HISTORY.DATE' | translate }}
+							<b>{{ getEmailDate(email.createdAt) }}</b>
+						</span>
 					</div>
 				</nb-list-item>
 			</nb-list>
 			<div class="email-container">
 				<div class="email-details" *ngIf="selectedEmail">
-					<span
-						>From:
+					<span>
+						{{ 'SETTINGS.EMAIL_HISTORY.FROM' | translate }}
 						<b>{{
 							selectedEmail.user
 								? selectedEmail.user.email
 								: 'System'
-						}}</b></span
-					>
-					<span
-						>To: <b>{{ selectedEmail.email }}</b></span
-					>
-					<span
-						>Subject: <b>{{ selectedEmail.name }}</b></span
-					>
-					<span
-						>Language:
+						}}</b>
+					</span>
+					<span>
+						{{ 'SETTINGS.EMAIL_HISTORY.TO' | translate }}
+						<b>{{ selectedEmail.email }}</b>
+					</span>
+					<span>
+						{{ 'SETTINGS.EMAIL_HISTORY.SUBJECT' | translate }}
+						<b>{{ selectedEmail.name }}</b>
+					</span>
+					<span>
+						{{ 'SETTINGS.EMAIL_HISTORY.LANGUAGE' | translate }}
 						<b>{{
 							getEmailLanguageFullName(
 								selectedEmail.emailTemplate.languageCode
 							)
-						}}</b></span
-					>
-					<span
-						>Template:
+						}}</b>
+					</span>
+					<span>
+						{{ 'SETTINGS.EMAIL_HISTORY.TEMPLATE' | translate }}
 						<b>{{
 							selectedEmail.emailTemplate.name | titlecase
-						}}</b></span
-					>
+						}}</b>
+					</span>
 				</div>
+				<button
+					*ngIf="selectedEmail"
+					class="w-25 email-history-archive"
+					status="primary"
+					nbButton
+					(click)="archive()"
+				>
+					{{ 'SETTINGS.EMAIL_HISTORY.ARCHIVE' | translate }}
+				</button>
 				<div
 					[innerHTML]="selectedEmailHTML"
 					*ngIf="selectedEmail; else emailNotSelected"
 					class="email-content"
 				></div>
 				<ng-template #emailNotSelected>
-					<h2>Please select an email</h2>
+					<h2>
+						{{
+							'SETTINGS.EMAIL_HISTORY.NO_EMAILS_SENT' | translate
+						}}
+					</h2>
 				</ng-template>
 			</div>
 		</div>

--- a/apps/gauzy/src/app/pages/settings/email-history/email-history.component.scss
+++ b/apps/gauzy/src/app/pages/settings/email-history/email-history.component.scss
@@ -9,6 +9,23 @@
     text-align: center;
   }
 
+  .email-history {
+    &-header {
+      margin-bottom: 15px;
+    }
+
+    &-archive {
+      margin-top: 15px;
+    }
+
+    &-avatar {
+      max-width: 50px;
+      width: 50px;
+      height: 100%;
+      border-radius: 50%;
+    }
+  }
+
   .content-container {
     display: flex;
 

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -2595,5 +2595,19 @@
 	},
 	"SMS_GATEWAY_PAGE": {
 		"HEADER": "SMS Provider"
+	},
+	"SETTINGS": {
+		"EMAIL_HISTORY": {
+			"EMAIL_ARCHIVED": "Email Archived",
+			"ARCHIVE": "Archive",
+			"HEADER": "Email History",
+			"FROM": "From:",
+			"TO": "To:",
+			"DATE": "Date:",
+			"SUBJECT": "Subject:",
+			"LANGUAGE": "Language:",
+			"TEMPLATE": "Template:",
+			"NO_EMAILS_SENT": "No emails sent."
+		}
 	}
 }

--- a/libs/models/src/lib/email.model.ts
+++ b/libs/models/src/lib/email.model.ts
@@ -9,6 +9,16 @@ export interface IEmail extends IBasePerTenantAndOrganizationEntityModel {
 	emailTemplate: IEmailTemplate;
 	email: string;
 	user?: IUser;
+	isArchived?: boolean;
+}
+
+export interface IEmailUpdateInput {
+	name?: string;
+	content?: string;
+	emailTemplate?: IEmailTemplate;
+	email?: string;
+	user?: IUser;
+	isArchived?: boolean;
 }
 
 export interface IEmailFindInput
@@ -17,4 +27,5 @@ export interface IEmailFindInput
 	// TODO! Maybe user here
 	userId?: string;
 	email?: string;
+	isArchived?: boolean;
 }


### PR DESCRIPTION
The emails are now ordered chronologically.
The date of the email is now displayed below "To:".
The latest email is now selected by default.
After the filter is used and no emails are found "No emails sent" is displayed.
Added button "Archive".
When emails are archived they are no longer displayed.
Emails are now loaded in 10 at a time. To load more the user needs to scroll down the list.
Renamed "+ADD FILTER" button to "Filter"
Added "Email History" header.
Emails sent to employees and contacts have the avater of the employee/contact over them. Other emails have a default image over them.
The gauzy logo in the emails doesn't load because the src url is saved in the email content as {{host}}/assets/images/logos/logo_Gauzy.svg it should be /assets/images/logos/logo_Gauzy.svg but I'm not sure how to change that.

Video: https://www.loom.com/share/79bf8e93fca24de592faa47b6e26c637