### PR TITLE
Fix/time-off-page-fixes

### DIFF
--- a/apps/api/src/app/time-off-request/time-off-request.module.ts
+++ b/apps/api/src/app/time-off-request/time-off-request.module.ts
@@ -11,6 +11,7 @@ import { RequestApproval } from '../request-approval/request-approval.entity';
 import { ApprovalPolicy } from '../approval-policy/approval-policy.entity';
 import { CqrsModule } from '@nestjs/cqrs';
 import { TenantModule } from '../tenant/tenant.module';
+import { CommandHandlers } from './commands/handlers';
 @Module({
 	imports: [
 		TypeOrmModule.forFeature([
@@ -25,7 +26,7 @@ import { TenantModule } from '../tenant/tenant.module';
 		TenantModule
 	],
 	controllers: [TimeOffRequestController],
-	providers: [TimeOffRequestService, UserService],
+	providers: [TimeOffRequestService, UserService, ...CommandHandlers],
 	exports: [TypeOrmModule]
 })
 export class TimeOffRequestModule {}

--- a/apps/gauzy/src/app/@core/services/time-off.service.ts
+++ b/apps/gauzy/src/app/@core/services/time-off.service.ts
@@ -7,8 +7,7 @@ import {
 	ITimeOffPolicyUpdateInput,
 	ITimeOffCreateInput,
 	ITimeOff,
-	ITimeOffFindInput,
-	ITimeOffUpdateInput
+	ITimeOffFindInput
 } from '@gauzy/models';
 import { Observable } from 'rxjs';
 

--- a/apps/gauzy/src/app/@core/services/time-off.service.ts
+++ b/apps/gauzy/src/app/@core/services/time-off.service.ts
@@ -69,11 +69,8 @@ export class TimeOffService {
 		);
 	}
 
-	updateRequestStatus(
-		id: string,
-		request: ITimeOffUpdateInput
-	): Observable<ITimeOff> {
-		return this.http.put(`/api/time-off-request/${id}`, request);
+	updateRequestStatus(id: string, action: string): Observable<ITimeOff> {
+		return this.http.put(`/api/time-off-request/${action}/${id}`, {});
 	}
 
 	deleteDaysOffRequest(id: string): Observable<ITimeOff> {

--- a/apps/gauzy/src/app/@shared/time-off/time-off-request-mutation/time-off-request-mutation.component.html
+++ b/apps/gauzy/src/app/@shared/time-off/time-off-request-mutation/time-off-request-mutation.component.html
@@ -96,6 +96,7 @@
 						'TIME_OFF_PAGE.POLICY.POLICY' | translate
 					}}</label>
 					<nb-select
+						[selected]="policy"
 						formControlName="policy"
 						(selectedChange)="onPolicySelected($event)"
 						fullWidth

--- a/apps/gauzy/src/app/@shared/time-off/time-off-request-mutation/time-off-request-mutation.component.ts
+++ b/apps/gauzy/src/app/@shared/time-off/time-off-request-mutation/time-off-request-mutation.component.ts
@@ -1,7 +1,13 @@
 import { Component, OnInit, ViewChild, Input } from '@angular/core';
 import { NbDialogRef } from '@nebular/theme';
 import * as Holidays from 'date-holidays';
-import { IEmployee, ITimeOffPolicy, ITimeOff } from '@gauzy/models';
+import {
+	IEmployee,
+	ITimeOffPolicy,
+	ITimeOff,
+	IOrganization,
+	IUser
+} from '@gauzy/models';
 import { EmployeeSelectorComponent } from '../../../@theme/components/header/selectors/employee/employee.component';
 import { Store } from '../../../@core/services/store.service';
 import { TimeOffService } from '../../../@core/services/time-off.service';
@@ -11,6 +17,7 @@ import { EmployeesService } from '../../../@core/services';
 import { OrganizationDocumentsService } from '../../../@core/services/organization-documents.service';
 import * as moment from 'moment';
 import { ToastrService } from '../../../@core/services/toastr.service';
+import { OrganizationsService } from '../../../@core/services/organizations.service';
 @Component({
 	selector: 'ngx-time-off-request-mutation',
 	templateUrl: './time-off-request-mutation.component.html',
@@ -24,7 +31,8 @@ export class TimeOffRequestMutationComponent implements OnInit {
 		private timeOffService: TimeOffService,
 		private employeesService: EmployeesService,
 		private documentsService: OrganizationDocumentsService,
-		private store: Store
+		private store: Store,
+		private organizationService: OrganizationsService
 	) {}
 
 	@ViewChild('employeeSelector')
@@ -54,44 +62,39 @@ export class TimeOffRequestMutationComponent implements OnInit {
 	isHoliday = false;
 	isEditMode = false;
 	minDate = new Date(moment().format('YYYY-MM-DD'));
+	organization: IOrganization;
+	organizationCountryCode: string;
+	currentUserCountryCode: string;
+	employeeIds: string[];
 
 	ngOnInit() {
-		if (this.type === 'holiday') {
-			this.isHoliday = true;
-			this._getAllHolidays();
-		} else if (this.type.hasOwnProperty('id')) {
-			this.isEditMode = true;
-			this.selectedEmployee = this.type['employees'][0];
-			this.policy = this.type['policy'];
-			this.startDate = this.type['start'];
-			this.endDate = this.type['end'];
-			this.description = this.type['description'];
-			this.employeesArr = this.type['employees'];
-		}
-
 		this._initializeForm();
 	}
 
 	private async _getAllHolidays() {
 		const holidays = new Holidays();
 		const currentMoment = new Date();
+		const countryCode = this.currentUserCountryCode
+			? this.currentUserCountryCode
+			: this.organizationCountryCode;
 
-		fetch('https://extreme-ip-lookup.com/json/')
-			.then((res) => res.json())
-			.then((response) => {
-				holidays.init(response.countryCode);
-				this.holidays = holidays
-					.getHolidays(currentMoment.getFullYear())
-					.filter((holiday) => holiday.type === 'public');
-			})
-			.catch(() => {
-				this.toastrService.danger('TOASTR.MESSAGE.HOLIDAY_ERROR');
-			});
+		if (countryCode) {
+			holidays.init(countryCode);
+			this.holidays = holidays
+				.getHolidays(currentMoment.getFullYear())
+				.filter((holiday) => holiday.type === 'public');
+		} else {
+			this.toastrService.danger('TOASTR.MESSAGE.HOLIDAY_ERROR');
+		}
 	}
 
 	private async _initializeForm() {
 		await this._getFormData();
 
+		this.setForm();
+	}
+
+	setForm() {
 		this.form = this.fb.group({
 			description: [this.description],
 			start: [this.startDate, Validators.required],
@@ -133,6 +136,10 @@ export class TimeOffRequestMutationComponent implements OnInit {
 
 	addHolidays() {
 		this._checkFormData();
+		this.employeeIds.forEach((element) => {
+			const employee = this.orgEmployees.find((e) => e.id === element);
+			this.employeesArr.push(employee);
+		});
 		this._createNewRecord();
 	}
 
@@ -173,6 +180,39 @@ export class TimeOffRequestMutationComponent implements OnInit {
 		this.organizationId = this.store.selectedOrganization.id;
 		this.tenantId = this.store.selectedOrganization.tenantId;
 
+		const { items } = await this.organizationService.getAll(['contact'], {
+			id: this.organizationId,
+			tenantId: this.tenantId
+		});
+		this.organization = items[0];
+
+		if (this.organization.contact) {
+			this.organizationCountryCode = this.organization.contact.country;
+		}
+
+		if (this.store.user.employeeId) {
+			this.employeesService
+				.getEmployeeById(this.store.user.employeeId, ['contact'])
+				.then((data) => {
+					if (data.contact) {
+						this.currentUserCountryCode = data.contact.country;
+					}
+				});
+		}
+
+		if (this.type === 'holiday') {
+			this.isHoliday = true;
+			this._getAllHolidays();
+		} else if (this.type.hasOwnProperty('id')) {
+			this.isEditMode = true;
+			this.selectedEmployee = this.type['employees'][0];
+			this.policy = this.type['policy'];
+			this.startDate = this.type['start'];
+			this.endDate = this.type['end'];
+			this.description = this.type['description'];
+			this.employeesArr = this.type['employees'];
+		}
+
 		this._getPolicies();
 		this._getOrganizationEmployees();
 	}
@@ -191,7 +231,7 @@ export class TimeOffRequestMutationComponent implements OnInit {
 				.pipe(first())
 				.subscribe((res) => {
 					this.policies = res.items;
-					this.policy = this.policies[res.items.length - 1];
+					this.policy = this.policies[0];
 				});
 		}
 	}
@@ -214,8 +254,8 @@ export class TimeOffRequestMutationComponent implements OnInit {
 		this.policy = policy;
 	}
 
-	onEmployeesSelected(employees: IEmployee[]) {
-		this.employeesArr = employees;
+	onEmployeesSelected(employees: string[]) {
+		this.employeeIds = employees;
 	}
 
 	onHolidaySelected(holiday) {
@@ -223,7 +263,7 @@ export class TimeOffRequestMutationComponent implements OnInit {
 		this.endDate = holiday.end || null;
 		this.description = holiday.name;
 
-		this._initializeForm();
+		this.setForm();
 	}
 
 	close() {

--- a/apps/gauzy/src/app/@shared/time-off/time-off-request-mutation/time-off-request-mutation.component.ts
+++ b/apps/gauzy/src/app/@shared/time-off/time-off-request-mutation/time-off-request-mutation.component.ts
@@ -5,8 +5,7 @@ import {
 	IEmployee,
 	ITimeOffPolicy,
 	ITimeOff,
-	IOrganization,
-	IUser
+	IOrganization
 } from '@gauzy/models';
 import { EmployeeSelectorComponent } from '../../../@theme/components/header/selectors/employee/employee.component';
 import { Store } from '../../../@core/services/store.service';

--- a/apps/gauzy/src/app/pages/time-off/time-off.component.ts
+++ b/apps/gauzy/src/app/pages/time-off/time-off.component.ts
@@ -230,9 +230,7 @@ export class TimeOffComponent
 			const requestId = this.selectedTimeOffRecord.id;
 			this.selectedTimeOffRecord.status = 'Approved';
 			this.timeOffService
-				.updateRequestStatus(requestId, {
-					status: this.selectedTimeOffRecord.status
-				})
+				.updateRequestStatus(requestId, 'approval')
 				.pipe(untilDestroyed(this), first())
 				.subscribe(
 					() => {
@@ -267,9 +265,7 @@ export class TimeOffComponent
 			const requestId = this.selectedTimeOffRecord.id;
 			this.selectedTimeOffRecord.status = 'Denied';
 			this.timeOffService
-				.updateRequestStatus(requestId, {
-					status: this.selectedTimeOffRecord.status
-				})
+				.updateRequestStatus(requestId, 'denied')
 				.pipe(untilDestroyed(this), first())
 				.subscribe(
 					() => {


### PR DESCRIPTION
The default policy is now selected by default in the Request Time Off and Add Holidays dialogs.
Fixed an issue causing an error to show up entering the Add Holidays dialog.
The holidays are now gotten by using the country code of the current user if they are an employee or the country code of the current organization if they are not an employee or don't have a country set.
If the current organization does not have a country set an error message "Unable to get holidays" will be displayed.
Fixed an issue causing the selected policy to be reset when selecting a holiday.
Fixed an issue causing the selected employees to not be saved when adding a holiday.
Fixed an issue that caused an error when trying to approve or deny a request.

Video: https://www.loom.com/share/f1e86b48e59b491da853e3b4c0135b6d