### PR TITLE
Feature/export-invoice-payments-to-csv

### DIFF
--- a/apps/gauzy/src/app/@shared/invoice/generate-csv.ts
+++ b/apps/gauzy/src/app/@shared/invoice/generate-csv.ts
@@ -1,0 +1,16 @@
+import { saveAs } from 'file-saver';
+
+export async function generateCsv(data: any, headers: any, fileName: string) {
+	const replacer = (key, value) => (value === null ? 'N/A' : value);
+	const header = Object.keys(data[0]);
+	const csv = data.map((row) =>
+		header
+			.map((fieldName) => JSON.stringify(row[fieldName], replacer))
+			.join(',')
+	);
+	csv.unshift(headers);
+	var BOM = '\uFEFF';
+	const csvArray = BOM + csv.join('\r\n');
+	var blob = new Blob([csvArray], { type: 'text/csv;charset=utf-8' });
+	saveAs(blob, `${fileName}.csv`);
+}

--- a/apps/gauzy/src/app/pages/invoices/invoice-add/invoice-add.component.ts
+++ b/apps/gauzy/src/app/pages/invoices/invoice-add/invoice-add.component.ts
@@ -94,6 +94,7 @@ export class InvoiceAddComponent
 	subtotal = 0;
 	total = 0;
 	tags: ITag[] = [];
+	currencyString: string;
 	invoiceTypePlaceholder = this.getTranslation(
 		'INVOICES_PAGE.INVOICE_TYPE.INVOICE_TYPE'
 	);
@@ -139,8 +140,7 @@ export class InvoiceAddComponent
 				filter((organization) => !!organization),
 				tap((organization) => (this.organization = organization)),
 				tap(({ currency }) => {
-					this.currency.setValue(currency);
-					this.currency.updateValueAndValidity();
+					this.currencyString = currency;
 				}),
 				tap(() => this._loadOrganizationData()),
 				untilDestroyed(this)
@@ -155,6 +155,8 @@ export class InvoiceAddComponent
 			.subscribe((languageEvent) => {
 				this.selectedLanguage = languageEvent.lang;
 			});
