### PR TITLE
Feature/invoice-estimate-default terms

### DIFF
--- a/apps/gauzy/src/app/pages/invoices/invoice-add/invoice-add.component.ts
+++ b/apps/gauzy/src/app/pages/invoices/invoice-add/invoice-add.component.ts
@@ -133,7 +133,6 @@ export class InvoiceAddComponent
 		if (!this.isEstimate) {
 			this.isEstimate = false;
 		}
-		this.initializeForm();
 		this.selectedLanguage = this.translateService.currentLang;
 		this.store.selectedOrganization$
 			.pipe(
@@ -147,6 +146,7 @@ export class InvoiceAddComponent
 				untilDestroyed(this)
 			)
 			.subscribe();
+		this.initializeForm();
 		this.observableTasks.pipe(untilDestroyed(this)).subscribe((data) => {
 			this.tasks = data;
 		});
@@ -178,7 +178,11 @@ export class InvoiceAddComponent
 				0,
 				Validators.compose([Validators.required, Validators.min(0)])
 			],
-			terms: [''],
+			terms: [
+				this.organization
+					? this.organization.defaultInvoiceEstimateTerms || ''
+					: ''
+			],
 			organizationContact: ['', Validators.required],
 			discountType: [''],
 			taxType: [''],

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.html
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.html
@@ -391,6 +391,25 @@
 							</nb-toggle>
 						</div>
 					</div>
+					<div class="col-6">
+						<div class="form-group invite-toggle">
+							<label class="label">
+								{{ 'FORM.LABELS.DEFAULT_TERMS' | translate }}
+							</label>
+							<textarea
+								nbInput
+								placeholder="{{
+									'INVOICES_PAGE.INVOICES_SELECT_TERMS'
+										| translate
+								}}"
+								formControlName="defaultInvoiceEstimateTerms"
+								id="inputTerms"
+								fullWidth
+								class="terms-textarea"
+							>
+							</textarea>
+						</div>
+					</div>
 				</div>
 			</div>
 		</nb-card-body>

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.ts
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.ts
@@ -216,6 +216,9 @@ export class EditOrganizationOtherSettingsComponent
 			separateInvoiceItemTaxAndDiscount: [
 				this.organization.separateInvoiceItemTaxAndDiscount
 			],
+			defaultInvoiceEstimateTerms: [
+				this.organization.defaultInvoiceEstimateTerms || ''
+			],
 			fiscalInformation: [this.organization.fiscalInformation || ''],
 			currencyPosition: [this.organization.currencyPosition || 'LEFT'],
 			discountAfterTax: [this.organization.discountAfterTax]

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -316,7 +316,8 @@
 				"LATITUDE": "Latitude",
 				"LONGITUDE": "Longitude"
 			},
-			"PUBLIC_LINK": "Public Link"
+			"PUBLIC_LINK": "Public Link",
+			"DEFAULT_TERMS": "Default terms for invoices and estimates"
 		},
 		"PLACEHOLDERS": {
 			"NAME": "Name",

--- a/packages/contracts/src/organization.model.ts
+++ b/packages/contracts/src/organization.model.ts
@@ -90,6 +90,7 @@ export interface IOrganization extends IBasePerTenantEntityModel {
 	awards?: IOrganizationAwards[];
 	languages?: IOrganizationLanguages[];
 	featureOrganizations?: IFeatureOrganization[];
+	defaultInvoiceEstimateTerms?: string;
 }
 
 export interface IOrganizationFindInput {
@@ -139,6 +140,7 @@ export interface IOrganizationCreateInput extends IContact {
 	show_clients?: boolean;
 	website?: string;
 	fiscalInformation?: string;
+	defaultInvoiceEstimateTerms?: string;
 }
 
 export interface IOrganizationUpdateInput extends IOrganizationCreateInput {

--- a/packages/core/src/organization/organization.entity.ts
+++ b/packages/core/src/organization/organization.entity.ts
@@ -448,4 +448,10 @@ export class Organization extends TenantBaseEntity implements IOrganization {
 	@ApiPropertyOptional({ type: String })
 	@Column({ nullable: true })
 	defaultEndTime?: string;
+
+	@ApiPropertyOptional({ type: String })
+	@IsString()
+	@IsOptional()
+	@Column({ nullable: true })
+	defaultInvoiceEstimateTerms?: string;
 }


### PR DESCRIPTION
Added text area in organization settings in the accounting section that lets the user set default terms for invoices and estimates.

![org-settings](https://user-images.githubusercontent.com/25152459/106290161-d6789880-6252-11eb-9c2f-0b44ece98219.PNG)
![invoice-add](https://user-images.githubusercontent.com/25152459/106290246-eabc9580-6252-11eb-884a-6981361bf39e.PNG)
