### PR TITLE
 Freature/default-days-until-due

### DIFF
--- a/apps/gauzy/src/app/pages/invoices/invoice-add/invoice-add.component.ts
+++ b/apps/gauzy/src/app/pages/invoices/invoice-add/invoice-add.component.ts
@@ -1184,11 +1184,11 @@ export class InvoiceAddComponent
 	}
 
 	getNextMonth() {
-		const date = new Date();
-		const d = date.getDate();
-		date.setMonth(date.getMonth() + 1);
-		if (date.getDate() !== d) {
-			date.setDate(0);
+		var date = new Date();
+		if (this.organization.daysUntilDue !== null) {
+			date.setDate(date.getDate() + this.organization.daysUntilDue);
+		} else {
+			date.setMonth(date.getMonth() + 1);
 		}
 		return date;
 	}

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.html
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.html
@@ -411,6 +411,25 @@
 						</div>
 					</div>
 				</div>
+				<div class="row">
+					<div class="col-6">
+						<div class="form-group">
+							<label class="label">
+								{{ 'FORM.LABELS.DEFAULT_DAYS' | translate }}
+							</label>
+							<input
+								placeholder="{{
+									'FORM.PLACEHOLDERS.DAYS_UNTIL_DUE'
+										| translate
+								}}"
+								formControlName="daysUntilDue"
+								fullWidth
+								type="number"
+								nbInput
+							/>
+						</div>
+					</div>
+				</div>
 			</div>
 		</nb-card-body>
 	</nb-card>

--- a/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.ts
+++ b/apps/gauzy/src/app/pages/organizations/edit-organization/edit-organization-settings/edit-organization-other-settings/edit-organization-other-settings.component.ts
@@ -221,7 +221,8 @@ export class EditOrganizationOtherSettingsComponent
 			],
 			fiscalInformation: [this.organization.fiscalInformation || ''],
 			currencyPosition: [this.organization.currencyPosition || 'LEFT'],
-			discountAfterTax: [this.organization.discountAfterTax]
+			discountAfterTax: [this.organization.discountAfterTax],
+			daysUntilDue: [this.organization.daysUntilDue || null]
 		});
 	}
 

--- a/apps/gauzy/src/assets/i18n/en.json
+++ b/apps/gauzy/src/assets/i18n/en.json
@@ -317,7 +317,8 @@
 				"LONGITUDE": "Longitude"
 			},
 			"PUBLIC_LINK": "Public Link",
-			"DEFAULT_TERMS": "Default terms for invoices and estimates"
+			"DEFAULT_TERMS": "Default terms for invoices and estimates",
+			"DEFAULT_DAYS": "Default days until invoices and estimates are due."
 		},
 		"PLACEHOLDERS": {
 			"NAME": "Name",
@@ -480,7 +481,8 @@
 			"SPRINT_END_DATE": "Sprint end date",
 			"SPRINT_GOAL": "Sprint goal",
 			"POLICY_NAME": "Policy Name",
-			"SELECT_DATE": "Select Date"
+			"SELECT_DATE": "Select Date",
+			"DAYS_UNTIL_DUE": "Days Until Due"
 		},
 		"RATES": {
 			"DEFAULT_RATE": "Default Rate",

--- a/packages/contracts/src/organization.model.ts
+++ b/packages/contracts/src/organization.model.ts
@@ -91,6 +91,7 @@ export interface IOrganization extends IBasePerTenantEntityModel {
 	languages?: IOrganizationLanguages[];
 	featureOrganizations?: IFeatureOrganization[];
 	defaultInvoiceEstimateTerms?: string;
+	daysUntilDue?: number;
 }
 
 export interface IOrganizationFindInput {
@@ -141,6 +142,7 @@ export interface IOrganizationCreateInput extends IContact {
 	website?: string;
 	fiscalInformation?: string;
 	defaultInvoiceEstimateTerms?: string;
+	daysUntilDue?: number;
 }
 
 export interface IOrganizationUpdateInput extends IOrganizationCreateInput {

--- a/packages/core/src/organization/organization.entity.ts
+++ b/packages/core/src/organization/organization.entity.ts
@@ -454,4 +454,10 @@ export class Organization extends TenantBaseEntity implements IOrganization {
 	@IsOptional()
 	@Column({ nullable: true })
 	defaultInvoiceEstimateTerms?: string;
+
+	@ApiPropertyOptional({ type: () => Number })
+	@IsNumber()
+	@IsOptional()
+	@Column({ nullable: true })
+	daysUntilDue?: number;
 }


### PR DESCRIPTION
Added an input to the organization settings under the 'Accounting' section that lets the user set how many days after the invoice date the due date is set by default. If the input is left empty the default is 1 month after the invoice date.
![days-until-due](https://user-images.githubusercontent.com/25152459/106897419-8fc7ea00-66fb-11eb-97cb-a5c9ee23b3e9.PNG)
![invoice-dates](https://user-images.githubusercontent.com/25152459/106897437-98b8bb80-66fb-11eb-880b-04317ffd77c5.PNG)
