### PR TITLE
Feature/#2679-add-networks-tab-to-employee

### DIFF
--- a/apps/api/src/app/employee/employee.entity.ts
+++ b/apps/api/src/app/employee/employee.entity.ts
@@ -287,4 +287,39 @@ export class Employee extends TenantOrganizationBase implements IEmployee {
 	@IsBoolean()
 	@Column({ nullable: true })
 	isJobSearchActive?: boolean;
+
+	@ApiPropertyOptional({ type: String })
+	@IsOptional()
+	@Column({ nullable: true })
+	linkedInUrl?: string;
+
+	@ApiPropertyOptional({ type: String })
+	@IsOptional()
+	@Column({ nullable: true })
+	facebookUrl?: string;
+
+	@ApiPropertyOptional({ type: String })
+	@IsOptional()
+	@Column({ nullable: true })
+	instagramUrl?: string;
+
+	@ApiPropertyOptional({ type: String })
+	@IsOptional()
+	@Column({ nullable: true })
+	twitterUrl?: string;
+
+	@ApiPropertyOptional({ type: String })
+	@IsOptional()
+	@Column({ nullable: true })
+	githubUrl?: string;
+
+	@ApiPropertyOptional({ type: String })
+	@IsOptional()
+	@Column({ nullable: true })
+	gitlabUrl?: string;
+
+	@ApiPropertyOptional({ type: String })
+	@IsOptional()
+	@Column({ nullable: true })
+	upworkUrl?: string;
 }

--- a/apps/gauzy/src/app/@shared/regex/regex-patterns.const.ts
+++ b/apps/gauzy/src/app/@shared/regex/regex-patterns.const.ts
@@ -1,0 +1,3 @@
+export const patterns = {
+	websiteUrl: /^((?:https?:\/\/)[^./]+(?:\.[^./]+)+(?:\/.*)?)$/
+};

--- a/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-networks/edit-employee-networks.component.html
+++ b/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-networks/edit-employee-networks.component.html
@@ -1,0 +1,143 @@
+<nb-card>
+	<nb-card-body>
+		<form [formGroup]="form">
+			<div class="row">
+				<div class="col-sm-3">
+					<div class="form-group">
+						<label class="label" for="linkedIn">{{
+							'FORM.LABELS.LINKEDIN' | translate
+						}}</label>
+						<input
+							fullWidth
+							id="linkedIn"
+							type="text"
+							nbInput
+							formControlName="linkedInUrl"
+							placeholder="{{
+								'FORM.PLACEHOLDERS.LINKEDIN' | translate
+							}}"
+						/>
+					</div>
+				</div>
+				<div class="col-sm-3">
+					<div class="form-group">
+						<label class="label" for="facebook">{{
+							'FORM.LABELS.FACEBOOK' | translate
+						}}</label>
+						<input
+							fullWidth
+							id="facebook"
+							type="text"
+							nbInput
+							formControlName="facebookUrl"
+							placeholder="{{
+								'FORM.PLACEHOLDERS.FACEBOOK' | translate
+							}}"
+						/>
+					</div>
+				</div>
+			</div>
+			<div class="row">
+				<div class="col-sm-3">
+					<div class="form-group">
+						<label class="label" for="instagram">{{
+							'FORM.LABELS.INSTAGRAM' | translate
+						}}</label>
+						<input
+							fullWidth
+							id="instagram"
+							type="text"
+							nbInput
+							formControlName="instagramUrl"
+							placeholder="{{
+								'FORM.PLACEHOLDERS.INSTAGRAM' | translate
+							}}"
+						/>
+					</div>
+				</div>
+				<div class="col-sm-3">
+					<div class="form-group">
+						<label class="label" for="twitter">{{
+							'FORM.LABELS.TWITTER' | translate
+						}}</label>
+						<input
+							fullWidth
+							id="twitter"
+							type="text"
+							nbInput
+							formControlName="twitterUrl"
+							placeholder="{{
+								'FORM.PLACEHOLDERS.TWITTER' | translate
+							}}"
+						/>
+					</div>
+				</div>
+			</div>
+			<div class="row">
+				<div class="col-sm-3">
+					<div class="form-group">
+						<label class="label" for="github">{{
+							'FORM.LABELS.GITHUB' | translate
+						}}</label>
+						<input
+							fullWidth
+							id="github"
+							type="text"
+							nbInput
+							formControlName="githubUrl"
+							placeholder="{{
+								'FORM.PLACEHOLDERS.GITHUB' | translate
+							}}"
+						/>
+					</div>
+				</div>
+				<div class="col-sm-3">
+					<div class="form-group">
+						<label class="label" for="gitlab">{{
+							'FORM.LABELS.GITLAB' | translate
+						}}</label>
+						<input
+							fullWidth
+							id="gitlab"
+							type="text"
+							nbInput
+							formControlName="gitlabUrl"
+							placeholder="{{
+								'FORM.PLACEHOLDERS.GITLAB' | translate
+							}}"
+						/>
+					</div>
+				</div>
+			</div>
+			<div class="row">
+				<div class="col-sm-3">
+					<div class="form-group">
+						<label class="label" for="upwork">{{
+							'FORM.LABELS.UPWORK' | translate
+						}}</label>
+						<input
+							fullWidth
+							id="upwork"
+							type="text"
+							nbInput
+							formControlName="upworkUrl"
+							placeholder="{{
+								'FORM.PLACEHOLDERS.UPWORK' | translate
+							}}"
+						/>
+					</div>
+				</div>
+			</div>
+			<div class="actions">
+				<button
+					[disabled]="form.invalid"
+					(click)="submitForm()"
+					nbButton
+					status="success"
+				>
+					{{ 'BUTTONS.SAVE' | translate }}
+				</button>
+			</div>
+		</form>
+	</nb-card-body>
+</nb-card>

