### PR TITLE
Feature/#2801 demo login credentials

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -16,6 +16,7 @@ FacebookClientId=
 FacebookClientSecret=
 INTEGRATED_HUBSTAFF_USER_PASS=hubstaffPassword
 UPWORK_CALLBACK_URL=http://localhost:4200/#/pages/integrations/upwork
+DEMO=false
 
 # File System
 FILE_PROVIDER=

--- a/.scripts/configure.ts
+++ b/.scripts/configure.ts
@@ -73,7 +73,8 @@ export const environment: Environment = {
   GOOGLE_PLACE_AUTOCOMPLETE: ${env.GOOGLE_PLACE_AUTOCOMPLETE},
   DEFAULT_LATITUDE: ${env.DEFAULT_LATITUDE},
   DEFAULT_LONGITUDE: ${env.DEFAULT_LONGITUDE},
-  DEFAULT_CURRENCY: '${env.DEFAULT_CURRENCY}'
+  DEFAULT_CURRENCY: '${env.DEFAULT_CURRENCY}',
+  DEMO: ${env.DEMO}
 };
 
 export const cloudinaryConfiguration: CloudinaryConfiguration = {

--- a/.scripts/env.ts
+++ b/.scripts/env.ts
@@ -13,6 +13,7 @@ export type Env = Readonly<{
 	DEFAULT_LATITUDE: number;
 	DEFAULT_LONGITUDE: number;
 	DEFAULT_CURRENCY: string;
+	DEMO: boolean;
 }>;
 
 export const env: Env = cleanEnv(
@@ -26,7 +27,8 @@ export const env: Env = cleanEnv(
 		SENTRY_DSN: str({ default: '' }),
 		DEFAULT_LATITUDE: num({ default: 42.6459136 }),
 		DEFAULT_LONGITUDE: num({ default: 23.3332736 }),
-		DEFAULT_CURRENCY: str({ default: 'USD' })
+		DEFAULT_CURRENCY: str({ default: 'USD' }),
+		DEMO: bool({ default: false })
 	},
 	{ strict: true, dotEnvPath: __dirname + '/../.env' }
 );

--- a/apps/gauzy/src/app/auth/auth-routing.module.ts
+++ b/apps/gauzy/src/app/auth/auth-routing.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { NbAuthComponent } from '@nebular/auth';
+import { NgxLoginComponent } from './login/login.component';
 import { NgxRegisterComponent } from './register/register.component';
 
 export const routes: Routes = [
@@ -11,6 +12,10 @@ export const routes: Routes = [
 			{
 				path: 'register',
 				component: NgxRegisterComponent
+			},
+			{
+				path: 'login',
+				component: NgxLoginComponent
 			}
 		]
 	}

--- a/apps/gauzy/src/app/auth/auth.module.ts
+++ b/apps/gauzy/src/app/auth/auth.module.ts
@@ -8,11 +8,13 @@ import { NbAuthModule } from '@nebular/auth';
 import {
 	NbAlertModule,
 	NbButtonModule,
+	NbCardModule,
 	NbCheckboxModule,
 	NbIconModule,
 	NbInputModule
 } from '@nebular/theme';
 import { NgxRegisterComponent } from './register/register.component';
+import { NgxLoginComponent } from './login/login.component';
 
 @NgModule({
 	imports: [
@@ -25,8 +27,9 @@ import { NgxRegisterComponent } from './register/register.component';
 		NbCheckboxModule,
 		NgxAuthRoutingModule,
 		NbAuthModule,
-		NbIconModule
+		NbIconModule,
+		NbCardModule
 	],
-	declarations: [NgxRegisterComponent]
+	declarations: [NgxRegisterComponent, NgxLoginComponent]
 })
 export class NgxAuthModule {}

--- a/apps/gauzy/src/app/auth/login/login.component.html
+++ b/apps/gauzy/src/app/auth/login/login.component.html
@@ -1,0 +1,186 @@
+<h1 id="title" class="title">Login</h1>
+<p class="sub-title">Hello! Log in with your email.</p>
+
+<nb-alert
+	*ngIf="showMessages.error && errors?.length && !submitted"
+	outline="danger"
+	role="alert"
+>
+	<p class="alert-title"><b>Oh snap!</b></p>
+	<ul class="alert-message-list">
+		<li *ngFor="let error of errors" class="alert-message">{{ error }}</li>
+	</ul>
+</nb-alert>
+
+<nb-alert
+	*ngIf="showMessages.success && messages?.length && !submitted"
+	outline="success"
+	role="alert"
+>
+	<p class="alert-title"><b>Hooray!</b></p>
+	<ul class="alert-message-list">
+		<li *ngFor="let message of messages" class="alert-message">
+			{{ message }}
+		</li>
+	</ul>
+</nb-alert>
+<form (ngSubmit)="login()" #form="ngForm" aria-labelledby="title">
+	<div class="form-control-group">
+		<label class="label" for="input-email">Email address:</label>
+		<input
+			nbInput
+			fullWidth
+			[(ngModel)]="user.email"
+			#email="ngModel"
+			name="email"
+			id="input-email"
+			pattern=".+@.+\..+"
+			placeholder="Email address"
+			fieldSize="large"
+			autofocus
+			[status]="
+				email.dirty ? (email.invalid ? 'danger' : 'success') : 'basic'
+			"
+			[required]="getConfigValue('forms.validation.email.required')"
+			[attr.aria-invalid]="email.invalid && email.touched ? true : null"
+		/>
+		<ng-container *ngIf="email.invalid && email.touched">
+			<p class="caption status-danger" *ngIf="email.errors?.required">
+				Email is required!
+			</p>
+			<p class="caption status-danger" *ngIf="email.errors?.pattern">
+				Email should be the real one!
+			</p>
+		</ng-container>
+	</div>
+
+	<div class="form-control-group">
+		<span class="label-with-link">
+			<label class="label" for="input-password">Password:</label>
+			<a
+				class="forgot-password caption-2"
+				routerLink="../request-password"
+				>Forgot Password?</a
+			>
+		</span>
+		<input
+			nbInput
+			fullWidth
+			[(ngModel)]="user.password"
+			#password="ngModel"
+			name="password"
+			type="password"
+			id="input-password"
+			placeholder="Password"
+			fieldSize="large"
+			[status]="
+				password.dirty
+					? password.invalid
+						? 'danger'
+						: 'success'
+					: 'basic'
+			"
+			[required]="getConfigValue('forms.validation.password.required')"
+			[minlength]="getConfigValue('forms.validation.password.minLength')"
+			[maxlength]="getConfigValue('forms.validation.password.maxLength')"
+			[attr.aria-invalid]="
+				password.invalid && password.touched ? true : null
+			"
+		/>
+		<ng-container *ngIf="password.invalid && password.touched">
+			<p class="caption status-danger" *ngIf="password.errors?.required">
+				Password is required!
+			</p>
+			<p
+				class="caption status-danger"
+				*ngIf="password.errors?.minlength || password.errors?.maxlength"
+			>
+				Password should contain from
+				{{ getConfigValue('forms.validation.password.minLength') }} to
+				{{ getConfigValue('forms.validation.password.maxLength') }}
+				characters
+			</p>
+		</ng-container>
+	</div>
+
+	<div class="form-control-group accept-group">
+		<nb-checkbox
+			name="rememberMe"
+			[(ngModel)]="user.rememberMe"
+			*ngIf="rememberMe"
+			>Remember me</nb-checkbox
+		>
+	</div>
+
+	<button
+		nbButton
+		fullWidth
+		status="primary"
+		size="large"
+		[disabled]="submitted || !form.valid"
+		[class.btn-pulse]="submitted"
+	>
+		Log In
+	</button>
+</form>
+
+<div *ngIf="environment.DEMO" class="demo-credentials-card">
+	<nb-card>
+		<nb-card-body>
+			<div>Demo Credentials</div>
+			<br />
+			<div>- User with "Super Admin" Role</div>
+			<br />
+			<div>Email: admin@ever.co</div>
+			<div>Password: admin</div>
+			<br />
+			<div>- "Employee" user</div>
+			<br />
+			<div>Email: ruslan@ever.co</div>
+			<div>Password: 123456</div>
+		</nb-card-body>
+	</nb-card>
+</div>
+
+<section
+	*ngIf="socialLinks && socialLinks.length > 0"
+	class="links"
+	aria-label="Social sign in"
+>
+	or enter with:
+	<div class="socials">
+		<ng-container *ngFor="let socialLink of socialLinks">
+			<a
+				*ngIf="socialLink.link"
+				[routerLink]="socialLink.link"
+				[attr.target]="socialLink.target"
+				[attr.class]="socialLink.icon"
+				[class.with-icon]="socialLink.icon"
+			>
+				<nb-icon
+					*ngIf="socialLink.icon; else title"
+					[icon]="socialLink.icon"
+				></nb-icon>
+				<ng-template #title>{{ socialLink.title }}</ng-template>
+			</a>
+			<a
+				*ngIf="socialLink.url"
+				[attr.href]="socialLink.url"
+				[attr.target]="socialLink.target"
+				[attr.class]="socialLink.icon"
+				[class.with-icon]="socialLink.icon"
+			>
+				<nb-icon
+					*ngIf="socialLink.icon; else title"
+					[icon]="socialLink.icon"
+				></nb-icon>
+				<ng-template #title>{{ socialLink.title }}</ng-template>
+			</a>
+		</ng-container>
+	</div>
+</section>
+
+<section class="another-action" aria-label="Register">
+	Don't have an account?
+	<a class="text-link" routerLink="../register">Register</a>
+</section>

--- a/apps/gauzy/src/app/auth/login/login.component.scss
+++ b/apps/gauzy/src/app/auth/login/login.component.scss
@@ -1,0 +1,5 @@
+.demo-credentials-card {
+  position: absolute;
+  top: 150px;
+  right: 75px;
+}

--- a/apps/gauzy/src/app/auth/login/login.component.ts
+++ b/apps/gauzy/src/app/auth/login/login.component.ts
@@ -1,0 +1,19 @@
+import { Component, OnInit } from '@angular/core';
+import { NbLoginComponent } from '@nebular/auth';
+import { environment } from 'apps/gauzy/src/environments/environment';
+
+@Component({
+	selector: 'ngx-login',
+	templateUrl: './login.component.html',
+	styleUrls: ['./login.component.scss']
+})
+export class NgxLoginComponent extends NbLoginComponent implements OnInit {
+	environment = environment;
+
+	ngOnInit() {
+		if (this.environment.DEMO) {
+			this.user.email = 'admin@ever.co';
+			this.user.password = 'admin';
+		}
+	}
+}

--- a/apps/gauzy/src/environments/model.ts
+++ b/apps/gauzy/src/environments/model.ts
@@ -31,4 +31,6 @@ export interface Environment {
 	DEFAULT_CURRENCY: string;
 
 	IS_INTEGRATED_DESKTOP: boolean;
+
+	DEMO: boolean;
 }


### PR DESCRIPTION
Added environment variable "DEMO" that is set to false by default.
When DEMO is set to true there is a card shown on the login page that dispays default login credentials and the email is set to "admin@ever.co" and password to "admin" by default.
Added DEMO=false to the .env.sample file in the root of mono-repo.

![login-demo-credentials](https://user-images.githubusercontent.com/25152459/104912944-a0573100-5995-11eb-83f4-f3001746fe97.png)