+		this.currency.setValue(this.currencyString);
+		this.currency.updateValueAndValidity();
 	}
 
 	initializeForm() {

--- a/apps/gauzy/src/app/pages/invoices/invoice-payments/payments.component.html
+++ b/apps/gauzy/src/app/pages/invoices/invoice-payments/payments.component.html
@@ -59,12 +59,44 @@
 				(click)="recordPayment()"
 				nbButton
 			>
-				<nb-icon class="mr-1" icon="plus-outline"></nb-icon>
-				{{ 'INVOICES_PAGE.PAYMENTS.RECORD_PAYMENT' | translate }}
+				<nb-icon icon="plus-outline"></nb-icon>
 			</button>
-			<button nbButton status="info" (click)="download()" class="mr-2">
-				<nb-icon class="mr-1" icon="download-outline"> </nb-icon>
-				{{ 'BUTTONS.DOWNLOAD' | translate }}
+			<button
+				class="mr-2"
+				status="info"
+				(click)="editPayment()"
+				[disabled]="disableButton"
+				nbButton
+			>
+				<nb-icon icon="edit-outline"></nb-icon>
+			</button>
+			<button
+				nbButton
+				status="info"
+				(click)="download()"
+				class="mr-2"
+				[disabled]="disableButton"
+			>
+				<nb-icon icon="download-outline"></nb-icon>
+			</button>
+			<button
+				class="mr-2"
+				status="danger"
+				(click)="deletePayment()"
+				[disabled]="disableButton"
+				nbButton
+			>
+				<nb-icon icon="trash-2-outline"></nb-icon>
+			</button>
+			<button
+				class="mr-2"
+				nbButton
+				status="info"
+				(click)="exportToCsv()"
+				[disabled]="payments ? payments.length <= 0 : true"
+			>
+				<nb-icon icon="file-text-outline"></nb-icon>
+				{{ 'BUTTONS.EXPORT_TO_CSV' | translate }}
 			</button>
 			<button
 				class="mr-2"
@@ -73,7 +105,7 @@
 				[disabled]="isDisabled"
 				nbButton
 			>
-				<nb-icon class="mr-1" icon="credit-card-outline"></nb-icon>
+				<nb-icon icon="credit-card-outline"></nb-icon>
 				{{ 'BUTTONS.RECORD_FULL_PAYMENT' | translate }}
 			</button>
 			<button
@@ -83,28 +115,8 @@
 				[disabled]="isDisabled"
 				nbButton
 			>
-				<nb-icon class="mr-1" icon="file-text-outline"></nb-icon>
+				<nb-icon icon="file-text-outline"></nb-icon>
 				{{ 'BUTTONS.INVOICE_REMAINING_AMOUNT' | translate }}
-			</button>
-			<button
-				class="mr-2"
-				status="info"
-				(click)="editPayment()"
-				[disabled]="disableButton"
-				nbButton
-			>
-				<nb-icon class="mr-1" icon="edit-outline"></nb-icon>
-				{{ 'INVOICES_PAGE.PAYMENTS.EDIT_PAYMENT' | translate }}
-			</button>
-			<button
-				class="mr-2"
-				status="danger"
-				(click)="deletePayment()"
-				[disabled]="disableButton"
-				nbButton
-			>
-				<nb-icon class="mr-1" icon="archive-outline"> </nb-icon>
-				{{ 'INVOICES_PAGE.PAYMENTS.DELETE_PAYMENT' | translate }}
 			</button>
 		</div>
 		<ng2-smart-table

--- a/apps/gauzy/src/app/pages/invoices/invoice-payments/payments.component.ts
+++ b/apps/gauzy/src/app/pages/invoices/invoice-payments/payments.component.ts
@@ -23,6 +23,7 @@ import { Store } from '../../../@core/services/store.service';
 import { InvoiceEstimateHistoryService } from '../../../@core/services/invoice-estimate-history.service';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { ToastrService } from '../../../@core/services/toastr.service';
+import { generateCsv } from '../../../@shared/invoice/generate-csv';
 @UntilDestroy({ checkProperties: true })
 @Component({
 	selector: 'ga-payments',
@@ -449,6 +450,45 @@ export class InvoicePaymentsComponent
 			[`/pages/accounting/invoices/edit/${this.invoice.id}`],
 			{ queryParams: { remainingAmount: true } }
 		);
+	}
+
+	exportToCsv() {
+		let data = [];
+
+		this.payments.forEach((payment) => {
+			data.push({
+				invoiceNumber: this.invoice.invoiceNumber,
+				contact: this.invoice.toContact.name,
+				paymentDate: payment.paymentDate.toString().slice(0, 10),
+				amount: payment.amount,
+				recordedBy:
+					payment.recordedBy.firstName + payment.recordedBy.lastName,
+				note: payment.note || '',
+				paymentMethod: payment.paymentMethod
+					? this.getTranslation(
+							`INVOICES_PAGE.PAYMENTS.${payment.paymentMethod}`
+					  )
+					: '',
+				status: payment.overdue
+					? this.getTranslation('INVOICES_PAGE.PAYMENTS.OVERDUE')
+					: this.getTranslation('INVOICES_PAGE.PAYMENTS.ON_TIME')
+			});
+		});
+
+		const headers = [
+			this.getTranslation('INVOICES_PAGE.INVOICE_NUMBER'),
+			this.getTranslation('INVOICES_PAGE.CONTACT'),
+			this.getTranslation('INVOICES_PAGE.PAYMENTS.PAYMENT_DATE'),
+			this.getTranslation('INVOICES_PAGE.PAYMENTS.AMOUNT'),
+			this.getTranslation('INVOICES_PAGE.PAYMENTS.RECORDED_BY'),
+			this.getTranslation('INVOICES_PAGE.PAYMENTS.NOTE'),
+			this.getTranslation('INVOICES_PAGE.PAYMENTS.PAYMENT_METHOD'),
+			this.getTranslation('INVOICES_PAGE.PAYMENTS.STATUS')
+		];
+
+		const fileName = this.getTranslation('INVOICES_PAGE.PAYMENTS.PAYMENT');
+
+		generateCsv(data, headers, fileName);
 	}
 
 	_applyTranslationOnSmartTable() {

--- a/apps/gauzy/src/app/pages/invoices/invoices.component.ts
+++ b/apps/gauzy/src/app/pages/invoices/invoices.component.ts
@@ -52,8 +52,8 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { NgxPermissionsService } from 'ngx-permissions';
 import { AddInternalNoteComponent } from './add-internal-note/add-internal-note.component';
 import { ToastrService } from '../../@core/services/toastr.service';
-import { saveAs } from 'file-saver';
 import { PublicLinkComponent } from './public-link/public-link.component';
+import { generateCsv } from '../../@shared/invoice/generate-csv';
 
 @UntilDestroy({ checkProperties: true })
 @Component({
@@ -594,9 +594,13 @@ export class InvoicesComponent
 		let fileName;
 
 		if (this.selectedInvoice.isEstimate) {
-			fileName = this.getTranslation('INVOICES_PAGE.ESTIMATE');
+			fileName = `${this.getTranslation('INVOICES_PAGE.ESTIMATE')}-${
+				this.selectedInvoice.invoiceNumber
+			}`;
 		} else {
-			fileName = this.getTranslation('INVOICES_PAGE.INVOICE');
+			fileName = `${this.getTranslation('INVOICES_PAGE.INVOICE')}-${
+				this.selectedInvoice.invoiceNumber
+			}`;
 		}
 
 		const data = [
@@ -615,16 +619,6 @@ export class InvoicesComponent
 			}
 		];
 
-		const replacer = (key, value) => (value === null ? 'N/A' : value);
-
-		const header = Object.keys(data[0]);
-
-		const csv = data.map((row) =>
-			header
-				.map((fieldName) => JSON.stringify(row[fieldName], replacer))
-				.join(',')
-		);
-
 		const headers = [
 			this.selectedInvoice.isEstimate
 				? this.getTranslation('INVOICES_PAGE.ESTIMATE_NUMBER')
@@ -641,15 +635,7 @@ export class InvoicesComponent
 			this.getTranslation('INVOICES_PAGE.CONTACT')
 		].join(',');
 
-		csv.unshift(headers);
-
-		var BOM = '\uFEFF';
-
-		const csvArray = BOM + csv.join('\r\n');
-
-		var blob = new Blob([csvArray], { type: 'text/csv;charset=utf-8' });
-
-		saveAs(blob, `${fileName}-${this.selectedInvoice.invoiceNumber}.csv`);
+		generateCsv(data, headers, fileName);
 	}
 
 	async generatePublicLink(selectedItem) {

--- a/packages/core/src/payment/payment.entity.ts
+++ b/packages/core/src/payment/payment.entity.ts
@@ -79,7 +79,7 @@ export class Payment extends TenantOrganizationBaseEntity implements IPayment {
 	@ApiPropertyOptional({ type: String })
 	@IsString()
 	@IsOptional()
-	@Column()
+	@Column({ nullable: true })
 	note?: string;
 
 	@ApiPropertyOptional({ type: String, enum: CurrenciesEnum })
@@ -89,7 +89,8 @@ export class Payment extends TenantOrganizationBaseEntity implements IPayment {
 
 	@ApiPropertyOptional({ type: String, enum: PaymentMethodEnum })
 	@IsEnum(PaymentMethodEnum)
-	@Column()
+	@IsOptional()
+	@Column({ nullable: true })
 	paymentMethod?: string;
 
 	@ApiPropertyOptional({ type: Boolean })


### PR DESCRIPTION
Added 'Export to csv' button to invoice payments page that exports all the recorded payments for the invoice in csv format. 
Changed invoice payments page ui to be consistent with invoices page ui.
Fixed issue that prevented a currency from being selected by defualt in the invoice add page.

Video: https://www.loom.com/share/55c6588dc4034c249c6ee252b5645e11