--- a/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-networks/edit-employee-networks.component.ts
+++ b/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-networks/edit-employee-networks.component.ts
@@ -1,0 +1,101 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { IEmployee, IOrganization } from '@gauzy/models';
+import { EmployeesService } from 'apps/gauzy/src/app/@core/services';
+import { EmployeeStore } from 'apps/gauzy/src/app/@core/services/employee-store.service';
+import { Store } from 'apps/gauzy/src/app/@core/services/store.service';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { patterns } from 'apps/gauzy/src/app/@shared/regex/regex-patterns.const';
+
+@Component({
+	selector: 'ga-edit-employee-networks',
+	templateUrl: './edit-employee-networks.component.html',
+	styleUrls: [
+		'../../../../organizations/edit-organization/edit-organization-settings/edit-organization-main/edit-organization-main.component.scss'
+	]
+})
+export class EditEmployeeNetworksComponent implements OnInit {
+	private _ngDestroy$ = new Subject<void>();
+	form: FormGroup;
+	selectedEmployee: IEmployee;
+	selectedOrganization: IOrganization;
+
+	constructor(
+		private fb: FormBuilder,
+		private readonly store: Store,
+		private readonly employeeStore: EmployeeStore,
+		private readonly employeesService: EmployeesService
+	) {}
+
+	ngOnInit() {
+		this.employeeStore.selectedEmployee$
+			.pipe(takeUntil(this._ngDestroy$))
+			.subscribe(async (emp) => {
+				this.selectedEmployee = emp;
+				if (this.selectedEmployee) {
+					this._initializeForm(this.selectedEmployee);
+				}
+
+				this.store.selectedOrganization$
+					.pipe(takeUntil(this._ngDestroy$))
+					.subscribe((organization) => {
+						this.selectedOrganization = organization;
+					});
+			});
+	}
+
+	private _initializeForm(employee: IEmployee) {
+		this.form = this.fb.group({
+			linkedInUrl: [
+				employee.linkedInUrl,
+				Validators.compose([
+					Validators.pattern(new RegExp(patterns.websiteUrl))
+				])
+			],
+			facebookUrl: [
+				employee.facebookUrl,
+				Validators.compose([
+					Validators.pattern(new RegExp(patterns.websiteUrl))
+				])
+			],
+			instagramUrl: [
+				employee.instagramUrl,
+				Validators.compose([
+					Validators.pattern(new RegExp(patterns.websiteUrl))
+				])
+			],
+			twitterUrl: [
+				employee.twitterUrl,
+				Validators.compose([
+					Validators.pattern(new RegExp(patterns.websiteUrl))
+				])
+			],
+			githubUrl: [
+				employee.githubUrl,
+				Validators.compose([
+					Validators.pattern(new RegExp(patterns.websiteUrl))
+				])
+			],
+			gitlabUrl: [
+				employee.gitlabUrl,
+				Validators.compose([
+					Validators.pattern(new RegExp(patterns.websiteUrl))
+				])
+			],
+			upworkUrl: [
+				employee.upworkUrl,
+				Validators.compose([
+					Validators.pattern(new RegExp(patterns.websiteUrl))
+				])
+			]
+		});
+	}
+
+	async submitForm() {
+		await this.employeesService.update(
+			this.selectedEmployee.id,
+			this.form.value
+		);
+	}
+}

