### PR TITLE
Fix/#2675-direct-url-entry-when-only-one-event-type

### DIFF
--- a/apps/gauzy/src/app/share/public-appointments/public-appointments.component.html
+++ b/apps/gauzy/src/app/share/public-appointments/public-appointments.component.html
@@ -25,8 +25,13 @@
 			</div>
 		</div>
 
-		<div class="body-header">
+		<div class="body-header" *ngIf="eventTypesExist">
 			<h5>{{ 'PUBLIC_APPOINTMENTS.SELECT_EVENT_TYPES' | translate }}</h5>
+		</div>
+		<div class="body-header" *ngIf="!eventTypesExist">
+			<h5>
+				{{ 'PUBLIC_APPOINTMENTS.NO_ACTIVE_EVENT_TYpES' | translate }}
+			</h5>
 		</div>
 		<div>
 			<div class="row block-content" *ngFor="let eventType of eventTypes">

--- a/apps/gauzy/src/app/share/public-appointments/public-appointments.component.ts
+++ b/apps/gauzy/src/app/share/public-appointments/public-appointments.component.ts
@@ -24,6 +24,7 @@ export class PublicAppointmentsComponent
 	timeOff: ITimeOff[] = timeOff;
 	loading = true;
 	_selectedOrganizationId: string;
+	eventTypesExist: boolean;
 
 	constructor(
 		private router: Router,
@@ -68,7 +69,8 @@ export class PublicAppointmentsComponent
 			{
 				employee: {
 					id: this.employee.id
-				}
+				},
+				isActive: true
 			}
 		);
 
@@ -77,9 +79,20 @@ export class PublicAppointmentsComponent
 			items = (
 				await this.eventTypeService.getAll(['tags'], {
 					organizationId: this._selectedOrganizationId,
-					tenantId
+					tenantId,
+					isActive: true
 				})
 			).items;
+		}
+
+		if (items.length === 1) {
+			this.router.navigate([
+				`/share/employee/${this.employee.id}/${items[0].id}`
+			]);
+		}
+
+		if (items.length !== 0) {
+			this.eventTypesExist = true;
 		}
 
 		const eventTypesOrder = ['Minute(s)', 'Hour(s)', 'Day(s)'];

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -2665,7 +2665,8 @@
 		"CHANGE": "(Change)",
 		"SELECT_EMPLOYEE_ERROR": "Please select an employee.",
 		"EXPIRED_OR_CANCELLED": "**This appointment has expired or has been cancelled.",
-		"EMAIL_SENT": "**An email has been sent to the host as well as to all the participants for this meeting."
+		"EMAIL_SENT": "**An email has been sent to the host as well as to all the participants for this meeting.",
+		"NO_ACTIVE_EVENT_TYpES": "There are no active event types"
 	},
 	"EMAIL_TEMPLATES_PAGE": {
 		"HEADER": "Email Templates for {{ organizationName }}",


### PR DESCRIPTION
If the user enters url for booking an appointment for specific employee directly it will skip the selection page if there is only 1 active event type. Also if there are no active event types it will display "There are no active event types".
![no-active-event-types](https://user-images.githubusercontent.com/25152459/103522026-6dd01300-4e82-11eb-9b82-abd3c38ec25a.PNG)
