### PR TITLE
Feature/permalink-for-invoices-and-estimates

### DIFF
--- a/apps/api/src/app/invoice/commands/handlers/invoice.generate.link.handler.ts
+++ b/apps/api/src/app/invoice/commands/handlers/invoice.generate.link.handler.ts
@@ -1,0 +1,17 @@
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+import { InvoiceService } from '../../invoice.service';
+import { InvoiceGenerateLinkCommand } from '../invoice.generate.link.command';
+
+@CommandHandler(InvoiceGenerateLinkCommand)
+export class InvoiceGenerateLinkHandler
+	implements ICommandHandler<InvoiceGenerateLinkCommand> {
+	constructor(private readonly invoiceService: InvoiceService) {}
+
+	public async execute(command: InvoiceGenerateLinkCommand): Promise<any> {
+		const { invoiceId, isEstimate } = command;
+		return this.invoiceService.generateLink(
+			invoiceId,
+			isEstimate.isEstimate
+		);
+	}
+}

--- a/apps/api/src/app/invoice/commands/index.ts
+++ b/apps/api/src/app/invoice/commands/index.ts
@@ -1,5 +1,6 @@
 import { InvoiceCreateHandler } from './handlers/invoice.create.handler';
 import { InvoiceDeleteHandler } from './handlers/invoice.delete.handler';
+import { InvoiceGenerateLinkHandler } from './handlers/invoice.generate.link.handler';
 import { InvoiceSendEmailHandler } from './handlers/invoice.send.email.handler';
 import { InvoiceUpdateHandler } from './handlers/invoice.update.handler';
 
@@ -7,10 +8,12 @@ export { InvoiceCreateCommand } from './invoice.create.command';
 export { InvoiceDeleteCommand } from './invoice.delete.command';
 export { InvoiceSendEmailCommand } from './invoice.send.email.command';
 export { InvoiceUpdateCommand } from './invoice.update.command';
+export { InvoiceGenerateLinkCommand } from './invoice.generate.link.command';
 
 export const CommandHandlers = [
 	InvoiceCreateHandler,
 	InvoiceUpdateHandler,
 	InvoiceSendEmailHandler,
-	InvoiceDeleteHandler
+	InvoiceDeleteHandler,
+	InvoiceGenerateLinkHandler
 ];

--- a/apps/api/src/app/invoice/commands/invoice.generate.link.command.ts
+++ b/apps/api/src/app/invoice/commands/invoice.generate.link.command.ts
@@ -1,0 +1,10 @@
+import { ICommand } from '@nestjs/cqrs';
+
+export class InvoiceGenerateLinkCommand implements ICommand {
+	static readonly type = '[Invoice] Generate Link';
+
+	constructor(
+		public readonly invoiceId: string,
+		public readonly isEstimate: any
+	) {}
+}

--- a/apps/api/src/app/invoice/invoice.entity.ts
+++ b/apps/api/src/app/invoice/invoice.entity.ts
@@ -165,6 +165,18 @@ export class Invoice extends TenantOrganizationBase implements IInvoice {
 	@Column({ nullable: true })
 	hasRemainingAmountInvoiced?: boolean;
 
+	@ApiPropertyOptional({ type: String })
+	@IsString()
+	@IsOptional()
+	@Column({ nullable: true })
+	publicLink?: string;
+
+	@ApiPropertyOptional({ type: String })
+	@IsString()
+	@IsOptional()
+	@Column({ nullable: true })
+	token?: string;
+
 	@ApiPropertyOptional({ type: Organization })
 	@ManyToOne((type) => Organization)
 	@JoinColumn()

--- a/apps/api/src/app/invoice/invoice.service.ts
+++ b/apps/api/src/app/invoice/invoice.service.ts
@@ -61,6 +61,18 @@ export class InvoiceService extends CrudService<Invoice> {
 		);
 	}
 