--- a/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-profile.component.ts
+++ b/apps/gauzy/src/app/pages/employees/edit-employee/edit-employee-profile/edit-employee-profile.component.ts
@@ -24,7 +24,8 @@ import { first, takeUntil } from 'rxjs/operators';
 	],
 	providers: [EmployeeStore]
 })
-export class EditEmployeeProfileComponent extends TranslationBaseComponent
+export class EditEmployeeProfileComponent
+	extends TranslationBaseComponent
 	implements OnInit, OnDestroy {
 	private _ngDestroy$ = new Subject<void>();
 	form: FormGroup;
@@ -87,6 +88,14 @@ export class EditEmployeeProfileComponent extends TranslationBaseComponent
 				icon: 'person-outline',
 				responsive: true,
 				route: this.getRoute('account')
+			},
+			{
+				title: this.getTranslation(
+					'EMPLOYEES_PAGE.EDIT_EMPLOYEE.NETWORKS'
+				),
+				icon: 'at-outline',
+				responsive: true,
+				route: this.getRoute('networks')
 			},
 			{
 				title: this.getTranslation(

--- a/apps/gauzy/src/app/pages/employees/employees-routing.module.ts
+++ b/apps/gauzy/src/app/pages/employees/employees-routing.module.ts
@@ -13,6 +13,7 @@ import { EditEmployeeHiringComponent } from './edit-employee/edit-employee-profi
 import { EditEmployeeLocationComponent } from './edit-employee/edit-employee-profile/edit-employee-location/edit-employee-location.component';
 import { EditEmployeeEmploymentComponent } from './edit-employee/edit-employee-profile/edit-employee-employment/edit-employee-employment.component';
 import { NgxPermissionsGuard } from 'ngx-permissions';
+import { EditEmployeeNetworksComponent } from './edit-employee/edit-employee-profile/edit-employee-networks/edit-employee-networks.component';
 
 export function redirectTo() {
 	return '/pages/dashboard';
@@ -49,6 +50,10 @@ const routes: Routes = [
 			{
 				path: 'account',
 				component: EditEmployeeMainComponent
+			},
+			{
+				path: 'networks',
+				component: EditEmployeeNetworksComponent
 			},
 			{
 				path: 'rates',

--- a/apps/gauzy/src/app/pages/employees/employees.module.ts
+++ b/apps/gauzy/src/app/pages/employees/employees.module.ts
@@ -59,6 +59,7 @@ import { EmployeeRatesModule } from '../../@shared/employee/employee-rates/emplo
 import { TableComponentsModule } from '../../@shared/table-components/table-components.module';
 import { SkillsService } from '../../@core/services/skills.service';
 import { CKEditorModule } from 'ng2-ckeditor';
+import { EditEmployeeNetworksComponent } from './edit-employee/edit-employee-profile/edit-employee-networks/edit-employee-networks.component';
 
 export function HttpLoaderFactory(http: HttpClient) {
 	return new TranslateHttpLoader(http, './assets/i18n/', '.json');
@@ -80,7 +81,8 @@ const COMPONENTS = [
 	EditEmployeeContactComponent,
 	EditEmployeeHiringComponent,
 	EditEmployeeLocationComponent,
-	EditEmployeeEmploymentComponent
+	EditEmployeeEmploymentComponent,
+	EditEmployeeNetworksComponent
 ];
 
 @NgModule({

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -269,6 +269,13 @@
 			"DISCOUNT_AFTER_TAX": "Discount after tax",
 			"APPLY_DISCOUNT_AFTER_TAX_FOR_INVOICES_AND_ESTIMATES": "Apply discount after tax for invoices and estimates",
 			"FIND_ADDRESS": "Find Address",
+			"LINKEDIN": "LinkedIn",
+			"FACEBOOK": "Facebook",
+			"INSTAGRAM": "Instagram",
+			"TWITTER": "Twitter",
+			"GITHUB": "Github",
+			"GITLAB": "Gitlab",
+			"UPWORK": "Upwork",
 			"COORDINATE": {
 				"TITLE": "COORDINATES",
 				"LATITUDE": "Latitude",
@@ -368,6 +375,13 @@
 			"OWNER": "Owner",
 			"TASK_VIEW_MODE": "Task view mode",
 			"SELECT_STATUS": "Select Status",
+			"LINKEDIN": "LinkedIn",
+			"FACEBOOK": "Facebook",
+			"INSTAGRAM": "Instagram",
+			"TWITTER": "Twitter",
+			"GITHUB": "Github",
+			"GITLAB": "Gitlab",
+			"UPWORK": "Upwork",
 			"ADD_EDUCATION": {
 				"SCHOOL_NAME": "School name",
 				"DEGREE": "Degree/Diploma",
@@ -842,7 +856,8 @@
 			"RATES": "Rates",
 			"PROJECTS": "Projects",
 			"CONTACTS": "Contacts",
-			"HIRING": "Hiring"
+			"HIRING": "Hiring",
+			"NETWORKS": "Networks"
 		},
 		"ADD_EMPLOYEES": {
 			"STEP_1": "Step 1",

--- a/libs/models/src/lib/employee.model.ts
+++ b/libs/models/src/lib/employee.model.ts
@@ -52,6 +52,13 @@ export interface IEmployee extends IBasePerTenantAndOrganizationEntityModel {
 	show_billrate?: boolean;
 	show_payperiod?: boolean;
 	isJobSearchActive?: boolean;
+	linkedInUrl?: string;
+	facebookUrl?: string;
+	instagramUrl?: string;
+	twitterUrl?: string;
+	githubUrl?: string;
+	gitlabUrl?: string;
+	upworkUrl?: string;
 }
 
 export type IEmployeeJobsStatisticsResponse = IEmployee &
@@ -90,6 +97,13 @@ export interface IEmployeeUpdateInput {
 	skills?: ISkill[];
 	isJobSearchActive?: boolean;
 	contact?: IContact;
+	linkedInUrl?: string;
+	facebookUrl?: string;
+	instagramUrl?: string;
+	twitterUrl?: string;
+	githubUrl?: string;
+	gitlabUrl?: string;
+	upworkUrl?: string;
 }
 
 export interface IEmployeeCreateInput


### PR DESCRIPTION
Added networks tab to employee.
User can now save different networks to employee (LinkedIn, Facebook, Github etc.).
Made a new file to save regex patterns.

Screenshot:
![employee-networks](https://user-images.githubusercontent.com/25152459/101634683-b6d2aa00-3a31-11eb-8f31-c64a47252278.PNG)