+	async generateLink(invoiceId: string, isEstimate: boolean) {
+		const token = this.createToken(invoiceId);
+		const result = `localhost:4200/#/share/${
+			isEstimate ? 'estimates' : 'invoices'
+		}/${invoiceId}/${token}`;
+		await this.invoiceRepository.update(invoiceId, {
+			token: token,
+			publicLink: result
+		});
+		return await this.invoiceRepository.findOne(invoiceId);
+	}
+
 	createToken(email): string {
 		const token: string = sign({ email }, env.JWT_SECRET, {});
 		return token;

--- a/apps/gauzy/src/app/@core/services/invoices.service.ts
+++ b/apps/gauzy/src/app/@core/services/invoices.service.ts
@@ -49,6 +49,16 @@ export class InvoicesService {
 			.toPromise();
 	}
 
+	getWithoutAuth(id: string, token: string, relations?: string[]) {
+		const data = JSON.stringify({ relations });
+		return this.http
+			.get<IInvoice>(`/api/invoices/public/${id}/${token}`, {
+				params: { data }
+			})
+			.pipe(first())
+			.toPromise();
+	}
+
 	add(invoice: IInvoiceCreateInput): Promise<IInvoice> {
 		return this.http
 			.post<IInvoice>('/api/invoices', invoice)
@@ -76,6 +86,17 @@ export class InvoicesService {
 	edit(invoice: IInvoice): Promise<IInvoice> {
 		return this.http
 			.put<IInvoice>(`/api/invoices/${invoice.id}`, invoice)
+			.pipe(first())
+			.toPromise();
+	}
+
+	generateLink(id: string, isEstimate: boolean): Promise<any> {
+		return this.http
+			.put<any>(`/api/invoices/generate/${id}`, {
+				params: {
+					isEstimate
+				}
+			})
 			.pipe(first())
 			.toPromise();
 	}

--- a/apps/gauzy/src/app/pages/invoices/invoices.component.html
+++ b/apps/gauzy/src/app/pages/invoices/invoices.component.html
@@ -559,6 +559,18 @@
 	<button
 		*ngIf="dataLayoutStyle === 'TABLE'"
 		nbButton
+		status="info"
+		(click)="generatePublicLink(selectedItem)"
+		class="mr-2"
+		[size]="buttonSize || 'medium'"
+		[disabled]="!selectedItem && disableButton"
+	>
+		<nb-icon class="mr-1" icon="link-2-outline"> </nb-icon>
+		{{ 'BUTTONS.PUBLIC_LINK' | translate }}
+	</button>
+	<button
+		*ngIf="dataLayoutStyle === 'TABLE'"
+		nbButton
 		status="danger"
 		(click)="delete(selectedItem)"
 		class="mr-2"

--- a/apps/gauzy/src/app/pages/invoices/invoices.component.ts
+++ b/apps/gauzy/src/app/pages/invoices/invoices.component.ts
@@ -45,6 +45,7 @@ import { NgxPermissionsService } from 'ngx-permissions';
 import { AddInternalNoteComponent } from './add-internal-note/add-internal-note.component';
 import { ToastrService } from '../../@core/services/toastr.service';
 import { saveAs } from 'file-saver';
+import { PublicLinkComponent } from './public-link/public-link.component';
 
 @UntilDestroy({ checkProperties: true })
 @Component({
@@ -638,6 +639,20 @@ export class InvoicesComponent
 		var blob = new Blob([csvArray], { type: 'text/csv;charset=utf-8' });
 
 		saveAs(blob, `${fileName}-${this.selectedInvoice.invoiceNumber}.csv`);
+	}
+
+	async generatePublicLink(selectedItem) {
+		if (selectedItem) {
+			this.selectInvoice({
+				isSelected: true,
+				data: selectedItem
+			});
+		}
+		this.dialogService.open(PublicLinkComponent, {
+			context: {
+				invoice: this.selectedInvoice
+			}
+		});
 	}
 
 	async loadSettings() {

--- a/apps/gauzy/src/app/pages/invoices/invoices.module.ts
+++ b/apps/gauzy/src/app/pages/invoices/invoices.module.ts
@@ -72,6 +72,7 @@ import { AddInternalNoteComponent } from './add-internal-note/add-internal-note.
 import { CurrencyModule } from '../../@shared/currency/currency.module';
 import { TranslateModule } from '../../@shared/translate/translate.module';
 import { TranslatableService } from '../../@core/services/translatable.service';
+import { PublicLinkComponent } from './public-link/public-link.component';
 
 @NgModule({
 	imports: [
@@ -150,7 +151,8 @@ import { TranslatableService } from '../../@core/services/translatable.service';
 		InvoiceApplyTaxDiscountComponent,
 		InvoiceExpensesSelectorComponent,
 		InvoicePdfComponent,
-		AddInternalNoteComponent
+		AddInternalNoteComponent,
+		PublicLinkComponent
 	],
 	declarations: [
 		InvoicesComponent,
@@ -177,7 +179,9 @@ import { TranslatableService } from '../../@core/services/translatable.service';
 		InvoiceApplyTaxDiscountComponent,
 		InvoiceExpensesSelectorComponent,
 		InvoicePdfComponent,
-		AddInternalNoteComponent
-	]
+		AddInternalNoteComponent,
+		PublicLinkComponent
+	],
+	exports: [InvoiceViewInnerComponent]
 })
 export class InvoicesModule {}

--- a/apps/gauzy/src/app/pages/invoices/public-link/public-link.component.html
+++ b/apps/gauzy/src/app/pages/invoices/public-link/public-link.component.html
@@ -1,0 +1,52 @@
+<nb-card>
+	<nb-card-header>
+		<h5>
+			{{ 'INVOICES_PAGE.PUBLIC_LINK.HEADER' | translate }}
+		</h5>
+	</nb-card-header>
+	<nb-card-body>
+		<div *ngIf="show" class="mb-3">
+			{{
+				'INVOICES_PAGE.PUBLIC_LINK.GENERATE'
+					| translate
+						: { text: invoice.isEstimate ? 'estimate' : 'invoice' }
+			}}
+		</div>
+		<div *ngIf="!show" class="mb-3">
+			{{
+				'INVOICES_PAGE.PUBLIC_LINK.ACCESS'
+					| translate
+						: { text: invoice.isEstimate ? 'estimate' : 'invoice' }
+			}}
+		</div>
+		<div>
+			<label for="inputDiscountValue" class="label">
+				{{ 'FORM.LABELS.PUBLIC_LINK' | translate }}
+			</label>
+			<input [ngModel]="invoice.publicLink" disabled nbInput fullWidth />
+		</div>
+	</nb-card-body>
+	<nb-card-footer class="text-right">
+		<button status="danger" class="mr-3" nbButton (click)="cancel()">
+			{{ 'BUTTONS.CANCEL' | translate }}
+		</button>
+		<button
+			*ngIf="show"
+			class="mr-3"
+			(click)="generateLink()"
+			status="success"
+			nbButton
+		>
+			{{ 'BUTTONS.GENERATE' | translate }}
+		</button>
+		<button
+			*ngIf="!show"
+			(click)="copyToClipboard()"
+			class="mr-3"
+			status="success"
+			nbButton
+		>
+			{{ 'BUTTONS.COPY_LINK' | translate }}
+		</button>
+	</nb-card-footer>
+</nb-card>

--- a/apps/gauzy/src/app/pages/invoices/public-link/public-link.component.ts
+++ b/apps/gauzy/src/app/pages/invoices/public-link/public-link.component.ts
@@ -1,0 +1,50 @@
+import { Component, OnInit } from '@angular/core';
+import { IInvoice } from '@gauzy/models';
+import { NbDialogRef } from '@nebular/theme';
+import { InvoicesService } from '../../../@core/services/invoices.service';
+
+@Component({
+	selector: 'public-link',
+	templateUrl: './public-link.component.html'
+})
+export class PublicLinkComponent implements OnInit {
+	invoice: IInvoice;
+	show = true;
+
+	constructor(
+		protected dialogRef: NbDialogRef<PublicLinkComponent>,
+		private invoicesService: InvoicesService
+	) {}
+
+	ngOnInit() {
+		this.toggleShow();
+	}
+
+	async generateLink() {
+		const updatedInvoice = await this.invoicesService.generateLink(
+			this.invoice.id,
+			this.invoice.isEstimate
+		);
+		this.invoice = updatedInvoice;
+		this.toggleShow();
+	}
+
+	copyToClipboard() {
+		const textField = document.createElement('textarea');
+		textField.innerText = `${this.invoice.publicLink}`;
+		document.body.appendChild(textField);
+		textField.select();
+		document.execCommand('copy');
+		textField.remove();
+	}
+
+	toggleShow() {
+		if (this.invoice.publicLink) {
+			this.show = false;
+		}
+	}
+
+	cancel() {
+		this.dialogRef.close();
+	}
+}

--- a/apps/gauzy/src/app/share/invoices-estimates/invoice-estimate.component.html
+++ b/apps/gauzy/src/app/share/invoices-estimates/invoice-estimate.component.html
@@ -1,0 +1,18 @@
+<nb-card *ngIf="invoice">
+	<nb-card-header class="d-flex">
+		<h3 *ngIf="!invoice.isEstimate">
+			{{ 'INVOICES_PAGE.VIEW_INVOICE' | translate }}
+		</h3>
+		<h3 *ngIf="invoice.isEstimate">
+			{{ 'INVOICES_PAGE.VIEW_ESTIMATE' | translate }}
+		</h3>
+	</nb-card-header>
+	<nb-card-body>
+		<ga-invoice-view-inner
+			*ngIf="invoice"
+			[invoice]="invoice"
+			[isEstimate]="invoice.isEstimate"
+		>
+		</ga-invoice-view-inner>
+	</nb-card-body>
+</nb-card>

--- a/apps/gauzy/src/app/share/invoices-estimates/invoice-estimate.component.ts
+++ b/apps/gauzy/src/app/share/invoices-estimates/invoice-estimate.component.ts
@@ -1,0 +1,60 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { IInvoice } from '@gauzy/models';
+import { TranslateService } from '@ngx-translate/core';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { InvoicesService } from '../../@core/services/invoices.service';
+import { TranslationBaseComponent } from '../../@shared/language-base/translation-base.component';
+
+@Component({
+	selector: 'ga-invoice-estimate',
+	templateUrl: './invoice-estimate.component.html'
+})
+export class InvoiceEstimateComponent
+	extends TranslationBaseComponent
+	implements OnInit {
+	private _ngDestroy$ = new Subject<void>();
+	invoiceId: string;
+	token: string;
+	invoice: IInvoice;
+
+	constructor(
+		private route: ActivatedRoute,
+		private invoicesService: InvoicesService,
+		readonly translateService: TranslateService
+	) {
+		super(translateService);
+	}
+
+	ngOnInit() {
+		this.route.params
+			.pipe(takeUntil(this._ngDestroy$))
+			.subscribe(async (params) => {
+				this.invoiceId = params.id;
+				this.token = params.token;
+				await this.getInvoiceEstimate();
+			});
+	}
+
+	async getInvoiceEstimate() {
+		const invoice = await this.invoicesService.getWithoutAuth(
+			this.invoiceId,
+			this.token,
+			[
+				'invoiceItems',
+				'invoiceItems.employee',
+				'invoiceItems.employee.user',
+				'invoiceItems.project',
+				'invoiceItems.product',
+				'invoiceItems.invoice',
+				'invoiceItems.expense',
+				'invoiceItems.task',
+				'fromOrganization',
+				'toContact'
+			]
+		);
+
+		this.invoice = invoice;
+	}
+}

--- a/apps/gauzy/src/app/share/invoices-estimates/invoice-estimate.module.ts
+++ b/apps/gauzy/src/app/share/invoices-estimates/invoice-estimate.module.ts
@@ -1,0 +1,23 @@
+import { NgModule } from '@angular/core';
+import { InvoiceEstimateRoutingModule } from './invoice-estimate.routing.module';
+import { InvoiceEstimateComponent } from './invoice-estimate.component';
+import { InvoicesService } from '../../@core/services/invoices.service';
+import { CommonModule } from '@angular/common';
+import { InvoicesModule } from '../../pages/invoices/invoices.module';
+import { NbCardModule } from '@nebular/theme';
+import { TranslateModule } from '@ngx-translate/core';
+
+@NgModule({
+	imports: [
+		InvoiceEstimateRoutingModule,
+		InvoicesModule,
+		CommonModule,
+		NbCardModule,
+		TranslateModule
+	],
+	declarations: [InvoiceEstimateComponent],
+	entryComponents: [InvoiceEstimateComponent],
+	exports: [InvoiceEstimateComponent],
+	providers: [InvoicesService]
+})
+export class InvoiceEstimateModule {}

--- a/apps/gauzy/src/app/share/invoices-estimates/invoice-estimate.routing.module.ts
+++ b/apps/gauzy/src/app/share/invoices-estimates/invoice-estimate.routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { InvoiceEstimateComponent } from './invoice-estimate.component';
+
+const routes: Routes = [
+	{
+		path: '',
+		component: InvoiceEstimateComponent
+	}
+];
+
+@NgModule({
+	imports: [RouterModule.forChild(routes)],
+	exports: [RouterModule]
+})
+export class InvoiceEstimateRoutingModule {}

--- a/apps/gauzy/src/app/share/share-routing.module.ts
+++ b/apps/gauzy/src/app/share/share-routing.module.ts
@@ -64,6 +64,20 @@ const routes: Routes = [
 					).then((m) => m.CreateAppointmentModule)
 			},
 			{
+				path: 'invoices/:id/:token',
+				loadChildren: () =>
+					import('./invoices-estimates/invoice-estimate.module').then(
+						(m) => m.InvoiceEstimateModule
+					)
+			},
+			{
+				path: 'estimates/:id/:token',
+				loadChildren: () =>
+					import('./invoices-estimates/invoice-estimate.module').then(
+						(m) => m.InvoiceEstimateModule
+					)
+			},
+			{
 				path: '**',
 				component: NotFoundComponent
 			}

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -97,7 +97,9 @@
 		"SET": "Set",
 		"RECORD_FULL_PAYMENT": "Record Full Payment",
 		"EXPORT_TO_CSV": "Export to CSV",
-		"INVOICE_REMAINING_AMOUNT": "Invoice Remaining Amount"
+		"INVOICE_REMAINING_AMOUNT": "Invoice Remaining Amount",
+		"PUBLIC_LINK": "Public Link",
+		"GENERATE": "Generate"
 	},
 	"SM_TABLE": {
 		"TRANSACTION_TYPE": "Type",
@@ -313,7 +315,8 @@
 				"TITLE": "COORDINATES",
 				"LATITUDE": "Latitude",
 				"LONGITUDE": "Longitude"
-			}
+			},
+			"PUBLIC_LINK": "Public Link"
 		},
 		"PLACEHOLDERS": {
 			"NAME": "Name",
@@ -2462,6 +2465,11 @@
 			"DELETE": "Delete",
 			"NOTE": "Note",
 			"PAYMENTS": "Payments"
+		},
+		"PUBLIC_LINK": {
+			"HEADER": "Generate Public Link",
+			"GENERATE": "Generate a link to the {{ text }} that anyone with the link can view.",
+			"ACCESS": "Anyone with access to this link can view the {{ text }}."
 		}
 	},
 	"PAYMENTS_PAGE": {

--- a/libs/models/src/lib/invoice.model.ts
+++ b/libs/models/src/lib/invoice.model.ts
@@ -37,6 +37,8 @@ export interface IInvoice extends IBasePerTenantAndOrganizationEntityModel {
 	alreadyPaid?: number;
 	amountDue?: number;
 	hasRemainingAmountInvoiced?: boolean;
+	publicLink?: string;
+	token?: string;
 }
 
 export interface IInvoiceCreateInput


### PR DESCRIPTION
Added a Public Link button in the invoices and estimmates pages that opens a dialog that lets the user generate a link that lets anyone with access to it view the invoice/estimate.
When the link is generated there is a 'Copy Link' button that copies the link to the clipboard.

Video: https://www.loom.com/share/36099c2a802d4d788636658596352b37